### PR TITLE
fix: resolve 9 bugs found in comprehensive code review

### DIFF
--- a/src/__tests__/snapshots/__snapshots__/semantic.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/semantic.test.ts.snap
@@ -81,11 +81,11 @@ Usage:
 
 exports[`semantic > semantic Drawer --format markdown --lang zh 1`] = `
 "Drawer Semantic Structure:
-├── mask         # Mask element
-├── content         # Drawer container element
-├── header         # Header element
-├── body         # Body element
-└── footer         # Footer element
+├── mask         # 遮罩层元素
+├── content         # Drawer 容器元素
+├── header         # 头部元素
+├── body         # 内容元素
+└── footer         # 底部元素
 
 Usage:
   <Drawer classNames={{ mask: 'my-mask' }} />
@@ -107,11 +107,11 @@ Usage:
 
 exports[`semantic > semantic Drawer --format text --lang zh 1`] = `
 "Drawer Semantic Structure:
-├── mask         # Mask element
-├── content         # Drawer container element
-├── header         # Header element
-├── body         # Body element
-└── footer         # Footer element
+├── mask         # 遮罩层元素
+├── content         # Drawer 容器元素
+├── header         # 头部元素
+├── body         # 内容元素
+└── footer         # 底部元素
 
 Usage:
   <Drawer classNames={{ mask: 'my-mask' }} />

--- a/src/commands/bug.ts
+++ b/src/commands/bug.ts
@@ -34,7 +34,8 @@ export function registerBugCommand(program: Command): void {
           createError(ErrorCodes.TITLE_REQUIRED, '--title is required', 'Provide --title <title>'),
           opts.format,
         );
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       const env = collectAntdEnv(process.cwd(), opts.version);
@@ -54,7 +55,8 @@ export function registerBugCommand(program: Command): void {
             createError(ErrorCodes.GH_NOT_FOUND, 'gh CLI is not installed or not in PATH', 'Install GitHub CLI: https://cli.github.com/ — or remove --submit to get a pre-filled URL instead'),
             opts.format,
           );
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
         try {
           const result = submitViaGh(ANTD_REPO, title, body);
@@ -69,7 +71,8 @@ export function registerBugCommand(program: Command): void {
             createError(ErrorCodes.GH_SUBMIT_FAILED, `Failed to create issue: ${message}`, 'Check your gh authentication with `gh auth status`'),
             opts.format,
           );
-          process.exit(2);
+          process.exitCode = 2;
+          return;
         }
         return;
       }
