### PR TITLE
docs: add antd mcp and antd upgrade commands to README and SKILL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npx skills add ant-design/ant-design-cli    # install as an agent skill
 - 🤖 **Agent-optimized** — `--format json` on every command. Structured errors with codes and suggestions. Clean stdout/stderr separation.
 - 🌍 **Bilingual** — Every component name, description, and doc has both English and Chinese. Switch with `--lang zh`.
 - 🔮 **Smart matching** — Typo `Buttn`? The CLI suggests `Button` using Levenshtein distance, with first-letter preference.
-- 🧩 **15 commands** — From prop lookup to project-wide lint, from design token queries to cross-version API diffing.
+- 🧩 **16 commands** — From prop lookup to project-wide lint, from design token queries to cross-version API diffing.
 - 🔌 **MCP server** — `antd mcp` starts a stdio server for native IDE integration (Claude Desktop, Cursor).
 
 <br>
@@ -117,6 +117,8 @@ antd usage ./src                    # Analyze antd imports in project
 antd lint ./src                     # Check deprecated APIs & best practices
 antd migrate 3 4                    # v3 → v4 migration guide
 antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
+antd mcp                            # Start MCP server for IDE integration
+antd upgrade                        # Upgrade CLI to latest version
 ```
 
 <br>
@@ -151,6 +153,13 @@ antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
 |---|---|
 | [`antd bug`](#antd-bug) | File a bug to ant-design/ant-design with auto-collected environment info |
 | [`antd bug-cli`](#antd-bug-cli) | File a bug to ant-design/ant-design-cli |
+
+### 🔧 CLI Management
+
+| Command | Description |
+|---|---|
+| [`antd mcp`](#antd-mcp) | Start MCP stdio server for IDE agent integration |
+| [`antd upgrade`](#antd-upgrade) | Upgrade the CLI to the latest version |
 
 <br>
 
@@ -388,6 +397,54 @@ antd bug --title "..." --submit     # submit via gh CLI
 antd bug-cli --title "info command crashes on v4"
 antd bug-cli --title "..." --submit
 ```
