### PR TITLE
fix: use parseAsync() to properly await async postAction hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,5 +70,5 @@ export function createProgram(): Command {
 
 // Auto-run when executed as CLI (skip when imported by tests)
 if (!process.env.VITEST) {
-  createProgram().parse();
+  createProgram().parseAsync();
 }


### PR DESCRIPTION
## Summary
- `parse()` is synchronous and silently drops the pending promise from the async `postAction` hook that calls `checkForUpdate()`, meaning the update check never completes before process exit
- Switch to `parseAsync()` so Commander properly awaits the hook

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` — 173/173 tests pass
- [ ] Manual: run `node dist/index.js list` and verify update notice still appears when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)