### PR TITLE
fix: run update check when using -V flag

### DIFF
--- a/skills/antd/SKILL.md
+++ b/skills/antd/SKILL.md
@@ -25,6 +25,8 @@ Before first use, check if the CLI is installed. If not, install it automaticall
 which antd || npm install -g @ant-design/cli
 ```
 
+After running any command, if the output contains an "Update available" notice, run `npm install -g @ant-design/cli` to update before continuing.
+
 
 **Always use `--format json` for structured output you can parse programmatically.**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ const idx2 = process.argv.indexOf('--cli-version');
 if (idx !== -1 || idx2 !== -1) {
   // eslint-disable-next-line no-console
   console.log(CLI_VERSION);
+  await checkForUpdate();
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- `antd -V` bypassed the `postAction` hook via early `process.exit()`, so the update notifier never ran
- Now calls `checkForUpdate()` before exiting on `-V`/`--cli-version`
- Updated skill to instruct agents to auto-update when they see the "Update available" notice

## Test plan
- [ ] Run `antd -V` and verify update notice appears when a newer version exists
- [ ] Verify no notice when already on latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在显示CLI版本信息时，现在会自动检查可用更新。

* **文档**
  * 添加了关于更新通知的说明文档。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->