+
+### `antd mcp`
+
+Start an MCP (Model Context Protocol) stdio server for IDE agent integration. Exposes 7 tools and 2 prompts for native IDE integration (Claude Desktop, Cursor, etc.).
+
+```bash
+antd mcp                                # start with auto-detected version
+antd mcp --version 5.20.0 --lang zh     # pin version and language
+```
+
+IDE configuration (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "antd",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+**MCP Tools (7):** `antd_list`, `antd_info`, `antd_doc`, `antd_demo`, `antd_token`, `antd_semantic`, `antd_changelog`
+
+**MCP Prompts (2):** `antd-expert`, `antd-page-generator`
+
+### `antd upgrade`
+
+Upgrade the CLI itself to the latest version published on npm. Automatically detects which package manager installed the CLI (npm, yarn, pnpm, bun, cnpm, utoo) and runs the corresponding upgrade command.
+
+```bash
+antd upgrade                        # upgrade to latest version
+antd upgrade --format json          # structured JSON output
+antd upgrade --lang zh              # Chinese output
+```
+
+<details>
+<summary>Example output</summary>
+
+```text
+Upgrading @ant-design/cli: v6.4.3 → v6.4.4
+Running: npm install -g @ant-design/cli@latest
+... (passthrough package manager output) ...
+Successfully upgraded to v6.4.4
+```
+
+</details>
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -430,8 +430,6 @@ Upgrade the CLI itself to the latest version published on npm. Automatically det
 
 ```bash
 antd upgrade                        # upgrade to latest version
-antd upgrade --format json          # structured JSON output
-antd upgrade --lang zh              # Chinese output
 ```
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -430,8 +430,6 @@ IDE 配置（`claude_desktop_config.json`）：
 
 ```bash
 antd upgrade                        # 升级到最新版本
-antd upgrade --format json          # 结构化 JSON 输出
-antd upgrade --lang zh              # 中文输出
 ```
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@ npx skills add ant-design/ant-design-cli    # 安装为 Agent Skill
 - 🤖 **Agent 优化** — 所有命令支持 `--format json`。结构化错误码与修复建议。stdout/stderr 严格分离。
 - 🌍 **双语输出** — 每个组件名、描述和文档均有中英文。通过 `--lang zh` 切换。
 - 🔮 **智能纠错** — 输入 `Buttn`？CLI 基于 Levenshtein 距离建议 `Button`，优先匹配首字母相同的候选。
-- 🧩 **15 条命令** — 从 Prop 查询到项目级 Lint，从 Design Token 到跨版本 API 对比。
+- 🧩 **16 条命令** — 从 Prop 查询到项目级 Lint，从 Design Token 到跨版本 API 对比。
 - 🔌 **MCP 服务** — `antd mcp` 启动 stdio 服务，原生集成 Claude Desktop、Cursor 等 IDE。
 
 <br>
@@ -117,6 +117,8 @@ antd usage ./src                    # 分析项目中的 antd 导入
 antd lint ./src                     # 检查废弃 API 和最佳实践
 antd migrate 3 4                    # v3 → v4 迁移指南
 antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
+antd mcp                            # 启动 MCP 服务，供 IDE 集成
+antd upgrade                        # 升级 CLI 到最新版本
 ```
 
 <br>
@@ -151,6 +153,13 @@ antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
 |---|---|
 | [`antd bug`](#antd-bug) | 向 ant-design/ant-design 报告 Bug，自动收集环境信息 |
 | [`antd bug-cli`](#antd-bug-cli) | 向 ant-design/ant-design-cli 报告 Bug |
+
+### 🔧 CLI 管理
+
+| 命令 | 说明 |
+|---|---|
+| [`antd mcp`](#antd-mcp) | 启动 MCP stdio 服务，供 IDE Agent 集成 |
+| [`antd upgrade`](#antd-upgrade) | 升级 CLI 到最新版本 |
 
 <br>
 
@@ -388,6 +397,54 @@ antd bug --title "..." --submit     # 通过 gh CLI 提交
 antd bug-cli --title "info 命令在 v4 组件上崩溃"
 antd bug-cli --title "..." --submit
 ```
+
+### `antd mcp`
+
+启动 MCP（Model Context Protocol）stdio 服务，供 IDE Agent 集成。提供 7 个工具和 2 个提示词，支持 Claude Desktop、Cursor 等 IDE 原生集成。
+
+```bash
+antd mcp                                # 使用自动检测的版本启动
+antd mcp --version 5.20.0 --lang zh     # 指定版本和语言
+```
+
+IDE 配置（`claude_desktop_config.json`）：
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "antd",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+**MCP 工具（7 个）：** `antd_list`、`antd_info`、`antd_doc`、`antd_demo`、`antd_token`、`antd_semantic`、`antd_changelog`
+
+**MCP 提示词（2 个）：** `antd-expert`、`antd-page-generator`
+
+### `antd upgrade`
+
+升级 CLI 自身到 npm 上发布的最新版本。自动检测安装 CLI 的包管理器（npm、yarn、pnpm、bun、cnpm、utoo）并执行对应的升级命令。
+
+```bash
+antd upgrade                        # 升级到最新版本
+antd upgrade --format json          # 结构化 JSON 输出
+antd upgrade --lang zh              # 中文输出
+```
+
+<details>
+<summary>示例输出</summary>
+
+```text
+正在升级 @ant-design/cli: v6.4.3 → v6.4.4
+执行: npm install -g @ant-design/cli@latest
+... (包管理器输出透传) ...
+成功升级到 v6.4.4
+```
+
+</details>
 
 <br>
 

--- a/skills/antd/SKILL.md
+++ b/skills/antd/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Bash(antd *)
   - Bash(antd bug*)
   - Bash(antd bug-cli*)
+  - Bash(antd upgrade*)
   - Bash(npm install -g @ant-design/cli*)
   - Bash(which antd)
 ---
@@ -25,7 +26,7 @@ Before first use, check if the CLI is installed. If not, install it automaticall
 which antd || npm install -g @ant-design/cli
 ```
 
-After running any command, if the output contains an "Update available" notice, run `npm install -g @ant-design/cli` to update before continuing.
+After running any command, if the output contains an "Update available" notice, run `antd upgrade` to update before continuing.
 
 
 **Always use `--format json` for structured output you can parse programmatically.**
@@ -221,7 +222,21 @@ antd bug-cli --title "antd info Button returns wrong props for v5.12.0" \
 
 **Opt-out:** If the environment variable `ANTD_NO_AUTO_REPORT=1` is set, skip all bug-reporting suggestions entirely — do not suggest `antd bug` or `antd bug-cli` unless the user directly asks.
 
-### 11. Using as MCP server
+### 11. Upgrading the CLI
+
+When the user wants to update `@ant-design/cli` to the latest version, or when an "Update available" notice appears:
+
+```bash
+# Upgrade to the latest version (auto-detects package manager)
+antd upgrade
+
+# Structured output
+antd upgrade --format json
+```
+
+The command detects which package manager installed the CLI (npm, yarn, pnpm, bun, cnpm, utoo) and runs the appropriate upgrade command. If detection fails, it suggests the manual command.
+
+### 12. Using as MCP server
 
 If working in an IDE that supports MCP (Claude Desktop, Cursor, etc.), the CLI can also run as an MCP server, exposing all knowledge-query tools directly:
 

--- a/skills/antd/SKILL.md
+++ b/skills/antd/SKILL.md
@@ -229,9 +229,6 @@ When the user wants to update `@ant-design/cli` to the latest version, or when a
 ```bash
 # Upgrade to the latest version (auto-detects package manager)
 antd upgrade
-
-# Structured output
-antd upgrade --format json
 ```
 
 The command detects which package manager installed the CLI (npm, yarn, pnpm, bun, cnpm, utoo) and runs the appropriate upgrade command. If detection fails, it suggests the manual command.


### PR DESCRIPTION
## Summary

- Add `antd mcp` and `antd upgrade` to Quick Start, command summary tables, and individual command sections in both README.md and README.zh-CN.md
- Add new CLI Management category in the command tables
- Update command count from 15 to 16
- Add upgrade scenario (#11) to SKILL.md, replace manual npm install -g upgrade instruction with antd upgrade
- Add antd upgrade* to SKILL.md allowed-tools

Both commands were fully implemented but missing from user-facing documentation.

## Test plan

- Verify README.md renders correctly with new sections
- Verify README.zh-CN.md renders correctly with new sections
- Verify SKILL.md scenarios are numbered correctly after insertion
- Verify all anchor links in command tables point to correct headings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 文档更新
* **文档**
  * 新增两条 CLI 管理命令说明：antd mcp（启动 MCP stdio 服务）与 antd upgrade（升级 CLI），并补充用法示例与输出示例
  * 在快速开始示例中加入新命令演示，完善升级流程说明，推荐使用 antd upgrade 自动检测并执行升级
  * 增补 MCP 配置、示例工具与提示词清单，更新相关使用指引

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-cli/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->