### PR TITLE
fix: exclude locale paths from lint performance rule default import check

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -437,7 +437,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
   - Typography.Text `ellipsis` with `expandable` / `rows` (not supported)
   - Radio `optionType` outside Radio.Group (only valid inside Radio.Group)
   - TreeSelect `multiple={false}` + `treeCheckable` conflict
-- **performance** — Wildcard imports from `antd`, `antd/*`, configured `--antd-alias` packages, or their subpaths, disabling virtual scroll on Select
+- **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports from non-locale subpaths; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern.
 
 #### `antd migrate <from> <to>`
 

--- a/spec.md
+++ b/spec.md
@@ -437,7 +437,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
   - Typography.Text `ellipsis` with `expandable` / `rows` (not supported)
   - Radio `optionType` outside Radio.Group (only valid inside Radio.Group)
   - TreeSelect `multiple={false}` + `treeCheckable` conflict
-- **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports from non-locale subpaths; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern.
+- **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern and there is no tree-shaking benefit to be gained.
 
 #### `antd migrate <from> <to>`
 

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -413,6 +413,21 @@ const App = () => (
       expect(issues[0].rule).toBe('performance');
       expect(issues[0].severity).toBe('error');
     });
+
+    it('does not flag default import from antd locale paths', async () => {
+      makeTmpFile(
+        'locale-import.tsx',
+        `import enUS from 'antd/locale/en_US';
+import jaJP from 'antd/es/locale/ja_JP';
+import zhCN from 'antd/lib/locale/zh_CN';
+
+const App = () => <div />;
+`,
+      );
+      const out = await runLint([join(tmpDir, 'locale-import.tsx')]);
+      const data = parseJson(out);
+      expect(data.issues).toHaveLength(0);
+    });
   });
 
   // --- --only filter ---

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -414,6 +414,27 @@ const App = () => (
       expect(issues[0].severity).toBe('error');
     });
 
