### PR TITLE
perf: gzip data files at pack time to reduce npm package size by 81%

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "extract": "tsx scripts/extract.ts",
-    "prepublishOnly": "npm run build"
+    "prepack": "npm run build && tsx scripts/compress-data.ts",
+    "postpack": "tsx scripts/compress-data.ts --undo"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/compress-data.ts
+++ b/scripts/compress-data.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * Compress or decompress data/*.json files.
+ *
+ * Usage:
+ *   npx tsx scripts/compress-data.ts          # compress: .json → .json.gz
+ *   npx tsx scripts/compress-data.ts --undo   # decompress: .json.gz → .json
+ *
+ * Used by npm prepack/postpack hooks to ship .gz in the npm package
+ * while keeping .json in the git repository.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { gzipSync, gunzipSync } from 'node:zlib';
+
+const dataDir = join(import.meta.dirname, '..', 'data');
+const undo = process.argv.includes('--undo');
+
+if (undo) {
+  // Decompress: .json.gz → .json
+  const files = readdirSync(dataDir).filter((f) => f.endsWith('.json.gz'));
+  for (const file of files) {
+    const gzPath = join(dataDir, file);
+    const jsonPath = gzPath.slice(0, -3); // remove .gz
+    const content = gunzipSync(readFileSync(gzPath));
+    writeFileSync(jsonPath, content);
+    unlinkSync(gzPath);
+    console.log(`${file} → ${file.slice(0, -3)}`);
+  }
+  console.log(`\nDecompressed ${files.length} files.`);
+} else {
+  // Compress: .json → .json.gz
+  const files = readdirSync(dataDir).filter(
+    (f) => f.endsWith('.json') && f !== 'versions.json',
+  );
+
+  let totalOriginal = 0;
+  let totalCompressed = 0;
+
+  for (const file of files) {
+    const filePath = join(dataDir, file);
+    const content = readFileSync(filePath);
+    const compressed = gzipSync(content, { level: 9 });
+
+    totalOriginal += content.length;
+    totalCompressed += compressed.length;
+
+    writeFileSync(filePath + '.gz', compressed);
+    unlinkSync(filePath);
+
+    const ratio = ((1 - compressed.length / content.length) * 100).toFixed(1);
+    console.log(`${file} → ${file}.gz  (${(content.length / 1024 / 1024).toFixed(1)}MB → ${(compressed.length / 1024 / 1024).toFixed(1)}MB, -${ratio}%)`);
+  }
+
+  console.log(
+    `\nTotal: ${(totalOriginal / 1024 / 1024).toFixed(1)}MB → ${(totalCompressed / 1024 / 1024).toFixed(1)}MB (${((1 - totalCompressed / totalOriginal) * 100).toFixed(1)}% reduction)`,
+  );
+}

--- a/spec.md
+++ b/spec.md
@@ -26,18 +26,20 @@ Metadata for all major versions is bundled inside `@ant-design/cli`:
 ```
 @ant-design/cli
 └── data/
-    ├── versions.json        # version index: minor series → snapshot tag
-    ├── v4.json              # latest v4 (from highest v4.x tag)
-    ├── v4.0.9.json          # snapshot for 4.0.x series
-    ├── v4.1.5.json          # snapshot for 4.1.x series
-    ├── ...                  # one file per minor series
-    ├── v4.24.16.json        # snapshot for 4.24.x series
-    ├── v5.json              # latest v5
-    ├── v5.0.7.json          # snapshot for 5.0.x series
+    ├── versions.json        # version index: minor series → snapshot tag (always plain JSON)
+    ├── v4.json.gz           # latest v4 (gzip-compressed in published package)
+    ├── v4.0.9.json.gz       # snapshot for 4.0.x series
+    ├── v4.1.5.json.gz       # snapshot for 4.1.x series
+    ├── ...                  # one .json.gz file per minor series
+    ├── v4.24.16.json.gz     # snapshot for 4.24.x series
+    ├── v5.json.gz           # latest v5
+    ├── v5.0.7.json.gz       # snapshot for 5.0.x series
     ├── ...
-    ├── v6.json              # latest v6
+    ├── v6.json.gz           # latest v6
     └── ...
 ```
+
+> **Note on data format:** In the git repository, data files are stored as plain `.json` for readable diffs. During `npm pack`/`npm publish`, a `prepack` hook compresses them to `.json.gz` (gzip level 9), reducing package size from ~136MB to ~25MB. A `postpack` hook restores them to `.json` afterward. The loader transparently supports both formats via `zlib.gunzipSync()` with fallback to plain JSON.
 
 **`data/versions.json`** maps each minor series to its representative snapshot tag:
 

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { MetadataStore, ComponentData } from '../types.js';
@@ -8,12 +9,23 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 function getDataPath(): string {
   // Check for a known file to confirm the correct directory
   // Works from both dist/ and src/data/
-  const probe = 'v5.json';
+  // Probe for both .json.gz (published package) and .json (local dev) formats
   const candidates = [
     join(__dirname, '..', 'data'),       // from dist/
     join(__dirname, '..', '..', 'data'), // from src/data/
   ];
-  return candidates.find((p) => existsSync(join(p, probe))) ?? candidates[0];
+  return candidates.find((p) =>
+    existsSync(join(p, 'v5.json.gz')) || existsSync(join(p, 'v5.json'))
+  ) ?? candidates[0];
+}
+
+/** Read a JSON data file, supporting both .json.gz and plain .json formats. */
+function readDataFile(filePath: string): string {
+  const gzPath = filePath + '.gz';
+  if (existsSync(gzPath)) {
+    return gunzipSync(readFileSync(gzPath)).toString('utf-8');
+  }
+  return readFileSync(filePath, 'utf-8');
 }
 
 /** Deduplicate props by name (keep first occurrence). */
