### PR TITLE
fix: improve lint rules accuracy and add usage category

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -331,7 +331,7 @@ JSON output:
 
 #### `antd lint [file/dir]`
 
-Check antd usage against best practices. Uses AST parsing (TypeScript compiler API) to analyze source files.
+Check antd usage against best practices. Uses pattern-based analysis (regex + line scanning) on source files.
 
 ```bash
 antd lint ./src

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -166,7 +166,7 @@ function lintFile(
     // Usage checks (prop combination mistakes)
     if (!only || only === 'usage') {
       // Form.Item: shouldUpdate and dependencies should not be used together
-      if (/Form\.Item\b/.test(line) || /<Form\.Item\b/.test(line)) {
+      if (/Form\.Item\b/.test(line)) {
         if (hasNearbyMatch(lines, i, 10, /shouldUpdate\s*[=]/) && hasNearbyMatch(lines, i, 10, /dependencies\s*[=]/)) {
           issues.push({
             file: filePath,
@@ -194,7 +194,7 @@ function lintFile(
 
       // Checkbox: value is not a valid prop, did you mean checked?
       if (hasCheckbox && /<Checkbox\b/.test(line) && !/Checkbox\.Group/.test(line)) {
-        if (hasNearbyMatch(lines, i, 5, /\bvalue\s*=/) && !hasNearbyMatch(lines, i, 5, /\bchecked\s*=/)) {
+        if (hasNearbyMatch(lines, i, 5, /\bvalue\s*=/)) {
           issues.push({
             file: filePath,
             line: i + 1,
@@ -208,7 +208,7 @@ function lintFile(
       // Divider: children not working in vertical mode
       if (hasDivider && /<Divider\b/.test(line)) {
         if (hasNearbyMatch(lines, i, 5, /type\s*=\s*['"{]vertical['"}]/) &&
-            !hasNearbyMatch(lines, i, 3, /\/>/)) {
+            (!hasNearbyMatch(lines, i, 3, /\/>/) || hasNearbyMatch(lines, i, 5, /\bchildren\s*=/))) {
           issues.push({
             file: filePath,
             line: i + 1,


### PR DESCRIPTION
## Summary

- **Remove 3 inaccurate rules**: Table `rowKey` (can't statically detect if dataSource has `key`), Form.Item `label` (valid without label), inline styles (legitimate usage)
- **Improve deprecated messages**: include full replacement info from metadata description (e.g. "use `popupRender` instead")
- **Add `usage` category** with 11 new rules from antd runtime warnings for prop combination mistakes
- **Add 3 deprecated component detections**: `BackTop`, `Button.Group`, `Input.Group`

### New `usage` rules

| Rule | Description |
|------|-------------|
| Form.Item shouldUpdate + dependencies | Should not be used together |
| Button ghost + link/text | `ghost` cannot be used with `type="link"` or `type="text"` |
| Checkbox value | Should be `checked`, not `value` |
| Divider vertical + children | Children not supported in vertical mode |
| Select maxCount | Requires `mode="multiple"` or `mode="tags"` |
| Menu inlineCollapsed | Requires `mode="inline"` |
| QRCode missing value | Missing required `value` prop |
| Typography.Link ellipsis | Only supports boolean, not object |
| Typography.Text ellipsis | Does not support `expandable` or `rows` |
| Radio optionType | Only supported on Radio.Group |
| TreeSelect multiple={false} + treeCheckable | Conflict |

## Test plan

- [x] All 60 existing tests pass
- [x] Manually verified all 11 new rules detect correctly with test file
- [x] Build succeeds with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 `usage` 检查类别，用于捕捉属性组合错误和常见使用误区
  * 移除 `best-practice` 检查类别，相关统计与过滤不再展示

* **改进**
  * 优化废弃警告的提示格式，信息更简洁易读
  * 扩展并细化对 Form.Item、Button、Checkbox、Select、Menu、QRCode、Typography 等组件的使用性与约束检查

* **文档**
  * 更新命令行选项与汇总输出说明，反映新类别变更
<!-- end of auto-generated comment: release notes by coderabbit.ai -->