### PR TITLE
docs: update README and SKILL for antd v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Query component knowledge, analyze project usage, and guide migrations — fully
 
 ## 🤔 Why
 
-Code agents (Claude Code, Codex, Gemini CLI) write better antd code when they have instant access to the right API data. This CLI gives them exactly that — **every prop, token, demo, and changelog entry for antd v4 / v5 / v6**, bundled locally, queryable in milliseconds.
+Code agents (Claude Code, Codex, Gemini CLI) write better antd code when they have instant access to the right API data. This CLI gives them exactly that — **every prop, token, demo, and changelog entry for antd v3 / v4 / v5 / v6**, bundled locally, queryable in milliseconds.
 
 ```bash
 npx skills add ant-design/ant-design-cli    # install as an agent skill
@@ -37,7 +37,7 @@ npx skills add ant-design/ant-design-cli    # install as an agent skill
 ## ✨ Highlights
 
 - 📦 **Fully offline** — All metadata ships with the package. No network calls, no latency, no API keys.
-- 🎯 **Version-accurate** — 55+ per-minor snapshots across v4/v5/v6. Query the exact API surface of `antd@5.3.0`, not just "latest v5".
+- 🎯 **Version-accurate** — 55+ per-minor snapshots across v3/v4/v5/v6. Query the exact API surface of `antd@5.3.0`, not just "latest v5".
 - 🤖 **Agent-optimized** — `--format json` on every command. Structured errors with codes and suggestions. Clean stdout/stderr separation.
 - 🌍 **Bilingual** — Every component name, description, and doc has both English and Chinese. Switch with `--lang zh`.
 - 🔮 **Smart matching** — Typo `Buttn`? The CLI suggests `Button` using Levenshtein distance, with first-letter preference.
@@ -115,6 +115,7 @@ antd doctor                         # Diagnose project issues
 antd env                            # Collect env info for bug reports
 antd usage ./src                    # Analyze antd imports in project
 antd lint ./src                     # Check deprecated APIs & best practices
+antd migrate 3 4                    # v3 → v4 migration guide
 antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
 ```
 
@@ -349,9 +350,10 @@ Use `--antd-alias <source>` to treat additional package names as aliases of `ant
 
 ### `antd migrate <from> <to>`
 
-v4→v5 covers 25+ migration steps; v5→v6 covers 30+. Each step includes component name, breaking flag, search pattern, and before/after code.
+v3→v4 covers 15+ migration steps; v4→v5 covers 25+ migration steps; v5→v6 covers 30+. Each step includes component name, breaking flag, search pattern, and before/after code.
 
 ```bash
+antd migrate 3 4                    # v3 → v4 migration
 antd migrate 4 5                    # full checklist
 antd migrate 4 5 --component Select # component-specific
 antd migrate 4 5 --apply ./src      # generate agent migration prompt

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,7 +26,7 @@
 
 ## 🤔 为什么
 
-Code Agent（Claude Code、Codex、Gemini CLI）在拥有即时 API 数据访问能力时，能写出更好的 antd 代码。这个 CLI 正是为此而生 — **antd v4 / v5 / v6 的每个 Prop、Token、Demo 和 Changelog 条目**，本地打包，毫秒级查询。
+Code Agent（Claude Code、Codex、Gemini CLI）在拥有即时 API 数据访问能力时，能写出更好的 antd 代码。这个 CLI 正是为此而生 — **antd v3 / v4 / v5 / v6 的每个 Prop、Token、Demo 和 Changelog 条目**，本地打包，毫秒级查询。
 
 ```bash
 npx skills add ant-design/ant-design-cli    # 安装为 Agent Skill
@@ -37,7 +37,7 @@ npx skills add ant-design/ant-design-cli    # 安装为 Agent Skill
 ## ✨ 亮点
 
 - 📦 **完全离线** — 所有元数据随包安装，无需网络请求，无延迟，无 API Key。
-- 🎯 **版本精确** — 跨 v4/v5/v6 的 55+ 小版本快照。查询 `antd@5.3.0` 的精确 API，而非仅 "最新 v5"。
+- 🎯 **版本精确** — 跨 v3/v4/v5/v6 的 55+ 小版本快照。查询 `antd@5.3.0` 的精确 API，而非仅 "最新 v5"。
 - 🤖 **Agent 优化** — 所有命令支持 `--format json`。结构化错误码与修复建议。stdout/stderr 严格分离。
 - 🌍 **双语输出** — 每个组件名、描述和文档均有中英文。通过 `--lang zh` 切换。
 - 🔮 **智能纠错** — 输入 `Buttn`？CLI 基于 Levenshtein 距离建议 `Button`，优先匹配首字母相同的候选。
@@ -115,6 +115,7 @@ antd doctor                         # 诊断项目配置问题
 antd env                            # 收集环境信息用于 Bug 报告
 antd usage ./src                    # 分析项目中的 antd 导入
 antd lint ./src                     # 检查废弃 API 和最佳实践
+antd migrate 3 4                    # v3 → v4 迁移指南
 antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
 ```
 
