### PR TITLE
chore: update 6.4.0 changelog and fix sync version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## [6.4.0](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0) (2026-05-14)
 
-- Update antd metadata ([v4@4.24.16](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0#diff-0f73f4b6da46cd62e857a1f41ea51e697389f2c62a0775fcfc545edd653c5e2c), [v5@5.29.3](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0#diff-6b390e384eeea7f593730f71f071bf947ec0fac7a19f6d32b91e13191b177a58), [v6@6.4.0](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+### New Features
+
+- `doctor` command now checks for known bugs in the installed antd version and displays related issue links ([#89](https://github.com/ant-design/ant-design-cli/pull/89))
+
+### Bug Fixes
+
+- Fix lint false positives for `Checkbox.Group`/`Radio.Group` — `value` on `Checkbox` inside `Checkbox.Group` and `optionType` on `Radio` inside `Radio.Group` are no longer incorrectly warned ([#93](https://github.com/ant-design/ant-design-cli/pull/93), closes [#91](https://github.com/ant-design/ant-design-cli/issues/91))
+- Fix lint performance rule incorrectly flagging locale default imports like `import enUS from 'antd/locale/en_US'` and improve suggestion to use actual component names instead of always suggesting `Button` ([#104](https://github.com/ant-design/ant-design-cli/pull/104), closes [#99](https://github.com/ant-design/ant-design-cli/issues/99), [#101](https://github.com/ant-design/ant-design-cli/issues/101))
+
+### Other Changes
+
+- Refactor update check to query multiple sources concurrently ([#89](https://github.com/ant-design/ant-design-cli/pull/89))
+- Update antd metadata ([v6@6.4.0](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+- Configure Dependabot for grouped updates as npm ecosystem ([#102](https://github.com/ant-design/ant-design-cli/pull/102))
+- Bump dependencies and resolve security alerts ([#103](https://github.com/ant-design/ant-design-cli/pull/103), [#105](https://github.com/ant-design/ant-design-cli/pull/105))
 
 
 ## [6.3.7](https://github.com/ant-design/ant-design-cli/compare/v6.3.6...v6.3.7) (2026-04-27)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,7 +2,21 @@
 
 ## [6.4.0](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0) (2026-05-14)
 
-- 同步 antd 元数据 ([v4@4.24.16](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0#diff-0f73f4b6da46cd62e857a1f41ea51e697389f2c62a0775fcfc545edd653c5e2c), [v5@5.29.3](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0#diff-6b390e384eeea7f593730f71f071bf947ec0fac7a19f6d32b91e13191b177a58), [v6@6.4.0](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+### 新功能
+
+- `doctor` 命令新增已知 Bug 检查，会检测当前安装的 antd 版本是否存在已知问题并显示相关 Issue 链接 ([#89](https://github.com/ant-design/ant-design-cli/pull/89))
+
+### Bug 修复
+
+- 修复 `Checkbox.Group`/`Radio.Group` 内 lint 误报 — `Checkbox.Group` 内的 `value` 属性和 `Radio.Group` 内的 `optionType` 属性不再被错误警告 ([#93](https://github.com/ant-design/ant-design-cli/pull/93), closes [#91](https://github.com/ant-design/ant-design-cli/issues/91))
+- 修复 lint 性能规则误判 locale 默认导入（如 `import enUS from 'antd/locale/en_US'`）为通配符导入，并改进建议信息使用实际组件名而非固定显示 `Button` ([#104](https://github.com/ant-design/ant-design-cli/pull/104), closes [#99](https://github.com/ant-design/ant-design-cli/issues/99), [#101](https://github.com/ant-design/ant-design-cli/issues/101))
+
+### 其他变更
+
+- 重构更新检查逻辑，并发查询多个来源以加快版本检测 ([#89](https://github.com/ant-design/ant-design-cli/pull/89))
+- 同步 antd 元数据 ([v6@6.4.0](https://github.com/ant-design/ant-design-cli/compare/v6.3.7...v6.4.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+- 配置 Dependabot 分组更新及 npm 生态系统 ([#102](https://github.com/ant-design/ant-design-cli/pull/102))
+- 升级依赖并修复安全告警 ([#103](https://github.com/ant-design/ant-design-cli/pull/103), [#105](https://github.com/ant-design/ant-design-cli/pull/105))
 
 
 ## [6.3.7](https://github.com/ant-design/ant-design-cli/compare/v6.3.6...v6.3.7) (2026-04-27)

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -41,7 +41,7 @@ function main() {
   }
 
   // Collect version info for changelog — only include versions whose data file actually changed
-  const changedFiles = new Set(run('git diff --name-only HEAD').split('\n').filter(Boolean));
+  const changedFiles = new Set(run('git diff --name-only HEAD -- data/').split(/\r?\n/).filter(Boolean));
   const versions: string[] = [];
   for (const major of [4, 5, 6]) {
     if (!changedFiles.has(`data/v${major}.json`)) continue;

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -40,16 +40,12 @@ function main() {
     process.exit(0);
   }
 
-  // Collect version info for changelog — only include versions that actually changed
+  // Collect version info for changelog — only include versions whose data file actually changed
+  const changedFiles = new Set(run('git diff --name-only HEAD').split('\n').filter(Boolean));
   const versions: string[] = [];
   for (const major of [4, 5, 6]) {
+    if (!changedFiles.has(`data/v${major}.json`)) continue;
     const data = JSON.parse(readFileSync(`data/v${major}.json`, 'utf-8'));
-    try {
-      const oldData = JSON.parse(run(`git show HEAD:data/v${major}.json`));
-      if (data.version === oldData.version) continue;
-    } catch {
-      // New file, include it
-    }
     versions.push(`v${major}@${data.version}`);
   }
   const versionsStr = versions.join(', ');


### PR DESCRIPTION
## Summary

- Expand v6.4.0 changelog with complete change details (previously only listed metadata sync)
- Fix `publish.ts` version detection bug that included unchanged v4/v5 versions in commit messages and changelogs

### Changelog updates
- **New Features**: `doctor` command known bug checks (#89)
- **Bug Fixes**: Checkbox.Group/Radio.Group lint false positives (#93), locale import misflagging (#104)
- **Other Changes**: Concurrent update checks (#89), Dependabot config (#102), dependency bumps (#103, #105)
- Corrected metadata sync entry from `v4@4.24.16, v5@5.29.3, v6@6.4.0` to just `v6@6.4.0` (only v6 data actually changed)

### Bug fix in `scripts/publish.ts`
The old code used `git show HEAD:data/v{major}.json` with a catch fallback that treated errors (e.g. in CI) as "new file, include it". This caused unchanged v4@4.24.16 and v5@5.29.3 to be listed in the sync commit message. Fixed by using `git diff --name-only HEAD` to only include versions whose data files actually changed.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Verify the sync workflow will correctly detect only changed versions on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本 6.4.0 发布说明

* **新功能**
  * doctor 命令新增已安装 antd 版本的已知 bug 检查功能

* **Bug 修复**
  * 修复 Checkbox.Group/Radio.Group 内字段的 lint 误报
  * 修复 lint 性能规则对 locale 默认导入的误判，改进建议信息显示

* **其他变更**
  * 优化更新检查逻辑，支持并发查询多个数据源
  * 依赖更新及安全问题修复

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-cli/pull/106)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->