### PR TITLE
feat: support configurable lint import sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,10 @@ Four rule categories: `deprecated`, `a11y`, `performance`, `best-practice`. Depr
 antd lint ./src
 antd lint ./src --only deprecated
 antd lint ./src --only a11y
+antd lint ./src --only deprecated --format json --antd-alias @shared-components
 ```
+
+Use `--antd-alias <source>` to treat additional package names as aliases of `antd`. Repeat the flag for multiple wrapper packages; `antd` remains enabled by default.
 
 ### `antd migrate <from> <to>`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -342,7 +342,10 @@ antd usage -f Button                # 过滤特定组件
 antd lint ./src
 antd lint ./src --only deprecated
 antd lint ./src --only a11y
+antd lint ./src --only deprecated --format json --antd-alias @shared-components
 ```
+
+使用 `--antd-alias <source>` 可以把额外包名视为 `antd` 的别名；可重复传入多个包装包名，且默认仍会匹配 `antd`。
 
 ### `antd migrate <from> <to>`
 

--- a/spec.md
+++ b/spec.md
@@ -437,7 +437,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
   - Typography.Text `ellipsis` with `expandable` / `rows` (not supported)
   - Radio `optionType` on Radio (only on Radio.Group)
   - TreeSelect `multiple={false}` + `treeCheckable` conflict
-- **performance** — Wildcard imports, disabling virtual scroll on Select
+- **performance** — Wildcard imports from `antd`, `antd/*`, configured `--import-source` roots, or their subpaths, disabling virtual scroll on Select
 
 #### `antd migrate <from> <to>`
 

--- a/spec.md
+++ b/spec.md
@@ -396,7 +396,12 @@ antd lint --only a11y               # only check accessibility
 antd lint --only usage              # only check usage mistakes
 antd lint --only performance        # only check performance
 antd lint --format json
+antd lint --only deprecated --format json --import-source @shared-components
 ```
+
+Options:
+- `--only <category>` — limit checks to `deprecated`, `a11y`, `usage`, or `performance`
+- `--import-source <source>` — treat additional import source roots as antd component entrypoints; repeat the flag for multiple wrapper roots. `antd` remains enabled by default.
 
 JSON output:
 ```json

--- a/spec.md
+++ b/spec.md
@@ -396,12 +396,12 @@ antd lint --only a11y               # only check accessibility
 antd lint --only usage              # only check usage mistakes
 antd lint --only performance        # only check performance
 antd lint --format json
-antd lint --only deprecated --format json --import-source @shared-components
+antd lint --only deprecated --format json --antd-alias @shared-components
 ```
 
 Options:
 - `--only <category>` — limit checks to `deprecated`, `a11y`, `usage`, or `performance`
-- `--import-source <source>` — treat additional import source roots as antd component entrypoints; repeat the flag for multiple wrapper roots. `antd` remains enabled by default.
+- `--antd-alias <source>` — treat additional package names as aliases of `antd`; repeat the flag for multiple wrapper packages. `antd` remains enabled by default.
 
 JSON output:
 ```json
@@ -437,7 +437,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
   - Typography.Text `ellipsis` with `expandable` / `rows` (not supported)
   - Radio `optionType` on Radio (only on Radio.Group)
   - TreeSelect `multiple={false}` + `treeCheckable` conflict
-- **performance** — Wildcard imports from `antd`, `antd/*`, configured `--import-source` roots, or their subpaths, disabling virtual scroll on Select
+- **performance** — Wildcard imports from `antd`, `antd/*`, configured `--antd-alias` packages, or their subpaths, disabling virtual scroll on Select
 
 #### `antd migrate <from> <to>`
 

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -620,7 +620,21 @@ const App = () => <DatePicker popupClassName="custom" />;
       expect(issues).toHaveLength(1);
     });
 