@@ -349,9 +350,10 @@ antd lint ./src --only deprecated --format json --antd-alias @shared-components
 
 ### `antd migrate <from> <to>`
 
-v4→v5 包含 25+ 迁移步骤，v5→v6 包含 30+。每个步骤包含组件名、破坏性标记、搜索正则和前后代码对比。
+v3→v4 包含 15+ 迁移步骤，v4→v5 包含 25+ 迁移步骤，v5→v6 包含 30+。每个步骤包含组件名、破坏性标记、搜索正则和前后代码对比。
 
 ```bash
+antd migrate 3 4                    # v3 → v4 迁移
 antd migrate 4 5                    # 完整迁移清单
 antd migrate 4 5 --component Select # 指定组件
 antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示

--- a/skills/antd/SKILL.md
+++ b/skills/antd/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools:
 
 # Ant Design CLI
 
-You have access to `@ant-design/cli` — a local CLI tool with bundled antd metadata for v4/v5/v6. Use it to query component knowledge, analyze projects, and guide migrations. All data is offline, no network needed.
+You have access to `@ant-design/cli` — a local CLI tool with bundled antd metadata for v3/v4/v5/v6. Use it to query component knowledge, analyze projects, and guide migrations. All data is offline, no network needed.
 
 ## Setup
 
@@ -83,11 +83,12 @@ antd doctor --format json
 
 ### 4. Migrating between versions
 
-When the user wants to upgrade antd (e.g., v4 → v5):
+When the user wants to upgrade antd (e.g., v3 → v4 or v4 → v5):
 
 ```bash
 # Get full migration checklist
-antd migrate 4 5 --format json
+antd migrate 3 4 --format json    # v3 → v4
+antd migrate 4 5 --format json    # v4 → v5
 
 # Check migration for a specific component
 antd migrate 4 5 --component Select --format json
@@ -258,7 +259,7 @@ This provides 7 tools (`antd_list`, `antd_info`, `antd_doc`, `antd_demo`, `antd_
 ## Key Rules
 
 1. **Always query before writing** — Don't guess antd APIs from memory. Run `antd info` first.
-2. **Match the user's version** — If the project uses antd 4.x, pass `--version 4.24.0`. The CLI auto-detects from `node_modules` if no flag is given.
+2. **Match the user's version** — If the project uses antd 3.x or 4.x, pass `--version 3.26.0` or `--version 4.24.0`. The CLI auto-detects from `node_modules` if no flag is given.
 3. **Use `--format json`** — Every command supports it. Parse the JSON output rather than regex-matching text output.
 4. **Check before suggesting migration** — Run `antd changelog <v1> <v2>` and `antd migrate` before advising on version upgrades.
 5. **Lint after changes** — After writing or modifying antd code, run `antd lint` on the changed files to catch deprecated or problematic usage.


### PR DESCRIPTION
## Summary
- Update version references from v4/v5/v6 to v3/v4/v5/v6 in README.md, README.zh-CN.md, and SKILL.md
- Add `antd migrate 3 4` examples to Quick Start and migrate sections
- Add v3→v4 migration step count in migrate docs
- Update SKILL.md migration scenario and Key Rules for v3 version matching

## Test plan
- [ ] Verify README and README.zh-CN.md consistently mention v3 support
- [ ] Verify SKILL.md includes v3 migration guidance and version matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)