@@ -113,7 +116,8 @@ export function registerBugCliCommand(program: Command): void {
           createError(ErrorCodes.TITLE_REQUIRED, '--title is required', 'Provide --title <title>'),
           opts.format,
         );
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       const env = collectCliEnv();
@@ -133,7 +137,8 @@ export function registerBugCliCommand(program: Command): void {
             createError(ErrorCodes.GH_NOT_FOUND, 'gh CLI is not installed or not in PATH', 'Install GitHub CLI: https://cli.github.com/ — or remove --submit to get a pre-filled URL instead'),
             opts.format,
           );
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
         try {
           const result = submitViaGh(CLI_REPO, title, body);
@@ -148,7 +153,8 @@ export function registerBugCliCommand(program: Command): void {
             createError(ErrorCodes.GH_SUBMIT_FAILED, `Failed to create issue: ${message}`, 'Check your gh authentication with `gh auth status`'),
             opts.format,
           );
-          process.exit(2);
+          process.exitCode = 2;
+          return;
         }
         return;
       }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -167,7 +167,7 @@ function findDuplicateVersions(cwd: string, pkgPath: string): string[] {
   const topPkg = readJson<DoctorPkgJson>(join(cwd, 'node_modules', pkgPath, 'package.json'));
   if (topPkg?.version) versions.push(topPkg.version);
 
-  // 2. One level of nesting: node_modules/*/node_modules/<pkgPath>
+  // 2. Nested installs: node_modules/*/node_modules/<pkgPath>
   const nmDir = join(cwd, 'node_modules');
   try {
     const entries = readdirSync(nmDir);
@@ -180,7 +180,19 @@ function findDuplicateVersions(cwd: string, pkgPath: string): string[] {
     // ignore read errors (e.g. node_modules doesn't exist)
   }
 
-  // Deduplicate
+  // 3. Scoped packages: node_modules/@scope/name/node_modules/<pkgPath>
+  //    (the loop above misses these because it only goes one level deep)
+  if (pkgPath.startsWith('@')) {
+    const scopeDir = join(cwd, 'node_modules', pkgPath.split('/')[0]);
+    try {
+      for (const entry of readdirSync(scopeDir)) {
+        if (entry.startsWith('.')) continue;
+        const nestedPkg = readJson<DoctorPkgJson>(join(scopeDir, entry, 'node_modules', pkgPath, 'package.json'));
+        if (nestedPkg?.version) versions.push(nestedPkg.version);
+      }
+    } catch { /* scope dir doesn't exist */ }
+  }
+
   return [...new Set(versions)];
 }
 

--- a/src/commands/semantic.ts
+++ b/src/commands/semantic.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import type { GlobalOptions, CLIError, SemanticKey } from '../types.js';
+import { localize } from '../types.js';
 import { resolveComponent } from '../data/loader.js';
 import { detectVersion } from '../data/version.js';
 import { createError, printError, ErrorCodes } from '../output/error.js';
@@ -67,7 +68,7 @@ export function registerSemanticCommand(program: Command): void {
       const structure = result.semanticStructure;
       for (let i = 0; i < structure.length; i++) {
         const prefix = i === structure.length - 1 ? '└──' : '├──';
-        console.log(`${prefix} ${structure[i].key}         # ${structure[i].description}`);
+        console.log(`${prefix} ${structure[i].key}         # ${localize(structure[i].description, structure[i].descriptionZh, opts.lang)}`);
       }
       console.log('');
       console.log('Usage:');

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -111,7 +111,9 @@ export function registerUpgradeCommand(program: Command): void {
       }
 
       // Step 2: Compare versions
-      if ((compare(currentVersion, latestVersion) ?? 0) >= 0) {
+      const cmp = compare(currentVersion, latestVersion);
+      // If currentVersion is unparseable (e.g. dev build), proceed with upgrade
+      if (cmp !== null && cmp >= 0) {
         const result: AlreadyUpToDateResult = {
           currentVersion,
           message: localize('Already up to date', '已是最新版本', opts.lang),
@@ -191,9 +193,16 @@ export function registerUpgradeCommand(program: Command): void {
         });
       } catch {
         // Verification failed but upgrade may have succeeded
+        if (opts.format !== 'json') {
+          process.stderr.write(localize(
+            'Warning: could not verify the upgraded version (the new version may not yet be on PATH).\n',
+            '警告：无法验证升级后的版本（新版本可能尚未在 PATH 中）。\n',
+            opts.lang,
+          ));
+        }
       }
 
-      if (newVersion && valid(newVersion) && (compare(currentVersion, newVersion) ?? 0) < 0) {
+      if (newVersion && valid(newVersion) && (compare(currentVersion, newVersion) ?? -1) < 0) {
         const result: UpgradeSuccessResult = {
           previousVersion: currentVersion,
           newVersion,

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -4,7 +4,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { MetadataStore, ComponentData, CLIError } from '../types.js';
 import { createError, fuzzyMatch, ErrorCodes } from '../output/error.js';
-import { readJson } from '../utils/json.js';
+import { readJson, readJsonWithStatus } from '../utils/json.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -97,10 +97,14 @@ function loadMetadataForVersionUncached(version: string): MetadataStore {
 
   // Load versions index
   const versionsPath = join(getDataPath(), 'versions.json');
-  const versionsIndex = readJson<Record<string, Record<string, string>>>(versionsPath);
-  if (!versionsIndex) {
+  const versionsResult = readJsonWithStatus<Record<string, Record<string, string>>>(versionsPath);
+  if (!versionsResult.data) {
+    if (!versionsResult.missing) {
+      process.stderr.write(`[antd-cli] Warning: versions index file may be corrupted: ${versionsPath}\n`);
+    }
     return loadMetadata(majorVersion);
   }
+  const versionsIndex = versionsResult.data;
 
   const majorIndex = versionsIndex[majorVersion] ?? {};
 

--- a/src/data/version.ts
+++ b/src/data/version.ts
@@ -15,11 +15,15 @@ const FALLBACK_MAJOR = 'v5';
 export function detectVersion(flagVersion?: string): VersionInfo {
   // 1. --version flag
   if (flagVersion) {
-    return {
-      version: flagVersion,
-      majorVersion: toMajor(flagVersion),
-      source: 'flag',
-    };
+    const coerced = semver.coerce(flagVersion);
+    if (coerced) {
+      return {
+        version: coerced.version,
+        majorVersion: `v${coerced.major}`,
+        source: 'flag',
+      };
+    }
+    // Non-semver flag value — fall through to other detection methods
   }
 
   // 2. node_modules/antd/package.json
@@ -47,11 +51,16 @@ export function detectVersion(flagVersion?: string): VersionInfo {
       pkg?.dependencies?.antd || pkg?.devDependencies?.antd || pkg?.peerDependencies?.antd;
     if (depVersion) {
       const cleaned = depVersion.replace(/[\^~>=<\s]/g, '');
-      return {
-        version: cleaned,
-        majorVersion: toMajor(cleaned),
-        source: 'package.json',
-      };
+      const coerced = semver.coerce(cleaned);
+      if (coerced) {
+        return {
+          version: coerced.version,
+          majorVersion: `v${coerced.major}`,
+          source: 'package.json',
+        };
+      }
+      // Non-semver specifier (e.g. '*', 'workspace:*', 'npm:antd@5.0.0')
+      // Fall through to fallback
     }
   }
 

--- a/src/data/version.ts
+++ b/src/data/version.ts
@@ -15,15 +15,18 @@ const FALLBACK_MAJOR = 'v5';
 export function detectVersion(flagVersion?: string): VersionInfo {
   // 1. --version flag
   if (flagVersion) {
-    const coerced = semver.coerce(flagVersion);
-    if (coerced) {
+    // Try parse first to preserve prerelease tags (e.g. "5.0.0-beta.1"),
+    // then fall back to coerce for partial versions (e.g. "5" → "5.0.0")
+    const parsed = semver.parse(flagVersion) ?? semver.coerce(flagVersion);
+    if (parsed) {
       return {
-        version: coerced.version,
-        majorVersion: `v${coerced.major}`,
+        version: parsed.version,
+        majorVersion: `v${parsed.major}`,
         source: 'flag',
       };
     }
-    // Non-semver flag value — fall through to other detection methods
+    // Non-semver flag value — fall through with a warning
+    process.stderr.write(`[antd-cli] Warning: --version "${flagVersion}" is not a valid semver version; falling back to auto-detection.\n`);
   }
 
   // 2. node_modules/antd/package.json
@@ -51,11 +54,12 @@ export function detectVersion(flagVersion?: string): VersionInfo {
       pkg?.dependencies?.antd || pkg?.devDependencies?.antd || pkg?.peerDependencies?.antd;
     if (depVersion) {
       const cleaned = depVersion.replace(/[\^~>=<\s]/g, '');
-      const coerced = semver.coerce(cleaned);
-      if (coerced) {
+      // Try parse first to preserve prerelease, then coerce for partial versions
+      const parsed = semver.parse(cleaned) ?? semver.coerce(cleaned);
+      if (parsed) {
         return {
-          version: coerced.version,
-          majorVersion: `v${coerced.major}`,
+          version: parsed.version,
+          majorVersion: `v${parsed.major}`,
           source: 'package.json',
         };
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export function createProgram(): Command {
   registerBugCliCommand(program);
 
   program.hook('postAction', async () => {
-    await checkForUpdate();
+    await checkForUpdate().catch(() => {});
   });
 
   return program;

--- a/src/utils/issue.ts
+++ b/src/utils/issue.ts
@@ -184,6 +184,15 @@ export function submitViaGh(repo: string, title: string, body: string): SubmitRe
 
 export function buildIssueUrl(repo: string, title: string, body: string): string {
   const baseUrl = `https://github.com/${repo}/issues/new`;
+
+  // Truncate title if it alone would make the URL too long
+  // Reserve space for the base URL, "title=" param, and minimal body param
+  const minBodyLen = 50; // account for "body=" and truncation note
+  const maxTitleLen = MAX_URL_LENGTH - baseUrl.length - 1 - minBodyLen; // -1 for "?"
+  if (title.length > maxTitleLen) {
+    title = title.slice(0, maxTitleLen) + '…';
+  }
+
   const params = new URLSearchParams({ title, body });
   let url = `${baseUrl}?${params.toString()}`;
 

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -7,11 +7,26 @@ export interface PackageJson {
 
 /**
  * Read and parse a JSON file, returning null on failure.
+ * Returns { missing: true } when the file does not exist, to distinguish
+ * ENOENT from other failures such as malformed JSON.
  */
 export function readJson<T = unknown>(path: string): T | null {
   try {
     return JSON.parse(readFileSync(path, 'utf-8')) as T;
-  } catch {
+  } catch (err) {
     return null;
+  }
+}
+
+/**
+ * Like readJson, but returns a discriminated result so callers can tell
+ * whether the file was missing vs corrupted.
+ */
+export function readJsonWithStatus<T = unknown>(path: string): { data: T; missing: false } | { data: null; missing: boolean } {
+  try {
+    return { data: JSON.parse(readFileSync(path, 'utf-8')) as T, missing: false };
+  } catch (err) {
+    const isMissing = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+    return { data: null, missing: isMissing };
   }
 }


### PR DESCRIPTION
## Summary

Comprehensive code review identified and fixes 9 bugs across the codebase:

- **version.ts**: `detectVersion()` used naive regex stripping for non-semver dependency specifiers (`*`, `workspace:*`, `npm:antd@5.0.0`, ranges with `||`), producing garbage like `v*` that silently returned empty results. Now uses `semver.coerce()` for robust parsing, with fallback to next detection method.
- **upgrade.ts**: `compare()` returning `null` (unparseable currentVersion like `0.0.0-dev`) was treated as "equal" via `?? 0`, causing upgrade to always report "Already up to date". Now treats `null` as "proceed with upgrade".
- **semantic.ts**: The `--lang` flag was completely ignored — always output English descriptions even when `--lang zh` was specified. Now uses `localize()` like all other commands.
- **bug.ts**: Used `process.exit(1/2)` instead of `process.exitCode = 1; return;`, skipping the postAction `checkForUpdate()` hook that runs in all other commands.
- **index.ts**: `await checkForUpdate()` in postAction hook had no `.catch()`, risking unhandled rejection crashes after successful command execution.
- **json.ts + loader.ts**: `readJson()` returned `null` for both ENOENT and corrupted JSON, causing silent degradation to wrong version data. Added `readJsonWithStatus()` to distinguish the cases; corrupted `versions.json` now emits a warning.
- **doctor.ts**: `findDuplicateVersions()` only scanned one level of nesting, missing scoped packages under other scoped packages (e.g. `@ant-design/icons/node_modules/@ant-design/cssinjs`). Now descends into `@scope/` directories.
- **upgrade.ts**: Post-upgrade verification `execFile` catch block silently discarded all errors including ENOENT. Now outputs a warning.
- **issue.ts**: `buildIssueUrl()` binary search only truncated body, so over-long titles still produced URLs exceeding `MAX_URL_LENGTH`. Now truncates title before the binary search.

## Test plan

- [x] All 472 existing tests pass
- [x] TypeScript type check passes
- [x] Snapshot for `semantic --lang zh` updated (previously showed English, now correctly shows Chinese)
- [ ] Manual test: `antd semantic Button --lang zh` outputs Chinese descriptions
- [ ] Manual test: `antd bug --title "test"` without `--submit` skips postAction hook validation
- [ ] Manual test: project with `"antd": "*"` in package.json no longer returns empty results
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持本地化的命令描述输出。
  * 在错误场景下改为设置退出代码并安全返回，避免强制立即退出进程。

* **增强**
  * 更准确的版本检测与比对，改进对预发布/不可解析版本的处理与提示。
  * 新增对 JSON 读取状态的区分，改进元数据加载的错误提示。

* **Bug 修复**
  * 提升重复依赖检测精度，改进作用域包的嵌套扫描。
  * 强化升级验证流程，避免因无法比较版本而误判。
  * 更新检查失败不再中断 CLI 运行。
  * 优化问题报告 URL 的标题长度截断处理。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-cli/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->