-    it('skips wrapper subpath default import in minimal mode', async () => {
+    it('detects wildcard import from configured wrapper root', async () => {
+      makeTmpFile(
+        'wrapper-wildcard.tsx',
+        `import * as Shared from '@shared-components';
+
+const App = () => <Shared.Button />;
+`,
+      );
+      const data = parseJson(await runLint([join(tmpDir, 'wrapper-wildcard.tsx')], 'json', '5.29.0', ['@shared-components']));
+      const issues = data.issues.filter((i: any) => i.rule === 'performance' && i.message.includes('@shared-components'));
+      expect(issues).toHaveLength(1);
+      expect(issues[0].severity).toBe('error');
+    });
+
+    it('detects wildcard import from configured wrapper subpath', async () => {
       makeTmpFile(
         'wrapper-subpath.tsx',
         `import DatePicker from '@shared-components/DatePicker';
@@ -629,7 +643,9 @@ const App = () => <DatePicker popupClassName="custom" />;
 `,
       );
       const data = parseJson(await runLint([join(tmpDir, 'wrapper-subpath.tsx')], 'json', '5.29.0', ['@shared-components']));
-      expect(data.issues).toHaveLength(0);
+      const issues = data.issues.filter((i: any) => i.rule === 'performance' && i.message.includes('@shared-components/DatePicker'));
+      expect(issues).toHaveLength(1);
+      expect(issues[0].severity).toBe('error');
     });
 
     it('skips wrapper imports by default when no import source is configured', async () => {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -15,7 +15,7 @@ async function runLint(
   args: string[] = [],
   format: string = 'json',
   version: string = '5.20.0',
-  importSources: string[] = [],
+  antdAliases: string[] = [],
 ): Promise<string> {
   const program = new Command();
   program.option('--format <format>', '', format);
@@ -23,8 +23,8 @@ async function runLint(
   program.option('--lang <lang>', '', 'en');
   registerLintCommand(program);
   const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-  const importArgs = importSources.flatMap((source) => ['--import-source', source]);
-  await program.parseAsync(['node', 'test', 'lint', ...args, ...importArgs]);
+  const aliasArgs = antdAliases.flatMap((source) => ['--antd-alias', source]);
+  await program.parseAsync(['node', 'test', 'lint', ...args, ...aliasArgs]);
   const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
   logSpy.mockRestore();
   return output;

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -15,6 +15,7 @@ async function runLint(
   args: string[] = [],
   format: string = 'json',
   version: string = '5.20.0',
+  importSources: string[] = [],
 ): Promise<string> {
   const program = new Command();
   program.option('--format <format>', '', format);
@@ -22,7 +23,8 @@ async function runLint(
   program.option('--lang <lang>', '', 'en');
   registerLintCommand(program);
   const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-  await program.parseAsync(['node', 'test', 'lint', ...args]);
+  const importArgs = importSources.flatMap((source) => ['--import-source', source]);
+  await program.parseAsync(['node', 'test', 'lint', ...args, ...importArgs]);
   const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
   logSpy.mockRestore();
   return output;
@@ -600,6 +602,67 @@ const App = () => (
       expect(alertIssue!.line).toBe(5);
       expect(dividerIssue!.line).toBe(6);
       expect(spaceIssue!.line).toBe(7);
+    });
+  });
+
+  // --- Configurable import sources ---
+  describe('configurable import sources', () => {
+    it('detects deprecated props from configured wrapper root import', async () => {
+      makeTmpFile(
+        'wrapper-root.tsx',
+        `import { DatePicker } from '@shared-components';
+
+const App = () => <DatePicker popupClassName="custom" />;
+`,
+      );
+      const data = parseJson(await runLint([join(tmpDir, 'wrapper-root.tsx')], 'json', '5.29.0', ['@shared-components']));
+      const issues = data.issues.filter((i: any) => i.rule === 'deprecated' && i.message.includes('DatePicker') && i.message.includes('popupClassName'));
+      expect(issues).toHaveLength(1);
+    });
+
+    it('skips wrapper subpath default import in minimal mode', async () => {
+      makeTmpFile(
+        'wrapper-subpath.tsx',
+        `import DatePicker from '@shared-components/DatePicker';
+
+const App = () => <DatePicker popupClassName="custom" />;
+`,
+      );
+      const data = parseJson(await runLint([join(tmpDir, 'wrapper-subpath.tsx')], 'json', '5.29.0', ['@shared-components']));
+      expect(data.issues).toHaveLength(0);
+    });
+
+    it('skips wrapper imports by default when no import source is configured', async () => {
+      makeTmpFile(
+        'wrapper-default-skip.tsx',
+        `import { DatePicker } from '@shared-components';
+
+const App = () => <DatePicker popupClassName="custom" />;
+`,
+      );
+      const data = parseJson(await runLint([join(tmpDir, 'wrapper-default-skip.tsx')], 'json', '5.29.0'));
+      expect(data.issues).toHaveLength(0);
+    });
+
+    it('supports multiple configured import sources', async () => {
+      makeTmpFile(
+        'wrapper-multiple.tsx',
+        `import { DatePicker } from '@shared-components';
+import { Divider } from '@another-ui';
+
+const App = () => (
+  <>
+    <DatePicker popupClassName="custom" />
+    <Divider type="vertical" />
+  </>
+);
+`,
+      );
+      const data = parseJson(await runLint([join(tmpDir, 'wrapper-multiple.tsx'), '--only', 'deprecated'], 'json', '6.0.0', ['@shared-components', '@another-ui']));
+      const datePickerIssues = data.issues.filter((i: any) => i.message.includes('DatePicker') && i.message.includes('popupClassName'));
+      const dividerIssues = data.issues.filter((i: any) => i.message.includes('Divider') && i.message.includes('type'));
+      expect(datePickerIssues).toHaveLength(1);
+      expect(dividerIssues).toHaveLength(1);
     });
   });
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -108,8 +108,8 @@ function createLineMapper(source: string): (offset: number) => number {
   };
 }
 
-function normalizeImportSources(importSources?: string[]): string[] {
-  const normalized = (importSources ?? [])
+function normalizeAntdAliases(antdAliases?: string[]): string[] {
+  const normalized = (antdAliases ?? [])
     .flatMap((source) => source.split(','))
     .map((source) => source.trim())
     .filter(Boolean);
@@ -117,22 +117,22 @@ function normalizeImportSources(importSources?: string[]): string[] {
   return Array.from(new Set(['antd', ...normalized]));
 }
 
-function matchesImportSource(source: string, importSources: string[]): boolean {
-  return importSources.some((importSource) => source === importSource || source.startsWith(`${importSource}/`));
+function matchesAntdAlias(source: string, antdAliases: string[]): boolean {
+  return antdAliases.some((antdAlias) => source === antdAlias || source.startsWith(`${antdAlias}/`));
 }
 
-function mayContainImportSource(content: string, importSources: string[]): boolean {
-  return importSources.some((importSource) => content.includes(importSource));
+function mayContainAntdAlias(content: string, antdAliases: string[]): boolean {
+  return antdAliases.some((antdAlias) => content.includes(antdAlias));
 }
 
-function collectImportSource(source: string, previous: string[]): string[] {
+function collectAntdAlias(source: string, previous: string[]): string[] {
   return [...previous, source];
 }
 
 function lintFile(
   filePath: string,
   deprecatedMap: Map<string, DeprecatedInfo[]>,
-  importSources: string[],
+  antdAliases: string[],
   only?: string,
 ): LintIssue[] {
   let content: string;
@@ -144,8 +144,8 @@ function lintFile(
   }
   /* v8 ignore stop */
 
-  // Fast pre-check: skip files that don't reference configured import sources
-  if (!mayContainImportSource(content, importSources)) return [];
+  // Fast pre-check: skip files that don't reference configured antd aliases
+  if (!mayContainAntdAlias(content, antdAliases)) return [];
 
   const result = parseSync(filePath, content);
   if (result.errors.length > 0) return [];
@@ -167,7 +167,7 @@ function lintFile(
   const visitor = new Visitor({
     ImportDeclaration(node: any) {
       const source = node.source.value;
-      if (!matchesImportSource(source, importSources)) return;
+      if (!matchesAntdAlias(source, antdAliases)) return;
 
       if (node.importKind === 'type') return;
 
@@ -336,20 +336,20 @@ export function registerLintCommand(program: Command): void {
     .command('lint [target]')
     .description('Check antd usage against best practices')
     .option('--only <category>', 'Only check specific category (deprecated, a11y, usage, performance)')
-    .option('--import-source <source>', 'Treat additional import source roots as antd component entrypoints', collectImportSource, [])
-    .action((target: string | undefined, cmdOpts: { only?: string; importSource?: string[] }) => {
+    .option('--antd-alias <source>', 'Treat additional package names as aliases of antd imports', collectAntdAlias, [])
+    .action((target: string | undefined, cmdOpts: { only?: string; antdAlias?: string[] }) => {
       const opts = program.opts<GlobalOptions>();
       const targetPath = target || '.';
       const versionInfo = detectVersion(opts.version);
       const store = loadMetadataForVersion(versionInfo.version);
       const deprecatedMap = getDeprecatedProps(store);
-      const importSources = normalizeImportSources(cmdOpts.importSource);
+      const antdAliases = normalizeAntdAliases(cmdOpts.antdAlias);
 
       const files = collectFiles(targetPath);
       const allIssues: LintIssue[] = [];
 
       for (const file of files) {
-        allIssues.push(...lintFile(file, deprecatedMap, importSources, cmdOpts.only));
+        allIssues.push(...lintFile(file, deprecatedMap, antdAliases, cmdOpts.only));
       }
 
       const summary = {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -179,7 +179,6 @@ function lintFile(
         }
 
         if ((!only || only === 'performance') &&
-            source === 'antd' &&
             (spec.type === 'ImportDefaultSpecifier' || spec.type === 'ImportNamespaceSpecifier')) {
           report('performance', 'error', lineOf(node),
             'Avoid wildcard import from antd. Use named imports: `import { Button } from \'antd\'`');

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -181,7 +181,7 @@ function lintFile(
         if ((!only || only === 'performance') &&
             (spec.type === 'ImportDefaultSpecifier' || spec.type === 'ImportNamespaceSpecifier')) {
           report('performance', 'error', lineOf(node),
-            'Avoid wildcard import from antd. Use named imports: `import { Button } from \'antd\'`');
+            `Avoid wildcard import from ${source}. Use named imports: \`import { Button } from '${source}'\``);
         }
       }
     },

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -108,9 +108,31 @@ function createLineMapper(source: string): (offset: number) => number {
   };
 }
 
+function normalizeImportSources(importSources?: string[]): string[] {
+  const normalized = (importSources ?? [])
+    .flatMap((source) => source.split(','))
+    .map((source) => source.trim())
+    .filter(Boolean);
+
+  return Array.from(new Set(['antd', ...normalized]));
+}
+
+function matchesImportSource(source: string, importSources: string[]): boolean {
+  return importSources.some((importSource) => source === importSource || source.startsWith(`${importSource}/`));
+}
+
+function mayContainImportSource(content: string, importSources: string[]): boolean {
+  return importSources.some((importSource) => content.includes(importSource));
+}
+
+function collectImportSource(source: string, previous: string[]): string[] {
+  return [...previous, source];
+}
+
 function lintFile(
   filePath: string,
   deprecatedMap: Map<string, DeprecatedInfo[]>,
+  importSources: string[],
   only?: string,
 ): LintIssue[] {
   let content: string;
@@ -122,8 +144,8 @@ function lintFile(
   }
   /* v8 ignore stop */
 
-  // Fast pre-check: skip files that don't reference antd at all
-  if (!content.includes('antd')) return [];
+  // Fast pre-check: skip files that don't reference configured import sources
+  if (!mayContainImportSource(content, importSources)) return [];
 
   const result = parseSync(filePath, content);
   if (result.errors.length > 0) return [];
@@ -145,7 +167,7 @@ function lintFile(
   const visitor = new Visitor({
     ImportDeclaration(node: any) {
       const source = node.source.value;
-      if (source !== 'antd' && !source.startsWith('antd/')) return;
+      if (!matchesImportSource(source, importSources)) return;
 
       if (node.importKind === 'type') return;
 
@@ -157,6 +179,7 @@ function lintFile(
         }
 
         if ((!only || only === 'performance') &&
+            source === 'antd' &&
             (spec.type === 'ImportDefaultSpecifier' || spec.type === 'ImportNamespaceSpecifier')) {
           report('performance', 'error', lineOf(node),
             'Avoid wildcard import from antd. Use named imports: `import { Button } from \'antd\'`');
@@ -314,18 +337,20 @@ export function registerLintCommand(program: Command): void {
     .command('lint [target]')
     .description('Check antd usage against best practices')
     .option('--only <category>', 'Only check specific category (deprecated, a11y, usage, performance)')
-    .action((target: string | undefined, cmdOpts: { only?: string }) => {
+    .option('--import-source <source>', 'Treat additional import source roots as antd component entrypoints', collectImportSource, [])
+    .action((target: string | undefined, cmdOpts: { only?: string; importSource?: string[] }) => {
       const opts = program.opts<GlobalOptions>();
       const targetPath = target || '.';
       const versionInfo = detectVersion(opts.version);
       const store = loadMetadataForVersion(versionInfo.version);
       const deprecatedMap = getDeprecatedProps(store);
+      const importSources = normalizeImportSources(cmdOpts.importSource);
 
       const files = collectFiles(targetPath);
       const allIssues: LintIssue[] = [];
 
       for (const file of files) {
-        allIssues.push(...lintFile(file, deprecatedMap, cmdOpts.only));
+        allIssues.push(...lintFile(file, deprecatedMap, importSources, cmdOpts.only));
       }
 
       const summary = {


### PR DESCRIPTION
## Summary
- add repeatable `--antd-alias <source>` to `antd lint` so wrapper packages can be treated as aliases of `antd`
- keep the default `antd` import matching behavior unchanged while allowing multiple configured aliases
- update lint command tests and `spec.md` to reflect the new option name and wording

## Test plan
- [x] npm run typecheck
- [x] npx vitest run src/__tests__/commands/lint.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为 antd lint 增加可重复的 --antd-alias <source> 选项，用于将额外包名视为 antd 的别名，保留对 antd 的默认匹配。
  * 新增 --only <category> 用法示例，支持限定为 deprecated、a11y、usage 或 performance。

* **文档**
  * 更新命令示例与参数说明，包含 --antd-alias 与示例输出（JSON）说明。

* **测试**
  * 补充并覆盖了带别名配置时的 lint 行为测试（deprecated 与 performance 场景）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
