### PR TITLE
chore: keep JSON in git, exclude from npm via .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 *.tsbuildinfo
 .DS_Store
+data/*.json.gz
 settings.local.json
 .worktrees/
 .claude/

--- a/data/.npmignore
+++ b/data/.npmignore
@@ -1,0 +1,4 @@
+# Exclude raw JSON data files from npm package (use .gz instead)
+# versions.json is kept as it's small and needed for version resolution
+*.json
+!versions.json

--- a/scripts/compress-data.ts
+++ b/scripts/compress-data.ts
@@ -4,32 +4,28 @@
  * Compress or decompress data/*.json files.
  *
  * Usage:
- *   npx tsx scripts/compress-data.ts          # compress: .json → .json.gz
- *   npx tsx scripts/compress-data.ts --undo   # decompress: .json.gz → .json
+ *   npx tsx scripts/compress-data.ts          # compress: create .json.gz alongside .json
+ *   npx tsx scripts/compress-data.ts --undo   # clean up: remove .json.gz files
  *
- * Used by npm prepack/postpack hooks to ship .gz in the npm package
- * while keeping .json in the git repository.
+ * Used by npm prepack/postpack hooks to generate .gz files for the npm package.
+ * JSON files are kept in git; .gz files are gitignored but included in npm via .npmignore.
  */
 
 import { readdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
-import { gzipSync, gunzipSync } from 'node:zlib';
+import { gzipSync } from 'node:zlib';
 
 const dataDir = join(import.meta.dirname, '..', 'data');
 const undo = process.argv.includes('--undo');
 
 if (undo) {
-  // Decompress: .json.gz → .json
+  // Clean up: remove .json.gz files (json files are kept in place)
   const files = readdirSync(dataDir).filter((f) => f.endsWith('.json.gz'));
   for (const file of files) {
-    const gzPath = join(dataDir, file);
-    const jsonPath = gzPath.slice(0, -3); // remove .gz
-    const content = gunzipSync(readFileSync(gzPath));
-    writeFileSync(jsonPath, content);
-    unlinkSync(gzPath);
-    console.log(`${file} → ${file.slice(0, -3)}`);
+    unlinkSync(join(dataDir, file));
+    console.log(`Removed ${file}`);
   }
-  console.log(`\nDecompressed ${files.length} files.`);
+  console.log(`\nCleaned up ${files.length} .gz files.`);
 } else {
   // Compress: .json → .json.gz
   const files = readdirSync(dataDir).filter(
@@ -48,7 +44,6 @@ if (undo) {
     totalCompressed += compressed.length;
 
     writeFileSync(filePath + '.gz', compressed);
-    unlinkSync(filePath);
 
     const ratio = ((1 - compressed.length / content.length) * 100).toFixed(1);
     console.log(`${file} → ${file}.gz  (${(content.length / 1024 / 1024).toFixed(1)}MB → ${(compressed.length / 1024 / 1024).toFixed(1)}MB, -${ratio}%)`);


### PR DESCRIPTION
## Summary

- **compress-data.ts**: 压缩时不再删除原始 JSON 文件，`--undo` 仅清理 .gz 文件
- **data/.npmignore**: 排除 `*.json`（保留 `versions.json`），npm 包只含 .gz 文件
- **.gitignore**: 添加 `data/*.json.gz`，git 中不追踪压缩文件

之前 prepack 会删除 JSON 并替换为 .gz，postpack 再恢复，如果中途中断会导致仓库状态异常。现在 JSON 和 .gz 共存，通过 .npmignore 控制发布内容。

## Test plan

- [x] `npm pack --dry-run` 验证 npm 包只含 .gz 和 versions.json
- [x] pack 后 JSON 文件仍然存在
- [x] postpack 后 .gz 文件被清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂项 (Chores)**
  * 优化了 npm 发布包的大小，配置排除 JSON 文件（versions.json 除外）的打包规则
  * 改进了数据压缩脚本的处理流程，完善了压缩后的文件管理机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->