+    it('suggests actual used members for wildcard import', async () => {
+      makeTmpFile(
+        'wildcard-usage.tsx',
+        `import * as Antd from 'antd';
+
+const App = () => (
+  <div>
+    <Antd.Button />
+    <Antd.Select />
+  </div>
+);
+`,
+      );
+      const out = await runLint([join(tmpDir, 'wildcard-usage.tsx')]);
+      const data = parseJson(out);
+      const issues = data.issues.filter((i: any) => i.message.includes('wildcard'));
+      expect(issues).toHaveLength(1);
+      expect(issues[0].message).toContain('Button');
+      expect(issues[0].message).toContain('Select');
+    });
+
     it('does not flag default import from antd locale paths', async () => {
       makeTmpFile(
         'locale-import.tsx',

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -449,6 +449,19 @@ const App = () => <div />;
       const data = parseJson(out);
       expect(data.issues).toHaveLength(0);
     });
+
+    it('does not flag wildcard import from antd locale paths', async () => {
+      makeTmpFile(
+        'locale-wildcard.tsx',
+        `import * as enUS from 'antd/locale/en_US';
+
+const App = () => <div />;
+`,
+      );
+      const out = await runLint([join(tmpDir, 'locale-wildcard.tsx')]);
+      const data = parseJson(out);
+      expect(data.issues).toHaveLength(0);
+    });
   });
 
   // --- --only filter ---

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -176,6 +176,10 @@ function lintFile(
   const jsxAncestorStack: string[] = [];
   const isInsideComponent = (name: string): boolean => jsxAncestorStack.includes(name);
 
+  // Track namespace/default import usage for performance rule suggestions
+  const pendingPerformanceIssues: { line: number; source: string; localName: string; kind: 'namespace' | 'default' }[] = [];
+  const namespaceMemberUsage = new Map<string, Set<string>>();
+
   // Single pass: collect imports and check all rules
   const visitor = new Visitor({
     JSXElement(node: any) {
@@ -199,16 +203,18 @@ function lintFile(
           if (name) importedComponents.add(name);
         }
 
-        if ((!only || only === 'performance') && spec.type === 'ImportNamespaceSpecifier') {
-          report('performance', 'error', lineOf(node),
-            `Avoid wildcard import from ${source}. Use named imports: \`import { Button } from '${source}'\``);
-        }
+        if (!only || only === 'performance') {
+          if (spec.type === 'ImportNamespaceSpecifier') {
+            const localName = spec.local?.name ?? '';
+            pendingPerformanceIssues.push({ line: lineOf(node), source, localName, kind: 'namespace' });
+            namespaceMemberUsage.set(localName, new Set());
+          }
 
-        if ((!only || only === 'performance') &&
-            spec.type === 'ImportDefaultSpecifier' &&
-            !isLocalePath(source, antdAliases)) {
-          report('performance', 'error', lineOf(node),
-            `Avoid default import from ${source}. Use named imports instead`);
+          if (spec.type === 'ImportDefaultSpecifier' && !isLocalePath(source, antdAliases)) {
+            const localName = spec.local?.name ?? '';
+            pendingPerformanceIssues.push({ line: lineOf(node), source, localName, kind: 'default' });
+            namespaceMemberUsage.set(localName, new Set());
+          }
         }
       }
     },
@@ -218,6 +224,15 @@ function lintFile(
       if (!compName) return;
       const attrs = node.attributes || [];
       const line = lineOf(node);
+
+      // Collect member usage from namespace/default imports (e.g. <Antd.Button />)
+      if (compName.includes('.')) {
+        const [obj, prop] = compName.split('.');
+        if (obj && prop) {
+          const members = namespaceMemberUsage.get(obj);
+          if (members) members.add(prop);
+        }
+      }
 
       // --- Deprecated checks ---
       if (!only || only === 'deprecated') {
@@ -354,6 +369,23 @@ function lintFile(
     },
   });
   visitor.visit(result.program);
+
+  // Process deferred performance issues with actual member usage
+  for (const pending of pendingPerformanceIssues) {
+    const usedMembers = namespaceMemberUsage.get(pending.localName);
+    const memberList = usedMembers && usedMembers.size > 0 ? [...usedMembers].join(', ') : '';
+    if (pending.kind === 'namespace') {
+      const suggestion = memberList
+        ? `Use named imports: \`import { ${memberList} } from '${pending.source}'\``
+        : `Use named imports instead (e.g., \`import { Button } from '${pending.source}'\`)`;
+      report('performance', 'error', pending.line, `Avoid wildcard import from ${pending.source}. ${suggestion}`);
+    } else {
+      const suggestion = memberList
+        ? `Use named imports: \`import { ${memberList} } from '${pending.source}'\``
+        : `Use named imports instead`;
+      report('performance', 'error', pending.line, `Avoid default import from ${pending.source}. ${suggestion}`);
+    }
+  }
 
   return issues;
 }

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -204,15 +204,14 @@ function lintFile(
         }
 
         if (!only || only === 'performance') {
-          if (spec.type === 'ImportNamespaceSpecifier') {
+          const isNamespace = spec.type === 'ImportNamespaceSpecifier';
+          const isNonLocaleDefault = spec.type === 'ImportDefaultSpecifier' && !isLocalePath(source, antdAliases);
+          if (isNamespace || isNonLocaleDefault) {
             const localName = spec.local?.name ?? '';
-            pendingPerformanceIssues.push({ line: lineOf(node), source, localName, kind: 'namespace' });
-            namespaceMemberUsage.set(localName, new Set());
-          }
-
-          if (spec.type === 'ImportDefaultSpecifier' && !isLocalePath(source, antdAliases)) {
-            const localName = spec.local?.name ?? '';
-            pendingPerformanceIssues.push({ line: lineOf(node), source, localName, kind: 'default' });
+            pendingPerformanceIssues.push({
+              line: lineOf(node), source, localName,
+              kind: isNamespace ? 'namespace' : 'default',
+            });
             namespaceMemberUsage.set(localName, new Set());
           }
         }
@@ -373,18 +372,14 @@ function lintFile(
   // Process deferred performance issues with actual member usage
   for (const pending of pendingPerformanceIssues) {
     const usedMembers = namespaceMemberUsage.get(pending.localName);
-    const memberList = usedMembers && usedMembers.size > 0 ? [...usedMembers].join(', ') : '';
-    if (pending.kind === 'namespace') {
-      const suggestion = memberList
-        ? `Use named imports: \`import { ${memberList} } from '${pending.source}'\``
-        : `Use named imports instead (e.g., \`import { Button } from '${pending.source}'\`)`;
-      report('performance', 'error', pending.line, `Avoid wildcard import from ${pending.source}. ${suggestion}`);
-    } else {
-      const suggestion = memberList
-        ? `Use named imports: \`import { ${memberList} } from '${pending.source}'\``
+    const memberList = usedMembers?.size ? [...usedMembers].join(', ') : '';
+    const importKind = pending.kind === 'namespace' ? 'wildcard' : 'default';
+    const suggestion = memberList
+      ? `Use named imports: \`import { ${memberList} } from '${pending.source}'\``
+      : pending.kind === 'namespace'
+        ? `Use named imports instead (e.g., \`import { Button } from '${pending.source}'\`)`
         : `Use named imports instead`;
-      report('performance', 'error', pending.line, `Avoid default import from ${pending.source}. ${suggestion}`);
-    }
+    report('performance', 'error', pending.line, `Avoid ${importKind} import from ${pending.source}. ${suggestion}`);
   }
 
   return issues;

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -121,6 +121,15 @@ function matchesAntdAlias(source: string, antdAliases: string[]): boolean {
   return antdAliases.some((antdAlias) => source === antdAlias || source.startsWith(`${antdAlias}/`));
 }
 
+function isLocalePath(source: string, antdAliases: string[]): boolean {
+  return antdAliases.some(
+    (alias) =>
+      source.startsWith(`${alias}/locale/`) ||
+      source.startsWith(`${alias}/es/locale/`) ||
+      source.startsWith(`${alias}/lib/locale/`),
+  );
+}
+
 function mayContainAntdAlias(content: string, antdAliases: string[]): boolean {
   return antdAliases.some((antdAlias) => content.includes(antdAlias));
 }
@@ -190,10 +199,16 @@ function lintFile(
           if (name) importedComponents.add(name);
         }
 
-        if ((!only || only === 'performance') &&
-            (spec.type === 'ImportDefaultSpecifier' || spec.type === 'ImportNamespaceSpecifier')) {
+        if ((!only || only === 'performance') && spec.type === 'ImportNamespaceSpecifier') {
           report('performance', 'error', lineOf(node),
             `Avoid wildcard import from ${source}. Use named imports: \`import { Button } from '${source}'\``);
+        }
+
+        if ((!only || only === 'performance') &&
+            spec.type === 'ImportDefaultSpecifier' &&
+            !isLocalePath(source, antdAliases)) {
+          report('performance', 'error', lineOf(node),
+            `Avoid default import from ${source}. Use named imports instead`);
         }
       }
     },

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -376,9 +376,7 @@ function lintFile(
     const importKind = pending.kind === 'namespace' ? 'wildcard' : 'default';
     const suggestion = memberList
       ? `Use named imports: \`import { ${memberList} } from '${pending.source}'\``
-      : pending.kind === 'namespace'
-        ? `Use named imports instead (e.g., \`import { Button } from '${pending.source}'\`)`
-        : `Use named imports instead`;
+      : 'Use named imports instead';
     report('performance', 'error', pending.line, `Avoid ${importKind} import from ${pending.source}. ${suggestion}`);
   }
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -204,13 +204,13 @@ function lintFile(
         }
 
         if (!only || only === 'performance') {
-          const isNamespace = spec.type === 'ImportNamespaceSpecifier';
+          const isNonLocaleNamespace = spec.type === 'ImportNamespaceSpecifier' && !isLocalePath(source, antdAliases);
           const isNonLocaleDefault = spec.type === 'ImportDefaultSpecifier' && !isLocalePath(source, antdAliases);
-          if (isNamespace || isNonLocaleDefault) {
+          if (isNonLocaleNamespace || isNonLocaleDefault) {
             const localName = spec.local?.name ?? '';
             pendingPerformanceIssues.push({
               line: lineOf(node), source, localName,
-              kind: isNamespace ? 'namespace' : 'default',
+              kind: isNonLocaleNamespace ? 'namespace' : 'default',
             });
             namespaceMemberUsage.set(localName, new Set());
           }


### PR DESCRIPTION
## 问题

`antd lint` 的 performance 规则存在两个问题：

**1. locale 默认导入被误报为通配符导入**

```tsx
import enUS from 'antd/locale/en_US';  // 官方文档推荐的写法
```

运行 `antd lint` 会报错：

```
✗ Avoid wildcard import from antd/locale/en_US. Use named imports: `import { Button } from 'antd/locale/en_US'`
```

这有两个问题：
- `import enUS from ...` 是默认导入，不是 `import * as` 通配符导入，不应该报错
- `antd/locale/en_US` 只有一个 default export，根本不存在 `Button` 这个命名导出，建议完全是错的

**2. 建议信息硬编码 `Button`**

即使对真正的通配符导入 `import * as Antd from 'antd'`，建议也总是写 `import { Button }`，但用户可能并没有使用 Button，可能用的是 Select、Input 等。

## 修复

1. **区分默认导入和通配符导入**：`import * as` 继续报错，`import X from 'antd/locale/*'` 不再报错
2. **建议信息使用实际组件名**：追踪代码中实际使用的成员（如 `<Antd.Button />`、`<Antd.Select />`），生成 `import { Button, Select } from 'antd'` 这样的具体建议

修复前：

```
✗ Avoid wildcard import from antd. Use named imports: `import { Button } from 'antd'`
✗ Avoid wildcard import from antd/locale/en_US. Use named imports: `import { Button } from 'antd/locale/en_US'`
```

修复后：

```
✗ Avoid wildcard import from antd. Use named imports: `import { Button, Select } from 'antd'`  ← 使用实际组件名
                                 ^^^^^^^^^^^^^^ locale 导入不再报错
```

Fixes #99
Fixes #101

## Test plan

- [x] 新增测试：locale 默认导入不报错
- [x] 新增测试：通配符导入建议使用实际组件名
- [x] 已有测试：通配符导入仍被正确检测
- [x] 全量测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)