### PR TITLE
fix: sync workflow never detects new antd versions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -22,24 +22,18 @@ jobs:
 
       - run: npm ci
 
-      - name: Check if version already published
+      - name: Check if sync needed
         id: check-version
-        run: |
-          CLI_VERSION=$(node -p "JSON.parse(require('fs').readFileSync('data/v6.json','utf8')).version")
-          if npm view "@ant-design/cli@${CLI_VERSION}" version >/dev/null 2>&1; then
-            echo "Version ${CLI_VERSION} already published to npm, exiting"
-            exit 0
-          fi
-          echo "needs_publish=true" >> $GITHUB_OUTPUT
+        run: npx tsx scripts/check-sync-needed.ts
 
       - name: Clone antd repo (shallow, filter tree)
-        if: steps.check-version.outputs.needs_publish == 'true'
+        if: steps.check-version.outputs.needs_sync == 'true'
         run: |
           git clone --filter=tree:0 --no-checkout \
             https://github.com/ant-design/ant-design.git antd-source
 
       - name: Sync v4, v5, v6 metadata
-        if: steps.check-version.outputs.needs_publish == 'true'
+        if: steps.check-version.outputs.needs_sync == 'true'
         run: npx tsx scripts/sync.ts --antd-dir antd-source
 
       - name: Build and publish

--- a/scripts/check-sync-needed.ts
+++ b/scripts/check-sync-needed.ts
@@ -6,46 +6,36 @@
  * Outputs (via GITHUB_OUTPUT):
  *   needs_sync    — antd has a new version not in local data
  *   needs_publish — CLI for the synced version hasn't been published yet (recovery scenario)
- *
- * Exit code 0 always — the workflow reads the outputs to decide which steps to run.
  */
 
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 
-const LATEST_ANTD = execSync('npm view antd version', { encoding: 'utf8' }).trim();
-const SYNCED_VERSION = JSON.parse(fs.readFileSync('data/v6.json', 'utf8')).version;
+const latestAntd = execSync('npm view antd version', { encoding: 'utf8' }).trim();
+const syncedVersion: string = JSON.parse(fs.readFileSync('data/v6.json', 'utf8')).version;
 
-console.log(`Latest antd on npm: ${LATEST_ANTD}`);
-console.log(`Local synced version: ${SYNCED_VERSION}`);
+console.log(`Latest antd on npm: ${latestAntd}`);
+console.log(`Local synced version: ${syncedVersion}`);
 
-const needsSync = LATEST_ANTD !== SYNCED_VERSION;
-let needsPublish = false;
-
-if (!needsSync) {
-  // Data is up to date — but maybe publish failed last time?
+const needsSync = latestAntd !== syncedVersion;
+const alreadyPublished = !needsSync && (() => {
   try {
-    execSync(`npm view "@ant-design/cli@${SYNCED_VERSION}" version`, { stdio: 'pipe' });
+    execSync(`npm view "@ant-design/cli@${syncedVersion}" version`, { stdio: 'pipe' });
+    return true;
   } catch {
-    needsPublish = true;
+    return false;
   }
-} else {
-  needsPublish = true; // new version always requires publish
-}
+})();
+const needsPublish = needsSync || !alreadyPublished;
 
-// Write GITHUB_OUTPUT
 const outputFile = process.env.GITHUB_OUTPUT;
 if (outputFile) {
-  const append = (key: string, value: string) => {
-    fs.appendFileSync(outputFile, `${key}=${value}\n`);
-  };
-  append('needs_sync', String(needsSync));
-  append('needs_publish', String(needsPublish));
+  fs.appendFileSync(outputFile, `needs_sync=${needsSync}\n`);
+  fs.appendFileSync(outputFile, `needs_publish=${needsPublish}\n`);
 }
 
 if (!needsSync && !needsPublish) {
   console.log('Data up to date and CLI published, nothing to do');
-  process.exit(0);
 }
 
 console.log(`needs_sync=${needsSync}, needs_publish=${needsPublish}`);

--- a/scripts/check-sync-needed.ts
+++ b/scripts/check-sync-needed.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * Check whether sync.yml needs to run.
+ *
+ * Outputs (via GITHUB_OUTPUT):
+ *   needs_sync    — antd has a new version not in local data
+ *   needs_publish — CLI for the synced version hasn't been published yet (recovery scenario)
+ *
+ * Exit code 0 always — the workflow reads the outputs to decide which steps to run.
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const LATEST_ANTD = execSync('npm view antd version', { encoding: 'utf8' }).trim();
+const SYNCED_VERSION = JSON.parse(fs.readFileSync('data/v6.json', 'utf8')).version;
+
+console.log(`Latest antd on npm: ${LATEST_ANTD}`);
+console.log(`Local synced version: ${SYNCED_VERSION}`);
+
+const needsSync = LATEST_ANTD !== SYNCED_VERSION;
+let needsPublish = false;
+
+if (!needsSync) {
+  // Data is up to date — but maybe publish failed last time?
+  try {
+    execSync(`npm view "@ant-design/cli@${SYNCED_VERSION}" version`, { stdio: 'pipe' });
+  } catch {
+    needsPublish = true;
+  }
+} else {
+  needsPublish = true; // new version always requires publish
+}
+
+// Write GITHUB_OUTPUT
+const outputFile = process.env.GITHUB_OUTPUT;
+if (outputFile) {
+  const append = (key: string, value: string) => {
+    fs.appendFileSync(outputFile, `${key}=${value}\n`);
+  };
+  append('needs_sync', String(needsSync));
+  append('needs_publish', String(needsPublish));
+}
+
+if (!needsSync && !needsPublish) {
+  console.log('Data up to date and CLI published, nothing to do');
+  process.exit(0);
+}
+
+console.log(`needs_sync=${needsSync}, needs_publish=${needsPublish}`);


### PR DESCRIPTION
## Summary

- Fix sync.yml version detection logic that caused the workflow to never detect new antd releases
- Root cause: the check compared local `data/v6.json` version against `@ant-design/cli` on npm, which is always true (CLI publishes at the synced version), so the workflow always exited early
- Extract the check logic into `scripts/check-sync-needed.ts` for local debuggability
- Cover recovery scenario: data pushed but `npm publish` failed

## Test plan

- [x] Ran `npx tsx scripts/check-sync-needed.ts` locally — correctly reports `needs_sync=true, needs_publish=true` for antd 6.3.6 vs local 6.3.5
- [ ] Trigger `workflow_dispatch` after merge and verify the workflow runs the full sync + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 改进自动化工作流中的版本检查和同步机制。系统现在能够智能检测版本变化，精准判断是否需要同步，自动触发相应的发布流程，提升整体可靠性和运行效率

<!-- end of auto-generated comment: release notes by coderabbit.ai -->