### PR TITLE
fix: opt-out auto bug reporting in SKILL.md and MCP prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,14 @@ antd bug-cli --title "..." --submit
 
 **Version auto-detection**: `--version` flag → `node_modules/antd` → `package.json` dependencies → fallback `5.24.0`
 
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `ANTD_NO_AUTO_REPORT=1` | Disable bug-reporting suggestions from AI agents (see [#82](https://github.com/ant-design/ant-design-cli/issues/82)) |
+| `NO_UPDATE_CHECK=1` | Skip the silent version update check |
+| `CI=1` | Skip the silent version update check (same as `NO_UPDATE_CHECK=1`) |
+
 <br>
 
 ## 📄 License

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -401,6 +401,14 @@ antd bug-cli --title "..." --submit
 
 **版本自动检测**：`--version` 参数 → `node_modules/antd` → `package.json` 依赖声明 → 回退 `5.24.0`
 
+### 环境变量
+
+| 变量 | 说明 |
+|---|---|
+| `ANTD_NO_AUTO_REPORT=1` | 禁用 AI Agent 的 Bug 上报建议（详见 [#82](https://github.com/ant-design/ant-design-cli/issues/82)） |
+| `NO_UPDATE_CHECK=1` | 跳过静默版本更新检查 |
+| `CI=1` | 跳过静默版本更新检查（同 `NO_UPDATE_CHECK=1`） |
+
 <br>
 
 ## 📄 开源协议

--- a/docs/superpowers/specs/2026-04-17-opt-out-auto-report-design.md
+++ b/docs/superpowers/specs/2026-04-17-opt-out-auto-report-design.md
@@ -1,0 +1,70 @@
+# Opt-Out Auto-Report Design
+
+**Date:** 2026-04-17
+**Issue:** [ant-design/ant-design-cli#82](https://github.com/ant-design/ant-design-cli/issues/82)
+
+## Problem
+
+The `skills/antd/SKILL.md` file instructs AI assistants to **proactively** report CLI bugs via `antd bug-cli` (section 10: "Auto-reporting CLI issues"). This feels like automatic bug reporting to users who don't want it — the AI initiates the report without the user asking.
+
+Quote from SKILL.md:
+
+> **IMPORTANT: Whenever you use any `antd` CLI command and notice something wrong, you should proactively initiate a bug report using `antd bug-cli`.**
+
+This creates a mismatch: the CLI `bug`/`bug-cli` commands are opt-in (require `--submit`), but the SKILL.md overrides that by instructing the AI to proactively suggest filing reports.
+
+## Design
+
+### 1. Change `antd bug-cli` reporting to user-initiated only
+
+Align section 10 ("Auto-reporting CLI issues") with section 9 ("Reporting antd bugs"):
+
+- **Before:** AI proactively detects issues and initiates bug reports
+- **After:** AI only suggests reporting when the user explicitly asks or complains about a problem
+
+Remove all "proactively" / "IMPORTANT" / "you should" language from section 10. Rewrite as "Reporting CLI issues" — a reference for how to report when the user wants to.
+
+### 2. Add `ANTD_NO_AUTO_REPORT` opt-out environment variable
+
+Add a global opt-out mechanism:
+
+- **Environment variable:** `ANTD_NO_AUTO_REPORT=1`
+- **Effect:** When set, the SKILL.md instructs AI assistants to skip all bug-reporting suggestions entirely — no `antd bug` or `antd bug-cli` guidance
+- **Scope:** Applies to both section 9 (antd bugs) and section 10 (CLI bugs)
+
+In the SKILL.md, add a check instruction at the top of the bug-reporting sections:
+
+```
+If the environment variable `ANTD_NO_AUTO_REPORT=1` is set, skip all bug-reporting suggestions below.
+```
+
+### 3. Update MCP prompt
+
+In `src/mcp/prompts.ts`, add a rule to `SHARED_TOOL_WORKFLOW`:
+
+```
+- Do not suggest filing bug reports (antd bug / antd bug-cli) unless the user explicitly asks. If the user has set ANTD_NO_AUTO_REPORT=1, never suggest reporting.
+```
+
+### 4. Update spec.md
+
+Add documentation for the `ANTD_NO_AUTO_REPORT` environment variable in the spec under the "Environment Variables" / "Update Check" section.
+
+### 5. Update Key Rules in SKILL.md
+
+- **Rule 6:** Keep as-is (already states "Always preview first, get user confirmation, then submit")
+- **Rule 7:** Remove "Auto-report CLI issues — ... proactively use `antd bug-cli`". Replace with: "Report CLI issues — If a user asks about a CLI problem, use `antd bug-cli` to help them file a report."
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `skills/antd/SKILL.md` | Rewrite section 10 as user-initiated; add opt-out env var check; update Key Rules |
+| `src/mcp/prompts.ts` | Add rule about not suggesting bug reports unless user asks |
+| `spec.md` | Document `ANTD_NO_AUTO_REPORT` environment variable |
+
+## Not In Scope
+
+- Changes to the `antd bug` / `antd bug-cli` CLI commands themselves — they already require `--submit` explicitly
+- Changes to the `--submit` flag behavior
+- Telemetry or analytics (none exists in the codebase)

--- a/skills/antd/SKILL.md
+++ b/skills/antd/SKILL.md
@@ -164,7 +164,7 @@ Collects: OS, Node, package managers (npm/pnpm/yarn/bun/utoo), npm registry, bro
 
 ### 9. Reporting antd bugs
 
-When you encounter a confirmed antd component bug that can't be resolved locally:
+When the user asks you to report an antd bug:
 
 ```bash
 # Step 0: Collect environment info for reference (optional — antd bug already embeds basic env)
@@ -190,23 +190,12 @@ antd bug --title "DatePicker crashes when selecting date" \
   --submit
 ```
 
-### 10. Auto-reporting CLI issues
+### 10. Reporting CLI issues
 
-**IMPORTANT: Whenever you use any `antd` CLI command and notice something wrong, you should proactively initiate a bug report using `antd bug-cli`.**
-
-Trigger conditions — report a CLI bug when you observe any of these:
-- A command **crashes or exits with an unexpected error**
-- A command **returns clearly incorrect data** (e.g. `antd info Button` shows wrong props, missing props, or props from the wrong version)
-- A command's **output doesn't match its documented behavior** (e.g. `--format json` returns non-JSON, `--version X` is ignored)
-- A command **returns empty or missing data** when it shouldn't (e.g. `antd demo Button` returns no demos, `antd token Button` returns no tokens for v5+)
-- **Inconsistencies between commands** (e.g. `antd list` shows a component but `antd info` says it doesn't exist)
-
-**Workflow:**
-1. You notice something wrong while using the CLI
-2. Gather evidence: the exact command you ran, what was returned, and what you expected
-3. Preview the bug report for the user:
+When the user asks you to report a CLI bug, or explicitly requests help filing one:
 
 ```bash
+# Preview the bug report for the user
 antd bug-cli --title "antd info Button returns wrong props for v5.12.0" \
   --description "When querying Button props for version 5.12.0, the output includes props that don't exist in that version" \
   --steps "1. Run: antd info Button --version 5.12.0 --format json" \
@@ -215,8 +204,7 @@ antd bug-cli --title "antd info Button returns wrong props for v5.12.0" \
   --format json
 ```
 
-4. Show the report to the user: "I noticed an issue with the CLI while working. Here's a bug report — shall I submit it?"
-5. Submit after user confirms:
+Show the report to the user and confirm before submitting:
 
 ```bash
 antd bug-cli --title "antd info Button returns wrong props for v5.12.0" \
@@ -227,7 +215,7 @@ antd bug-cli --title "antd info Button returns wrong props for v5.12.0" \
   --submit
 ```
 
-**Key principle:** You are a quality feedback loop for the CLI. Don't silently work around CLI issues — report them so they get fixed. Always confirm with the user before submitting.
+**Opt-out:** If the environment variable `ANTD_NO_AUTO_REPORT=1` is set, skip all bug-reporting suggestions entirely — do not suggest `antd bug` or `antd bug-cli` unless the user directly asks.
 
 ### 11. Using as MCP server
 
@@ -262,5 +250,5 @@ This provides 7 tools (`antd_list`, `antd_info`, `antd_doc`, `antd_demo`, `antd_
 3. **Use `--format json`** — Every command supports it. Parse the JSON output rather than regex-matching text output.
 4. **Check before suggesting migration** — Run `antd changelog <v1> <v2>` and `antd migrate` before advising on version upgrades.
 5. **Lint after changes** — After writing or modifying antd code, run `antd lint` on the changed files to catch deprecated or problematic usage.
-6. **Report antd bugs** — First run `antd env` to capture the full environment, then use `antd bug` to report. Always preview first, get user confirmation, then submit.
-7. **Auto-report CLI issues** — If any `antd` command crashes, returns wrong data, or behaves inconsistently, proactively use `antd bug-cli` to report it. You are the quality feedback loop for the CLI — don't silently work around issues.
+6. **Report antd bugs** — When the user asks to report an antd bug, use `antd bug`. Always preview first, get user confirmation, then submit.
+7. **Report CLI issues** — When the user asks about a CLI problem, use `antd bug-cli` to help them file a report. Always preview first, get user confirmation, then submit.

--- a/spec.md
+++ b/spec.md
@@ -703,6 +703,7 @@ After each command completes, the CLI silently checks whether a newer version is
 **Behavior details:**
 
 - Skipped when `CI=1` or `NO_UPDATE_CHECK=1` is set
+- Bug-reporting suggestions in SKILL.md and MCP prompts are skipped when `ANTD_NO_AUTO_REPORT=1` is set
 - Uses `registry.npmjs.org` with a 3 s timeout; failures are silent
 - Output goes to **stderr**, so `--format json` stdout is never polluted
 - No new production dependencies — uses only built-in Node modules (`node:https`, `node:fs`, `node:os`, `node:path`)

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -12,7 +12,8 @@ const SHARED_TOOL_WORKFLOW = `## Tool usage workflow
 ## Rules
 - Avoid duplicate tool calls — do not call the same tool with the same parameters twice
 - Always query component docs before generating code that uses the component
-- Prefer reading real documentation over guessing API usage`;
+- Prefer reading real documentation over guessing API usage
+- Do not suggest filing bug reports (antd bug / antd bug-cli) unless the user explicitly asks. If the user has set ANTD_NO_AUTO_REPORT=1, never suggest reporting.`;
 
 export const ANTD_EXPERT_PROMPT = `You are an expert assistant for Ant Design (antd), a React UI component library.
 


### PR DESCRIPTION
## Summary

- Change `antd bug-cli` reporting from proactive (AI-initiated) to reactive (user-initiated), matching the `antd bug` command behavior
- Add `ANTD_NO_AUTO_REPORT=1` environment variable to fully disable bug-reporting suggestions in SKILL.md and MCP prompts
- Update Key Rules in SKILL.md to reflect user-initiated-only reporting

## Background

Issue #82 reported unwanted "auto reporting" behavior. The root cause was `skills/antd/SKILL.md` section 10 instructing AI assistants to **proactively** initiate bug reports via `antd bug-cli`. While actual submission still required user confirmation, the proactivity felt like automatic reporting to users.

## Changes

| File | Change |
|------|--------|
| `skills/antd/SKILL.md` | Rewrite section 10 from "Auto-reporting CLI issues" to "Reporting CLI issues" (user-initiated); add `ANTD_NO_AUTO_REPORT=1` opt-out; update Key Rules 6 & 7 |
| `src/mcp/prompts.ts` | Add rule: don't suggest bug reports unless user explicitly asks; respect `ANTD_NO_AUTO_REPORT=1` |
| `spec.md` | Document `ANTD_NO_AUTO_REPORT=1` environment variable |
| `docs/superpowers/specs/2026-04-17-opt-out-auto-report-design.md` | Design spec for this change |

Closes #82

## Test plan

- [ ] Verify SKILL.md section 10 no longer contains "proactively" or "IMPORTANT" language for bug reporting
- [ ] Verify Key Rules 6 & 7 reflect user-initiated-only reporting
- [ ] Verify MCP prompt includes the non-proactive reporting rule
- [ ] Verify spec.md documents `ANTD_NO_AUTO_REPORT=1`
- [ ] Run `npm run build` and `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)