### PR TITLE
fix(lint): avoid false positives for deprecated prop rule on unrelated components

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -364,7 +364,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
 
 **Rule categories:**
 
-- **deprecated** — Deprecated props (with replacement info from metadata) and deprecated components (`BackTop` → `FloatButton.BackTop`, `Button.Group` / `Input.Group` → `Space.Compact`)
+- **deprecated** — Deprecated props (with replacement info from metadata) and deprecated components (`BackTop` → `FloatButton.BackTop`, `Button.Group` / `Input.Group` → `Space.Compact`). Deprecated prop detection is scoped to the owning component's JSX tag (within ±10 lines) to avoid false positives when the same prop name appears on unrelated components.
 - **a11y** — Accessibility: missing `alt` on Image, missing `aria-label` on clickable icons
 - **usage** — Prop combination mistakes detected from antd runtime warnings:
   - Form.Item `shouldUpdate` + `dependencies` conflict

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process';
 import { writeFileSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import type { LintIssue } from '../commands/lint.js';
 
 const CLI = join(__dirname, '..', '..', 'dist', 'index.js');
 
@@ -383,18 +384,49 @@ describe('CLI e2e', () => {
     expect(data).toHaveProperty('issues');
   });
 
-  it('lint deprecated message includes replacement hint from description', () => {
-    const tmpDir = join(__dirname, '__tmp_lint_deprecated__');
-    const fixture = join(tmpDir, 'card-test.tsx');
+  /** Create a temp fixture, run lint, and clean up. */
+  function lintFixture(name: string, content: string, extraArgs: string[] = []): string {
+    const tmpDir = join(__dirname, `__tmp_lint_${name}__`);
+    const fixture = join(tmpDir, `${name}.tsx`);
     try {
       mkdirSync(tmpDir, { recursive: true });
-      writeFileSync(fixture, `import { Card } from 'antd';\nconst App = () => <Card bordered={false}>x</Card>;\n`);
-      const out = run('lint', fixture, '--version', '6.3.1');
-      expect(out).toMatch(/bordered.*deprecated/i);
-      expect(out).toMatch(/variant/i);
+      writeFileSync(fixture, content);
+      return run('lint', fixture, '--version', '6.3.1', ...extraArgs);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }
+  }
+
+  it('lint deprecated message includes replacement hint from description', () => {
+    const out = lintFixture('card', `import { Card } from 'antd';\nconst App = () => <Card bordered={false}>x</Card>;\n`);
+    expect(out).toMatch(/bordered.*deprecated/i);
+    expect(out).toMatch(/variant/i);
+  });
+
+  it('lint deprecated prop should not flag same prop name on unrelated components', () => {
+    const out = lintFixture(
+      'button',
+      `import { Button, Divider } from 'antd';\nconst App = () => <Button type="primary">Click</Button>;\n`,
+      ['--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    const dividerTypeIssues = data.issues.filter(
+      (i: LintIssue) => i.rule === 'deprecated' && i.message.includes('Divider') && i.message.includes('type'),
+    );
+    expect(dividerTypeIssues).toHaveLength(0);
+  });
+
+  it('lint deprecated prop should still flag when used on the correct component', () => {
+    const out = lintFixture(
+      'divider',
+      `import { Divider } from 'antd';\nconst App = () => <Divider type="vertical" />;\n`,
+      ['--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    const dividerTypeIssues = data.issues.filter(
+      (i: LintIssue) => i.rule === 'deprecated' && i.message.includes('Divider') && i.message.includes('type'),
+    );
+    expect(dividerTypeIssues.length).toBeGreaterThan(0);
   });
 
   it('changelog should error when from > to', () => {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -6,7 +6,7 @@ import { detectVersion } from '../data/version.js';
 import { output } from '../output/formatter.js';
 import { collectFiles, parseAntdImports } from '../utils/scan.js';
 
-interface LintIssue {
+export interface LintIssue {
   file: string;
   line: number;
   rule: string;
@@ -40,10 +40,11 @@ function getDeprecatedProps(store: ReturnType<typeof loadMetadataForVersion>): M
   return result;
 }
 
-/** Check if a pattern exists within `lookahead` lines starting from index `i`. */
-function hasNearbyMatch(lines: string[], i: number, lookahead: number, pattern: RegExp): boolean {
+/** Check if a pattern exists within a window around index `i`. */
+function hasNearbyMatch(lines: string[], i: number, lookahead: number, pattern: RegExp, lookbehind = 0): boolean {
+  const start = Math.max(0, i - lookbehind);
   const end = Math.min(i + lookahead, lines.length);
-  for (let j = i; j < end; j++) {
+  for (let j = start; j < end; j++) {
     if (pattern.test(lines[j])) return true;
   }
   return false;
@@ -68,13 +69,19 @@ function lintFile(
   if (importedComponents.length === 0) return [];
 
   // Build per-component deprecated prop regexes once
-  const deprecatedChecks: { compName: string; dep: { prop: string; since: string; message: string }; regex: RegExp }[] = [];
+  const deprecatedChecks: { compName: string; dep: { prop: string; since: string; message: string }; regex: RegExp; compRegex: RegExp }[] = [];
   if (!only || only === 'deprecated') {
     for (const compName of importedComponents) {
       const deprecations = deprecatedMap.get(compName);
       if (!deprecations) continue;
+      const compRegex = new RegExp(`<${escapeRegExp(compName)}[\\s/>]`);
       for (const dep of deprecations) {
-        deprecatedChecks.push({ compName, dep, regex: new RegExp(`\\b${escapeRegExp(dep.prop)}\\b\\s*[=({]`) });
+        deprecatedChecks.push({
+          compName,
+          dep,
+          regex: new RegExp(`\\b${escapeRegExp(dep.prop)}\\b\\s*[=({]`),
+          compRegex,
+        });
       }
     }
   }
@@ -95,8 +102,8 @@ function lintFile(
     const line = lines[i];
 
     // Deprecated prop checks
-    for (const { compName, dep, regex } of deprecatedChecks) {
-      if (regex.test(line)) {
+    for (const { compName, dep, regex, compRegex } of deprecatedChecks) {
+      if (regex.test(line) && hasNearbyMatch(lines, i, 3, compRegex, 10)) {
         issues.push({
           file: filePath,
           line: i + 1,


### PR DESCRIPTION
## Summary

- The `lint` command's deprecated prop check was matching prop names (e.g. `type`) on **any** JSX line, not just lines belonging to the component that owns the deprecation
- For example, `Divider` has a deprecated `type` prop, so `<Button type="primary">` was incorrectly flagged as a Divider deprecation
- Fixed by verifying the component's opening JSX tag appears within ±10 lines of the matched prop line before reporting the issue

## Test plan

- [ ] `<Button type="primary">` with Divider imported → no false positive reported
- [ ] `<Divider type="vertical" />` → still correctly flagged as deprecated
- [ ] All 69 existing tests pass

Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)