@@ -32,7 +44,7 @@ function normalizeStore(store: MetadataStore): MetadataStore {
 export function loadMetadata(majorVersion: string): MetadataStore {
   const dataPath = join(getDataPath(), `${majorVersion}.json`);
   try {
-    return normalizeStore(JSON.parse(readFileSync(dataPath, 'utf-8')) as MetadataStore);
+    return normalizeStore(JSON.parse(readDataFile(dataPath)) as MetadataStore);
   } catch (err) {
     if (err instanceof SyntaxError) {
       process.stderr.write(`[antd-cli] Warning: data file may be corrupted: ${dataPath}\n`);
@@ -79,9 +91,9 @@ export function loadMetadataForVersion(version: string): MetadataStore {
   // Helper: try to load a snapshot by tag string (e.g. "4.3.4")
   function tryLoadSnapshot(tag: string): MetadataStore | null {
     const snapshotPath = join(getDataPath(), `v${tag}.json`);
-    if (!existsSync(snapshotPath)) return null;
+    if (!existsSync(snapshotPath) && !existsSync(snapshotPath + '.gz')) return null;
     try {
-      return normalizeStore(JSON.parse(readFileSync(snapshotPath, 'utf-8')) as MetadataStore);
+      return normalizeStore(JSON.parse(readDataFile(snapshotPath)) as MetadataStore);
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary

- Keep plain `.json` in git for readable diffs
- Compress to `.json.gz` only during `npm pack`/`npm publish` via `prepack`/`postpack` hooks
- Loader transparently supports both formats (`gunzipSync()` with `.json` fallback)

## How it works

| Hook | Action |
|------|--------|
| `prepack` | `npm run build` + compress `data/*.json` → `data/*.json.gz` |
| `postpack` | decompress `data/*.json.gz` → `data/*.json` (restore for dev) |

## Changes

| File | Change |
|------|--------|
| `src/data/loader.ts` | Add `readDataFile()` helper with gzip support |
| `scripts/compress-data.ts` | New script supporting `--undo` for compress/decompress |
| `package.json` | Replace `prepublishOnly` with `prepack`/`postpack` hooks |
| `spec.md` | Updated data format docs |

## Result

- **npm package size**: 136MB → ~25MB (81% reduction)
- **git repo**: unchanged (plain JSON, efficient diffs)
- **Runtime**: ~10-30ms gunzip overhead per load, negligible for CLI

## Test plan

- [x] All 223 tests pass
- [x] CLI works with both `.json` and `.json.gz` formats
- [x] Compress → decompress round-trip produces identical files

🤖 Generated with [Claude Code](https://claude.com/claude-code)