### PR TITLE
fix: only include changed versions in sync commit and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 ## [6.3.6](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6) (2026-04-17)
 
-- Update antd metadata ([v4@4.24.16](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6#diff-0f73f4b6da46cd62e857a1f41ea51e697389f2c62a0775fcfc545edd653c5e2c), [v5@5.29.3](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6#diff-6b390e384eeea7f593730f71f071bf947ec0fac7a19f6d32b91e13191b177a58), [v6@6.3.6](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+### New Features
+
+- Add antd v3 support — `antd list`, `antd info`, `antd doc`, `antd demo`, `antd migrate 3 4` now work with v3 projects ([#77](https://github.com/ant-design/ant-design-cli/pull/77))
+- Add `--antd-alias` flag to `antd lint` for recognizing wrapper import sources ([#81](https://github.com/ant-design/ant-design-cli/pull/81))
+- Enhance `antd env` with full envinfo output ([#75](https://github.com/ant-design/ant-design-cli/pull/75))
+- Add MCP tool annotations for better IDE integration ([#79](https://github.com/ant-design/ant-design-cli/pull/79))
+
+### Bug Fixes
+
+- Fix `antd token` outputting plain text instead of valid JSON when no tokens available ([#80](https://github.com/ant-design/ant-design-cli/pull/80))
+- Fix sync workflow never detecting new antd versions ([#83](https://github.com/ant-design/ant-design-cli/pull/83))
+- Fix AI assistant proactively suggesting bug reports; bug reporting is now user-initiated only, with `ANTD_NO_AUTO_REPORT=1` to fully opt out ([#85](https://github.com/ant-design/ant-design-cli/pull/85), closes [#82](https://github.com/ant-design/ant-design-cli/issues/82))
+
+### Other Changes
+
+- Update antd metadata ([v6@6.3.6](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+- Require Node.js >= 20 (Commander v14 compatibility) ([#76](https://github.com/ant-design/ant-design-cli/pull/76))
 
 
 ## [6.3.5](https://github.com/ant-design/ant-design-cli/compare/v6.3.5-beta.0...v6.3.5) (2026-03-30)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,7 +2,23 @@
 
 ## [6.3.6](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6) (2026-04-17)
 
-- 同步 antd 元数据 ([v4@4.24.16](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6#diff-0f73f4b6da46cd62e857a1f41ea51e697389f2c62a0775fcfc545edd653c5e2c), [v5@5.29.3](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6#diff-6b390e384eeea7f593730f71f071bf947ec0fac7a19f6d32b91e13191b177a58), [v6@6.3.6](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+### 新功能
+
+- 新增 antd v3 支持 — `antd list`、`antd info`、`antd doc`、`antd demo`、`antd migrate 3 4` 现可用于 v3 项目 ([#77](https://github.com/ant-design/ant-design-cli/pull/77))
+- `antd lint` 新增 `--antd-alias` 参数，支持识别二次封装的 import 来源 ([#81](https://github.com/ant-design/ant-design-cli/pull/81))
+- `antd env` 增强为完整的环境信息输出 ([#75](https://github.com/ant-design/ant-design-cli/pull/75))
+- MCP 工具新增 annotations，改善 IDE 集成体验 ([#79](https://github.com/ant-design/ant-design-cli/pull/79))
+
+### Bug 修复
+
+- 修复 `antd token` 在无组件 token 时输出纯文本而非有效 JSON 的问题 ([#80](https://github.com/ant-design/ant-design-cli/pull/80))
+- 修复同步工作流无法检测 antd 新版本的问题 ([#83](https://github.com/ant-design/ant-design-cli/pull/83))
+- 修复 AI 助手主动建议提交 Bug 报告的问题；Bug 报告改为仅用户主动触发，新增 `ANTD_NO_AUTO_REPORT=1` 环境变量可完全关闭提示 ([#85](https://github.com/ant-design/ant-design-cli/pull/85), closes [#82](https://github.com/ant-design/ant-design-cli/issues/82))
+
+### 其他变更
+
+- 同步 antd 元数据 ([v6@6.3.6](https://github.com/ant-design/ant-design-cli/compare/v6.3.5...v6.3.6#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+- 最低 Node.js 版本要求提升至 20（Commander v14 兼容性） ([#76](https://github.com/ant-design/ant-design-cli/pull/76))
 
 
 ## 6.3.5

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -11,11 +11,13 @@ import { resolve } from 'node:path';
 const GH_TOKEN = process.env.GH_TOKEN;
 
 function run(cmd: string, options?: { cwd?: string; stdio?: 'pipe' | 'inherit' }): string {
-  return execSync(cmd, {
+  const result = execSync(cmd, {
     encoding: 'utf-8',
     stdio: options?.stdio ?? 'pipe',
     cwd: options?.cwd,
-  }).trim();
+  });
+  // execSync returns null when stdio is 'inherit'
+  return result?.trim() ?? '';
 }
 
 function getNpmVersion(pkgName: string, version: string): string | null {
@@ -38,10 +40,16 @@ function main() {
     process.exit(0);
   }
 
-  // Collect version info for changelog
+  // Collect version info for changelog — only include versions that actually changed
   const versions: string[] = [];
   for (const major of [4, 5, 6]) {
     const data = JSON.parse(readFileSync(`data/v${major}.json`, 'utf-8'));
+    try {
+      const oldData = JSON.parse(run(`git show HEAD:data/v${major}.json`));
+      if (data.version === oldData.version) continue;
+    } catch {
+      // New file, include it
+    }
     versions.push(`v${major}@${data.version}`);
   }
   const versionsStr = versions.join(', ');


### PR DESCRIPTION
## Summary
- Update v6.3.6 changelog (both en/zh) to only list `v6@6.3.6` — v4 and v5 data files were unchanged in this release
- Fix `publish.ts` to compare data files against HEAD and skip unchanged versions in the sync commit message
- Fix `publish.ts` crash: `execSync` returns `null` when `stdio: 'inherit'`, so `trim()` on null threw `TypeError`

## Test plan
- [ ] Verify CHANGELOG.md and CHANGELOG.zh-CN.md v6.3.6 section only references v6@6.3.6
- [ ] Verify the GitHub release for v6.3.6 has been updated to match
- [ ] Confirm `scripts/publish.ts` handles `stdio: 'inherit'` without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)