### PR TITLE
docs: add doc command to spec/README and add missing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ onClick       (event: React.MouseEvent) => void                 -
 
 ---
 
+#### `antd doc <Component>`
+
+Output full API documentation for a component in markdown.
+
+```bash
+antd doc Button                     # full markdown docs to stdout
+antd doc Button --format json       # structured { name, doc }
+antd doc Button --lang zh           # Chinese docs
+```
+
+---
+
 #### `antd demo <Component> [name]`
 
 Get demo source code.
@@ -313,6 +325,7 @@ Add the following to your `CLAUDE.md` (or equivalent agent config) to let your C
 Use `@ant-design/cli` to query antd component knowledge:
 
 - `antd info <Component>` — get props, types, and defaults
+- `antd doc <Component>` — get full markdown documentation
 - `antd demo <Component> [name]` — get demo source code
 - `antd token <Component>` — get design tokens
 - `antd migrate 4 5 --apply ./src` — generate migration instructions

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,18 @@ onClick       (event: React.MouseEvent) => void                 -
 
 ---
 
+#### `antd doc <Component>`
+
+输出组件的完整 API 文档（Markdown 格式）。
+
+```bash
+antd doc Button                     # 输出完整 Markdown 文档
+antd doc Button --format json       # 结构化输出 { name, doc }
+antd doc Button --lang zh           # 中文文档
+```
+
+---
+
 #### `antd demo <Component> [name]`
 
 获取 Demo 源码。
@@ -313,6 +325,7 @@ Total: 2 steps (2 auto-fixable, 0 manual)
 使用 `@ant-design/cli` 查询 antd 组件知识：
 
 - `antd info <Component>` — 获取 Props、类型和默认值
+- `antd doc <Component>` — 获取完整 Markdown 文档
 - `antd demo <Component> [name]` — 获取 Demo 源码
 - `antd token <Component>` — 获取 Design Token
 - `antd migrate 4 5 --apply ./src` — 生成迁移指令

--- a/spec.md
+++ b/spec.md
@@ -67,9 +67,9 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 - CLI version aligns with the latest antd version (e.g., antd 6.3.2 → CLI 6.3.2)
 - The components schema is consistent across major versions to enable cross-version diffing
 
-## Commands (11)
+## Commands (12)
 
-### Knowledge Query (7)
+### Knowledge Query (8)
 
 #### `antd list`
 
@@ -136,6 +136,26 @@ JSON output (--detail):
 ```
 
 Text output for components with sub-components shows main props first, then each sub-component section labeled with its full name (e.g. `Splitter.Panel`).
+
+#### `antd doc <Component>`
+
+Output the full API documentation for a component in markdown format. Useful for agents that need the complete component reference in one call.
+
+```bash
+antd doc Button                          # output full markdown docs to stdout
+antd doc Button --format json            # structured output with name and doc fields
+antd doc Button --lang zh                # Chinese documentation
+```
+
+JSON output:
+```json
+{
+  "name": "Button",
+  "doc": "## Button\n\nTo trigger an operation.\n\n### When To Use\n..."
+}
+```
+
+For text and markdown formats, the raw markdown content is written directly to stdout with no additional decoration. Returns error `DOC_NOT_AVAILABLE` if documentation is not available for the component (e.g. older CLI versions without doc data).
 
 #### `antd demo <Component> [name]`
 
@@ -411,7 +431,7 @@ Common error codes: `COMPONENT_NOT_FOUND`, `VERSION_NOT_FOUND`, `NO_PROJECT_DETE
 ┌─────────────┐     ┌──────────────┐     ┌──────────────────┐
 │  CLI Layer   │────>│  Data Layer  │────>│  Data Sources    │
 │              │     │              │     │                  │
-│  11 commands │     │  Version     │     │  Bundled data    │
+│  12 commands │     │  Version     │     │  Bundled data    │
 │  Flag parse  │     │   routing    │     │  data/v4,v5,v6   │
 │  Output fmt  │     │  Filtering   │     │  (JSON files)    │
 └─────────────┘     └──────────────┘     └──────────────────┘

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -118,6 +118,39 @@ describe('CLI e2e', () => {
   });
 
 
+  // ─── Doc command ────────────────────────────────────────────────────
+
+  it('should show full doc for a component', () => {
+    const out = run('doc', 'Button');
+    expect(out).toContain('Button');
+    expect(out).toContain('API');
+  });
+
+  it('should show doc as JSON', () => {
+    const out = run('doc', 'Button', '--format', 'json');
+    const data = JSON.parse(out);
+    expect(data.name).toBe('Button');
+    expect(typeof data.doc).toBe('string');
+    expect(data.doc.length).toBeGreaterThan(0);
+  });
+
+  it('should show doc in Chinese', () => {
+    const out = run('doc', 'Button', '--lang', 'zh');
+    expect(out).toContain('按钮');
+  });
+
+  it('should handle doc not found for unknown component', () => {
+    const result = runWithStatus('doc', 'NonExistent');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('not found');
+  });
+
+  it('should suggest correct name for doc typo', () => {
+    const result = runWithStatus('doc', 'Btn');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Did you mean 'Button'");
+  });
+
   it('should show changelog', () => {
     const out = run('changelog', '5.21.0');
     expect(out).toContain('5.21.0');

--- a/src/data/__tests__/loader.test.ts
+++ b/src/data/__tests__/loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { loadMetadata, findComponent, getAllComponentNames } from '../loader.js';
+import { loadMetadata, loadMetadataForVersion, findComponent, getAllComponentNames } from '../loader.js';
 
 describe('loadMetadata', () => {
   it('should load v5 data', () => {
@@ -18,6 +18,34 @@ describe('loadMetadata', () => {
     const store = loadMetadata('v_nonexistent_version');
     expect(store.components).toEqual([]);
     expect(store.majorVersion).toBe('v_nonexistent_version');
+  });
+});
+
+describe('loadMetadataForVersion', () => {
+  it('should load data for a full semver version', () => {
+    const store = loadMetadataForVersion('5.21.0');
+    expect(store.components.length).toBeGreaterThan(0);
+  });
+
+  it('should fall back to major version for unrecognized minor', () => {
+    const store = loadMetadataForVersion('5.999.0');
+    expect(store.components.length).toBeGreaterThan(0);
+  });
+
+  it('should fall back for version without minor part', () => {
+    const store = loadMetadataForVersion('5');
+    expect(store.components.length).toBeGreaterThan(0);
+    expect(store.majorVersion).toBe('v5');
+  });
+
+  it('should return empty store for unknown major version', () => {
+    const store = loadMetadataForVersion('99.0.0');
+    expect(store.components).toEqual([]);
+  });
+
+  it('should load v4 snapshot', () => {
+    const store = loadMetadataForVersion('4.24.0');
+    expect(store.components.length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- **spec.md**: Add `antd doc <Component>` command documentation, update command count from 11 to 12 (Knowledge Query 7→8)
- **README.md / README.zh-CN.md**: Add `antd doc` section and agent config entry
- **cli.test.ts**: Add 5 e2e tests for the `doc` command (text/JSON/zh output, error handling, typo suggestion)
- **loader.test.ts**: Add 5 unit tests for `loadMetadataForVersion` (semver resolution, fallback logic)

## Test plan

- [x] All 104 tests pass (`npm run test`)
- [x] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `antd doc <Component>` CLI 命令，可输出组件完整 API 文档
  * 支持 `--format json` 选项获取结构化格式输出
  * 支持 `--lang zh` 选项查看中文文档

* **文档**
  * 更新README和规范文档，说明新命令用法

<!-- end of auto-generated comment: release notes by coderabbit.ai -->