### PR TITLE
docs: remove redundant Multi-Format Output feature entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Designed for Code Agents (Claude Code, Cursor, Copilot, etc.) to invoke via shel
 | Feature | Description |
 |---|---|
 | 🤖 **Agent-Ready** | Every command supports `--format json` with clean, parseable output and structured error codes — built for Claude Code, Cursor, and Copilot tool calls |
-| 📋 **Multi-Format Output** | Every command supports `--format text\|json\|markdown` — aligned tables for humans, JSON for scripts and agents, Markdown for docs and reports |
 | 📦 **Fully Offline** | Props, tokens, demos, and changelogs for v4/v5/v6 are all bundled at install — no network calls, no latency |
 | 🔀 **Multi-Version** | Query any antd version; diff APIs between two versions; browse changelogs with categorized change types (feature / fix / breaking / deprecation) |
 | 🧠 **Deep Component Data** | Props with types and defaults; Design Tokens; runnable demo source code; semantic `classNames` / `styles` structure — all queryable from the terminal |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,6 @@
 | 功能 | 说明 |
 |---|---|
 | 🤖 **Agent 就绪** | 每条命令均支持 `--format json`，输出结构化数据与标准错误码，为 Claude Code、Cursor、Copilot 等工具调用而生 |
-| 📋 **多格式输出** | 每条命令均支持 `--format text\|json\|markdown`——对齐表格方便人类阅读，JSON 供脚本和 Agent 解析，Markdown 用于文档和报告 |
 | 📦 **完全离线** | v4/v5/v6 的 Props、Token、Demo、Changelog 全部随包安装，无需网络，零延迟 |
 | 🔀 **多版本支持** | 查询任意 antd 版本；对比两个版本间的 API 变更；浏览按类型分类的 Changelog（新功能 / 修复 / 破坏性变更 / 废弃） |
 | 🧠 **深度组件数据** | Props 类型与默认值；Design Token；可运行的 Demo 源码；`classNames` / `styles` 语义结构——均可从终端直接查询 |


### PR DESCRIPTION
## Summary

- Remove the `Multi-Format Output` row added in #6, as its content overlaps with the existing `Agent-Ready` entry

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)