### PR TITLE
refactor: extract readJson, fix compare() null safety, and clean up code reuse

### DIFF
--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -23,7 +23,7 @@ function filterEntries(changelog: ChangelogEntry[], versionArg?: string): Change
     return changelog.filter((e) => e.version === parsed.exact);
   }
   return changelog.filter(
-    (e) => compare(e.version, parsed.from) >= 0 && compare(e.version, parsed.to) <= 0,
+    (e) => (compare(e.version, parsed.from) ?? -1) >= 0 && (compare(e.version, parsed.to) ?? 1) <= 0,
   );
 }
 
@@ -138,7 +138,7 @@ export function diffChangelog(opts: {
   component?: string;
 }): DiffResult | CLIError {
   // Validate version order
-  if (compare(opts.v1, opts.v2) > 0) {
+  if ((compare(opts.v1, opts.v2) ?? 0) > 0) {
     return createError(
       ErrorCodes.INVALID_ARGUMENT,
       `Version order is invalid: "${opts.v1}" is newer than "${opts.v2}"`,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3,7 +3,9 @@ import type { GlobalOptions } from '../types.js';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { output } from '../output/formatter.js';
-import { readJson } from '../utils/scan.js';
+import { readJson } from '../utils/json.js';
+
+interface PkgJson { version?: string; peerDependencies?: Record<string, string>; peerDependenciesMeta?: Record<string, { optional?: boolean }>; theme?: unknown; babel?: unknown }
 import { satisfies } from '../data/version.js';
 import { getBugVersions, findBugInfo } from '../utils/bug-versions.js';
 
@@ -40,7 +42,7 @@ interface EcosystemPackage {
  * Returns null if not installed. Handles scoped packages (e.g. "@ant-design/cssinjs").
  */
 function getInstalledVersion(cwd: string, pkgName: string): string | null {
-  const pkg = readJson(join(cwd, 'node_modules', pkgName, 'package.json'));
+  const pkg = readJson<PkgJson>(join(cwd, 'node_modules', pkgName, 'package.json'));
   return pkg?.version ?? null;
 }
 
@@ -61,7 +63,7 @@ function scanEcosystemPackages(cwd: string): EcosystemPackage[] {
   const result: EcosystemPackage[] = [];
   for (const entry of entries) {
     if (entry.startsWith('.')) continue;
-    const pkg = readJson(join(scopeDir, entry, 'package.json'));
+    const pkg = readJson<PkgJson>(join(scopeDir, entry, 'package.json'));
     if (!pkg?.version) continue;
     const peerDeps: Record<string, string> = pkg.peerDependencies ?? {};
     if (Object.keys(peerDeps).length === 0) continue;
@@ -77,12 +79,12 @@ function scanEcosystemPackages(cwd: string): EcosystemPackage[] {
 }
 
 function buildContext(cwd: string): DoctorContext {
-  const antdPkg = readJson(join(cwd, 'node_modules', 'antd', 'package.json'));
-  const antdMajor = antdPkg ? parseInt(antdPkg.version.split('.')[0], 10) : 0;
-  const projectPkg = readJson(join(cwd, 'package.json'));
-  const reactPkg = readJson(join(cwd, 'node_modules', 'react', 'package.json'));
-  const cssinjsPkg = readJson(join(cwd, 'node_modules', '@ant-design', 'cssinjs', 'package.json'));
-  const iconsPkg = readJson(join(cwd, 'node_modules', '@ant-design', 'icons', 'package.json'));
+  const antdPkg = readJson<PkgJson>(join(cwd, 'node_modules', 'antd', 'package.json'));
+  const antdMajor = antdPkg?.version ? parseInt(antdPkg.version.split('.')[0], 10) : 0;
+  const projectPkg = readJson<PkgJson>(join(cwd, 'package.json'));
+  const reactPkg = readJson<PkgJson>(join(cwd, 'node_modules', 'react', 'package.json'));
+  const cssinjsPkg = readJson<PkgJson>(join(cwd, 'node_modules', '@ant-design', 'cssinjs', 'package.json'));
+  const iconsPkg = readJson<PkgJson>(join(cwd, 'node_modules', '@ant-design', 'icons', 'package.json'));
   const ecosystemPackages = scanEcosystemPackages(cwd);
   return { cwd, antdPkg, antdMajor, projectPkg, reactPkg, cssinjsPkg, iconsPkg, ecosystemPackages };
 }
@@ -157,7 +159,7 @@ function findDuplicateVersions(cwd: string, pkgPath: string): string[] {
   const versions: string[] = [];
 
   // 1. Top-level install
-  const topPkg = readJson(join(cwd, 'node_modules', pkgPath, 'package.json'));
+  const topPkg = readJson<PkgJson>(join(cwd, 'node_modules', pkgPath, 'package.json'));
   if (topPkg?.version) versions.push(topPkg.version);
 
   // 2. One level of nesting: node_modules/*/node_modules/<pkgPath>
@@ -166,7 +168,7 @@ function findDuplicateVersions(cwd: string, pkgPath: string): string[] {
     const entries = readdirSync(nmDir);
     for (const entry of entries) {
       if (entry.startsWith('.') || entry === pkgPath) continue;
-      const nestedPkg = readJson(join(nmDir, entry, 'node_modules', pkgPath, 'package.json'));
+      const nestedPkg = readJson<PkgJson>(join(nmDir, entry, 'node_modules', pkgPath, 'package.json'));
       if (nestedPkg?.version) versions.push(nestedPkg.version);
     }
   } catch {
@@ -200,7 +202,7 @@ function checkDuplicateInstall(ctx: DoctorContext): CheckResult {
 function checkThemeConfig(ctx: DoctorContext): CheckResult {
   if (ctx.antdMajor >= 5) {
     // Check for old Less variable customization (should not exist in v5+)
-    const lessOverrides = readJson(join(ctx.cwd, 'theme', 'antd.less'));
+    const lessOverrides = readJson<unknown>(join(ctx.cwd, 'theme', 'antd.less'));
     const modifyVars = ctx.projectPkg?.theme;
     if (lessOverrides !== null || modifyVars) {
       return {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,13 +1,18 @@
 import type { Command } from 'commander';
 import type { GlobalOptions } from '../types.js';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { output } from '../output/formatter.js';
-import { readJson } from '../utils/json.js';
-
-interface PkgJson { version?: string; peerDependencies?: Record<string, string>; peerDependenciesMeta?: Record<string, { optional?: boolean }>; theme?: unknown; babel?: unknown }
+import { readJson, type PackageJson } from '../utils/json.js';
 import { satisfies } from '../data/version.js';
 import { getBugVersions, findBugInfo } from '../utils/bug-versions.js';
+
+interface DoctorPkgJson extends PackageJson {
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  theme?: unknown;
+  babel?: unknown;
+}
 
 interface CheckResult {
   name: string;
@@ -42,7 +47,7 @@ interface EcosystemPackage {
  * Returns null if not installed. Handles scoped packages (e.g. "@ant-design/cssinjs").
  */
 function getInstalledVersion(cwd: string, pkgName: string): string | null {
-  const pkg = readJson<PkgJson>(join(cwd, 'node_modules', pkgName, 'package.json'));
+  const pkg = readJson<DoctorPkgJson>(join(cwd, 'node_modules', pkgName, 'package.json'));
   return pkg?.version ?? null;
 }
 
@@ -63,7 +68,7 @@ function scanEcosystemPackages(cwd: string): EcosystemPackage[] {
   const result: EcosystemPackage[] = [];
   for (const entry of entries) {
     if (entry.startsWith('.')) continue;
-    const pkg = readJson<PkgJson>(join(scopeDir, entry, 'package.json'));
+    const pkg = readJson<DoctorPkgJson>(join(scopeDir, entry, 'package.json'));
     if (!pkg?.version) continue;
     const peerDeps: Record<string, string> = pkg.peerDependencies ?? {};
     if (Object.keys(peerDeps).length === 0) continue;
@@ -79,12 +84,12 @@ function scanEcosystemPackages(cwd: string): EcosystemPackage[] {
 }
 
 function buildContext(cwd: string): DoctorContext {
-  const antdPkg = readJson<PkgJson>(join(cwd, 'node_modules', 'antd', 'package.json'));
+  const antdPkg = readJson<DoctorPkgJson>(join(cwd, 'node_modules', 'antd', 'package.json'));
   const antdMajor = antdPkg?.version ? parseInt(antdPkg.version.split('.')[0], 10) : 0;
-  const projectPkg = readJson<PkgJson>(join(cwd, 'package.json'));
-  const reactPkg = readJson<PkgJson>(join(cwd, 'node_modules', 'react', 'package.json'));
-  const cssinjsPkg = readJson<PkgJson>(join(cwd, 'node_modules', '@ant-design', 'cssinjs', 'package.json'));
-  const iconsPkg = readJson<PkgJson>(join(cwd, 'node_modules', '@ant-design', 'icons', 'package.json'));
+  const projectPkg = readJson<DoctorPkgJson>(join(cwd, 'package.json'));
+  const reactPkg = readJson<DoctorPkgJson>(join(cwd, 'node_modules', 'react', 'package.json'));
+  const cssinjsPkg = readJson<DoctorPkgJson>(join(cwd, 'node_modules', '@ant-design', 'cssinjs', 'package.json'));
+  const iconsPkg = readJson<DoctorPkgJson>(join(cwd, 'node_modules', '@ant-design', 'icons', 'package.json'));
   const ecosystemPackages = scanEcosystemPackages(cwd);
   return { cwd, antdPkg, antdMajor, projectPkg, reactPkg, cssinjsPkg, iconsPkg, ecosystemPackages };
 }
@@ -159,7 +164,7 @@ function findDuplicateVersions(cwd: string, pkgPath: string): string[] {
   const versions: string[] = [];
 
   // 1. Top-level install
-  const topPkg = readJson<PkgJson>(join(cwd, 'node_modules', pkgPath, 'package.json'));
+  const topPkg = readJson<DoctorPkgJson>(join(cwd, 'node_modules', pkgPath, 'package.json'));
   if (topPkg?.version) versions.push(topPkg.version);
 
   // 2. One level of nesting: node_modules/*/node_modules/<pkgPath>
@@ -168,7 +173,7 @@ function findDuplicateVersions(cwd: string, pkgPath: string): string[] {
     const entries = readdirSync(nmDir);
     for (const entry of entries) {
       if (entry.startsWith('.') || entry === pkgPath) continue;
-      const nestedPkg = readJson<PkgJson>(join(nmDir, entry, 'node_modules', pkgPath, 'package.json'));
+      const nestedPkg = readJson<DoctorPkgJson>(join(nmDir, entry, 'node_modules', pkgPath, 'package.json'));
       if (nestedPkg?.version) versions.push(nestedPkg.version);
     }
   } catch {
@@ -202,9 +207,9 @@ function checkDuplicateInstall(ctx: DoctorContext): CheckResult {
 function checkThemeConfig(ctx: DoctorContext): CheckResult {
   if (ctx.antdMajor >= 5) {
     // Check for old Less variable customization (should not exist in v5+)
-    const lessOverrides = readJson<unknown>(join(ctx.cwd, 'theme', 'antd.less'));
+    const hasLessOverrides = existsSync(join(ctx.cwd, 'theme', 'antd.less'));
     const modifyVars = ctx.projectPkg?.theme;
-    if (lessOverrides !== null || modifyVars) {
+    if (hasLessOverrides || modifyVars) {
       return {
         name: 'theme-config',
         status: 'warn',

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -3,8 +3,11 @@ import type { GlobalOptions } from '../types.js';
 import { readdirSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join, isAbsolute } from 'node:path';
+import stringWidth from 'string-width';
 import { output } from '../output/formatter.js';
-import { readJson } from '../utils/scan.js';
+import { readJson } from '../utils/json.js';
+
+interface PkgJson { version?: string }
 
 export type EnvinfoValue = string | { version?: string; path?: string } | null;
 export type EnvinfoData = Record<string, Record<string, EnvinfoValue>>;
@@ -78,7 +81,7 @@ const CORE_DEPS = ['antd', 'react', 'react-dom', 'dayjs', '@ant-design/cssinjs',
 export function collectDependencies(cwd: string): Record<string, string | null> {
   const result: Record<string, string | null> = {};
   for (const dep of CORE_DEPS) {
-    const pkg = readJson(join(cwd, 'node_modules', dep, 'package.json'));
+    const pkg = readJson<PkgJson>(join(cwd, 'node_modules', dep, 'package.json'));
     result[dep] = pkg?.version ?? null;
   }
   return result;
@@ -96,7 +99,7 @@ export function scanEcosystem(cwd: string): Record<string, string> {
       if (entry.startsWith('.')) continue;
       const fullName = `@ant-design/${entry}`;
       if (coreSet.has(fullName)) continue;
-      const pkg = readJson(join(scopeDir, entry, 'package.json'));
+      const pkg = readJson<PkgJson>(join(scopeDir, entry, 'package.json'));
       if (pkg?.version) result[fullName] = pkg.version;
     }
   } catch { /* scope dir doesn't exist */ }
@@ -107,7 +110,7 @@ export function scanEcosystem(cwd: string): Record<string, string> {
     const entries = readdirSync(nmDir);
     for (const entry of entries) {
       if (!entry.startsWith('rc-')) continue;
-      const pkg = readJson(join(nmDir, entry, 'package.json'));
+      const pkg = readJson<PkgJson>(join(nmDir, entry, 'package.json'));
       if (pkg?.version) result[entry] = pkg.version;
     }
   } catch { /* node_modules doesn't exist */ }
@@ -132,7 +135,7 @@ const ENVINFO_ORDER = ['System', 'Binaries', 'Managers', 'Utilities', 'Servers',
 export function collectBuildTools(cwd: string): Record<string, string> {
   const result: Record<string, string> = {};
   for (const tool of BUILD_TOOLS) {
-    const pkg = readJson(join(cwd, 'node_modules', tool, 'package.json'));
+    const pkg = readJson<PkgJson>(join(cwd, 'node_modules', tool, 'package.json'));
     if (pkg?.version) result[tool] = pkg.version;
   }
   return result;
@@ -155,10 +158,11 @@ export function formatText(data: EnvResult): string {
     if (filtered.length === 0) return;
 
     lines.push(`  ${title}:`);
-    const maxKey = Math.max(...filtered.map(([k]) => k.length));
+    const maxKeyWidth = Math.max(...filtered.map(([k]) => stringWidth(k)));
     for (const [key, value] of filtered) {
       const display = getDisplayValue(value);
-      lines.push(`    ${key.padEnd(maxKey + 1)} ${display ?? 'Not found'}`);
+      const padded = key + ' '.repeat(maxKeyWidth - stringWidth(key) + 1);
+      lines.push(`    ${padded} ${display ?? 'Not found'}`);
     }
     lines.push('');
   };

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -5,9 +5,7 @@ import { execFileSync } from 'node:child_process';
 import { join, isAbsolute } from 'node:path';
 import stringWidth from 'string-width';
 import { output } from '../output/formatter.js';
-import { readJson } from '../utils/json.js';
-
-interface PkgJson { version?: string }
+import { readJson, type PackageJson } from '../utils/json.js';
 
 export type EnvinfoValue = string | { version?: string; path?: string } | null;
 export type EnvinfoData = Record<string, Record<string, EnvinfoValue>>;
@@ -81,7 +79,7 @@ const CORE_DEPS = ['antd', 'react', 'react-dom', 'dayjs', '@ant-design/cssinjs',
 export function collectDependencies(cwd: string): Record<string, string | null> {
   const result: Record<string, string | null> = {};
   for (const dep of CORE_DEPS) {
-    const pkg = readJson<PkgJson>(join(cwd, 'node_modules', dep, 'package.json'));
+    const pkg = readJson<PackageJson>(join(cwd, 'node_modules', dep, 'package.json'));
     result[dep] = pkg?.version ?? null;
   }
   return result;
@@ -99,7 +97,7 @@ export function scanEcosystem(cwd: string): Record<string, string> {
       if (entry.startsWith('.')) continue;
       const fullName = `@ant-design/${entry}`;
       if (coreSet.has(fullName)) continue;
-      const pkg = readJson<PkgJson>(join(scopeDir, entry, 'package.json'));
+      const pkg = readJson<PackageJson>(join(scopeDir, entry, 'package.json'));
       if (pkg?.version) result[fullName] = pkg.version;
     }
   } catch { /* scope dir doesn't exist */ }
@@ -110,7 +108,7 @@ export function scanEcosystem(cwd: string): Record<string, string> {
     const entries = readdirSync(nmDir);
     for (const entry of entries) {
       if (!entry.startsWith('rc-')) continue;
-      const pkg = readJson<PkgJson>(join(nmDir, entry, 'package.json'));
+      const pkg = readJson<PackageJson>(join(nmDir, entry, 'package.json'));
       if (pkg?.version) result[entry] = pkg.version;
     }
   } catch { /* node_modules doesn't exist */ }
@@ -135,7 +133,7 @@ const ENVINFO_ORDER = ['System', 'Binaries', 'Managers', 'Utilities', 'Servers',
 export function collectBuildTools(cwd: string): Record<string, string> {
   const result: Record<string, string> = {};
   for (const tool of BUILD_TOOLS) {
-    const pkg = readJson<PkgJson>(join(cwd, 'node_modules', tool, 'package.json'));
+    const pkg = readJson<PackageJson>(join(cwd, 'node_modules', tool, 'package.json'));
     if (pkg?.version) result[tool] = pkg.version;
   }
   return result;

--- a/src/data/__tests__/version.test.ts
+++ b/src/data/__tests__/version.test.ts
@@ -183,6 +183,10 @@ describe('compare', () => {
     expect(compare('1.0', '1.0.0')).toBe(0);
     expect(compare('1', '1.0.0')).toBe(0);
   });
+  it('should return null for unparseable versions', () => {
+    expect(compare('abc', '1.0.0')).toBeNull();
+    expect(compare('1.0.0', '')).toBeNull();
+  });
 });
 
 describe('valid', () => {

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -4,7 +4,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { MetadataStore, ComponentData, CLIError } from '../types.js';
 import { createError, fuzzyMatch, ErrorCodes } from '../output/error.js';
-import { readJson } from '../utils/scan.js';
+import { readJson } from '../utils/json.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -97,7 +97,7 @@ function loadMetadataForVersionUncached(version: string): MetadataStore {
 
   // Load versions index
   const versionsPath = join(getDataPath(), 'versions.json');
-  const versionsIndex = readJson(versionsPath) as Record<string, Record<string, string>> | null;
+  const versionsIndex = readJson<Record<string, Record<string, string>>>(versionsPath);
   if (!versionsIndex) {
     return loadMetadata(majorVersion);
   }

--- a/src/data/version.ts
+++ b/src/data/version.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import semver from 'semver';
-import { readJson } from '../utils/scan.js';
+import { readJson } from '../utils/json.js';
 
 export interface VersionInfo {
   version: string;
@@ -25,7 +25,7 @@ export function detectVersion(flagVersion?: string): VersionInfo {
   // 2. node_modules/antd/package.json
   const nmPath = join(process.cwd(), 'node_modules', 'antd', 'package.json');
   if (existsSync(nmPath)) {
-    const pkg = readJson(nmPath) as { version?: string } | null;
+    const pkg = readJson<{ version?: string }>(nmPath);
     if (pkg?.version) {
       return {
         version: pkg.version,
@@ -38,11 +38,11 @@ export function detectVersion(flagVersion?: string): VersionInfo {
   // 3. Project package.json dependencies
   const pkgPath = join(process.cwd(), 'package.json');
   if (existsSync(pkgPath)) {
-    const pkg = readJson(pkgPath) as {
+    const pkg = readJson<{
       dependencies?: { antd?: string };
       devDependencies?: { antd?: string };
       peerDependencies?: { antd?: string };
-    } | null;
+    }>(pkgPath);
     const depVersion =
       pkg?.dependencies?.antd || pkg?.devDependencies?.antd || pkg?.peerDependencies?.antd;
     if (depVersion) {
@@ -68,11 +68,11 @@ function toMajor(version: string): string {
   return `v${major}`;
 }
 
-/** Semver comparison using the `semver` package. Returns -1, 0, or 1. */
-export function compare(a: string, b: string): number {
+/** Semver comparison using the `semver` package. Returns -1, 0, or 1, or null if either version is unparseable. */
+export function compare(a: string, b: string): number | null {
   const sa = semver.coerce(a);
   const sb = semver.coerce(b);
-  if (!sa || !sb) return 0;
+  if (!sa || !sb) return null;
   return semver.compare(sa, sb);
 }
 

--- a/src/data/version.ts
+++ b/src/data/version.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import semver from 'semver';
-import { readJson } from '../utils/json.js';
+import { readJson, type PackageJson } from '../utils/json.js';
 
 export interface VersionInfo {
   version: string;
@@ -25,7 +25,7 @@ export function detectVersion(flagVersion?: string): VersionInfo {
   // 2. node_modules/antd/package.json
   const nmPath = join(process.cwd(), 'node_modules', 'antd', 'package.json');
   if (existsSync(nmPath)) {
-    const pkg = readJson<{ version?: string }>(nmPath);
+    const pkg = readJson<PackageJson>(nmPath);
     if (pkg?.version) {
       return {
         version: pkg.version,

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -143,14 +143,19 @@ export function formatTable(
   }
 
   // Text format: aligned columns (CJK-aware)
-  const colWidths = headers.map((h, i) =>
-    Math.max(stringWidth(h), ...rows.map((r) => stringWidth(r[i] || ''))),
+  // Pre-compute visual widths to avoid calling stringWidth twice per cell
+  const sw = (s: string) => stringWidth(s);
+  const headerWidths = headers.map(sw);
+  const cellWidths = rows.map((row) => row.map((cell) => sw(cell || '')));
+  const colWidths = headers.map((_, i) =>
+    Math.max(headerWidths[i], ...cellWidths.map((rw) => rw[i])),
   );
-  const padCell = (cell: string, width: number) => cell + ' '.repeat(width - stringWidth(cell));
-  const headerLine = headers.map((h, i) => padCell(h, colWidths[i])).join('  ');
+  const padCell = (cell: string, cellWidth: number, colWidth: number) =>
+    cell + ' '.repeat(colWidth - cellWidth);
+  const headerLine = headers.map((h, i) => padCell(h, headerWidths[i], colWidths[i])).join('  ');
   const separator = colWidths.map((w) => '-'.repeat(w)).join('  ');
-  const bodyLines = rows.map((row) =>
-    row.map((cell, i) => padCell(cell || '', colWidths[i])).join('  '),
+  const bodyLines = rows.map((row, ri) =>
+    row.map((cell, ci) => padCell(cell || '', cellWidths[ri][ci], colWidths[ci])).join('  '),
   );
   return [headerLine, separator, ...bodyLines].join('\n');
 }

--- a/src/utils/__tests__/json.test.ts
+++ b/src/utils/__tests__/json.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readJson } from '../json.js';
+import { join } from 'node:path';
+import { writeFileSync, rmSync } from 'node:fs';
+
+describe('readJson', () => {
+  it('should return null for non-existent file', () => {
+    expect(readJson('/nonexistent/file.json')).toBeNull();
+  });
+
+  it('should return parsed JSON for valid file', () => {
+    const tmpPath = join(__dirname, '__tmp_readjson_test__.json');
+    writeFileSync(tmpPath, JSON.stringify({ name: 'test' }));
+    try {
+      const result = readJson(tmpPath);
+      expect(result).toEqual({ name: 'test' });
+    } finally {
+      rmSync(tmpPath);
+    }
+  });
+
+  it('should return null for invalid JSON', () => {
+    const tmpPath = join(__dirname, '__tmp_readjson_bad__.json');
+    writeFileSync(tmpPath, 'not json');
+    try {
+      expect(readJson(tmpPath)).toBeNull();
+    } finally {
+      rmSync(tmpPath);
+    }
+  });
+
+  it('should support generic type parameter', () => {
+    const tmpPath = join(__dirname, '__tmp_readjson_generic__.json');
+    writeFileSync(tmpPath, JSON.stringify({ version: '1.0.0' }));
+    try {
+      const result = readJson<{ version: string }>(tmpPath);
+      expect(result?.version).toBe('1.0.0');
+    } finally {
+      rmSync(tmpPath);
+    }
+  });
+});

--- a/src/utils/__tests__/scan.test.ts
+++ b/src/utils/__tests__/scan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { collectFiles, readJson, getJSXElementName, SCAN_EXTENSIONS, SKIP_DIRS } from '../scan.js';
+import { collectFiles, getJSXElementName, SCAN_EXTENSIONS, SKIP_DIRS } from '../scan.js';
 import { join } from 'node:path';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 
@@ -69,32 +69,6 @@ describe('collectFiles', () => {
   });
 });
 
-describe('readJson', () => {
-  it('should return null for non-existent file', () => {
-    expect(readJson('/nonexistent/file.json')).toBeNull();
-  });
-
-  it('should return parsed JSON for valid file', () => {
-    const tmpPath = join(__dirname, '__tmp_readjson_test__.json');
-    writeFileSync(tmpPath, JSON.stringify({ name: 'test' }));
-    try {
-      const result = readJson(tmpPath);
-      expect(result).toEqual({ name: 'test' });
-    } finally {
-      rmSync(tmpPath);
-    }
-  });
-
-  it('should return null for invalid JSON', () => {
-    const tmpPath = join(__dirname, '__tmp_readjson_bad__.json');
-    writeFileSync(tmpPath, 'not json');
-    try {
-      expect(readJson(tmpPath)).toBeNull();
-    } finally {
-      rmSync(tmpPath);
-    }
-  });
-});
 
 describe('getJSXElementName', () => {
   it('should handle JSXIdentifier', () => {

--- a/src/utils/issue.ts
+++ b/src/utils/issue.ts
@@ -1,9 +1,7 @@
 import { platform, release } from 'node:os';
 import { execFileSync } from 'node:child_process';
-import { readJson } from './json.js';
+import { readJson, type PackageJson } from './json.js';
 import { join } from 'node:path';
-
-interface PkgJson { version?: string }
 
 declare const __CLI_VERSION__: string;
 
@@ -25,8 +23,8 @@ function getSystem(): string {
 }
 
 export function collectAntdEnv(cwd: string, versionOverride?: string): AntdEnv {
-  const antdPkg = readJson<PkgJson>(join(cwd, 'node_modules', 'antd', 'package.json'));
-  const reactPkg = readJson<PkgJson>(join(cwd, 'node_modules', 'react', 'package.json'));
+  const antdPkg = readJson<PackageJson>(join(cwd, 'node_modules', 'antd', 'package.json'));
+  const reactPkg = readJson<PackageJson>(join(cwd, 'node_modules', 'react', 'package.json'));
 
   return {
     antd: versionOverride || antdPkg?.version || 'unknown',

--- a/src/utils/issue.ts
+++ b/src/utils/issue.ts
@@ -1,7 +1,9 @@
 import { platform, release } from 'node:os';
 import { execFileSync } from 'node:child_process';
-import { readJson } from './scan.js';
+import { readJson } from './json.js';
 import { join } from 'node:path';
+
+interface PkgJson { version?: string }
 
 declare const __CLI_VERSION__: string;
 
@@ -23,8 +25,8 @@ function getSystem(): string {
 }
 
 export function collectAntdEnv(cwd: string, versionOverride?: string): AntdEnv {
-  const antdPkg = readJson(join(cwd, 'node_modules', 'antd', 'package.json'));
-  const reactPkg = readJson(join(cwd, 'node_modules', 'react', 'package.json'));
+  const antdPkg = readJson<PkgJson>(join(cwd, 'node_modules', 'antd', 'package.json'));
+  const reactPkg = readJson<PkgJson>(join(cwd, 'node_modules', 'react', 'package.json'));
 
   return {
     antd: versionOverride || antdPkg?.version || 'unknown',

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Read and parse a JSON file, returning null on failure.
+ */
+export function readJson<T = unknown>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,5 +1,10 @@
 import { readFileSync } from 'node:fs';
 
+/** Minimal package.json shape for versioned packages. */
+export interface PackageJson {
+  version?: string;
+}
+
 /**
  * Read and parse a JSON file, returning null on failure.
  */

--- a/src/utils/scan.ts
+++ b/src/utils/scan.ts
@@ -1,11 +1,15 @@
-import { statSync, readFileSync } from 'node:fs';
+import { statSync } from 'node:fs';
 import { join } from 'node:path';
 import fg from 'fast-glob';
 
 export const SCAN_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
 export const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.next']);
 
+// .umi* matches umi's generated temp dirs (.umi, .umi-production, etc.)
 const GLOB_IGNORE = [...SKIP_DIRS, '.umi*'].map((d) => `**/${d}/**`);
+
+// Derive glob pattern from SCAN_EXTENSIONS to keep them in sync
+const SOURCE_GLOB = `**/*.{${[...SCAN_EXTENSIONS].map((e) => e.slice(1)).join(',')}}`;
 
 /**
  * Recursively collect source files from a directory or return a single file.
@@ -19,7 +23,7 @@ export function collectFiles(dir: string): string[] {
   }
 
   try {
-    return fg.globSync('**/*.{ts,tsx,js,jsx}', {
+    return fg.globSync(SOURCE_GLOB, {
       cwd: dir,
       absolute: true,
       ignore: GLOB_IGNORE,
@@ -41,13 +45,3 @@ export function getJSXElementName(name: any): string {
   return '';
 }
 
-/**
- * Read and parse a JSON file, returning null on failure.
- */
-export function readJson(path: string): any | null {
-  try {
-    return JSON.parse(readFileSync(path, 'utf-8'));
-  } catch {
-    return null;
-  }
-}

--- a/src/utils/update-check.ts
+++ b/src/utils/update-check.ts
@@ -1,6 +1,6 @@
 import { compare, valid } from '../data/version.js';
 import { cacheStore } from './store.js';
-import { fetchWithTimeout } from './fetch.js';
+import { fetchFirstJson } from './fetch.js';
 
 declare const __CLI_VERSION__: string;
 
@@ -13,15 +13,8 @@ const NPM_SOURCES = [
 ];
 
 async function fetchLatestVersion(): Promise<string | null> {
-  // Race all registries — return the fastest successful response
-  return Promise.any(
-    NPM_SOURCES.map(async (url) => {
-      const res = await fetchWithTimeout(url, 3000);
-      const json = (await res.json()) as { version?: string };
-      if (json.version) return json.version;
-      throw new Error('No version provided');
-    }),
-  ).catch(() => null as string | null);
+  const json = await fetchFirstJson<{ version?: string }>(NPM_SOURCES, 3000);
+  return json?.version ?? null;
 }
 
 function printUpdateNotice(currentVersion: string, latestVersion: string): void {
@@ -59,7 +52,7 @@ export async function checkForUpdate(): Promise<void> {
     if (fetched) latestVersion = fetched;
   }
 
-  if (latestVersion && valid(latestVersion) && compare(currentVersion, latestVersion) < 0) {
+  if (latestVersion && valid(latestVersion) && (compare(currentVersion, latestVersion) ?? 0) < 0) {
     printUpdateNotice(currentVersion, latestVersion);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up cleanup from #109, addressing code review findings from `/simplify`:

- **Extract `readJson` to `src/utils/json.ts`** — moved the misplaced utility out of the file-scanning module into its own module, made it generic (`readJson<T>()`) instead of returning `any | null`, and updated all 6 call sites with proper type parameters
- **Fix `compare()` null safety** — `compare()` previously returned `0` for unparseable versions, making them indistinguishable from "equal". Now returns `null` with callers using nullish coalescing
- **Refactor `update-check.ts`** — replaced duplicated `Promise.any`+`fetchWithTimeout` pattern with shared `fetchFirstJson` utility
- **Optimize `formatTable`** — pre-compute `stringWidth` values in a single pass to avoid calling it twice per cell
- **Fix CJK-unaware `padEnd` in `env.ts`** — use `stringWidth` for column alignment instead of `.length`
- **Derive `SOURCE_GLOB` from `SCAN_EXTENSIONS`** — keeps glob pattern and extension set in sync
- **Add comment for `.umi*`** in `GLOB_IGNORE`

## Test plan

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` — 610/610 passing
- [x] New test for `compare()` returning `null` on unparseable versions
- [x] `readJson` tests moved to new `json.test.ts` with generic type test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进版本比较与更新判定，处理不可解析的版本并在比较缺失时使用安全默认，降低错误判断风险。
  * 表格列宽计算改为基于显示宽度，文本表格对齐更准确。

* **Refactor**
  * 重构并统一 JSON 读取工具，替换旧的读取路径以提升健壮性与类型约束。

* **Tests**
  * 补充 JSON 读取与版本比较相关测试，增强行为验证。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-cli/pull/111)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->