### PR TITLE
fix(deps): upgrade qs to 6.15.2 to resolve CVE-2026-8723

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3962,9 +3962,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Upgrade `qs` from 6.15.0 to 6.15.2 to fix [CVE-2026-8723](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) / [GHSA-q8mj-m7cp-5q26](https://github.com/ant-design/ant-design-cli/security/dependabot/10)
- `qs.stringify` could crash with `TypeError` on `null`/`undefined` entries in comma-format arrays when `encodeValuesOnly` is set, enabling a remotely triggerable DoS
- `qs` is a transitive dependency via `express` (used by `@modelcontextprotocol/sdk`)

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (389 tests)
- [x] `npm audit` reports 0 vulnerabilities

Closes #10 (Dependabot alert)