### PR TITLE
fix: resolve 3 severe bugs — version parsing, upgrade null compare, semantic --lang

### DIFF
--- a/src/__tests__/commands/upgrade.test.ts
+++ b/src/__tests__/commands/upgrade.test.ts
@@ -29,15 +29,28 @@ vi.mock('../../utils/detect-pm.js', () => ({
   inferPackageManagerFromPath: vi.fn(),
 }));
 
+// Mock version module so we can control compare() return value
+vi.mock('../../data/version.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../data/version.js')>();
+  return {
+    ...original,
+    compare: vi.fn(original.compare),
+    valid: vi.fn(original.valid),
+  };
+});
+
 // Import mocked modules after vi.mock
 import { spawn, execFile } from 'node:child_process';
 import { fetchLatestVersion } from '../../utils/update-check.js';
 import { detectPackageManager } from '../../utils/detect-pm.js';
+import { compare, valid } from '../../data/version.js';
 
 const mockSpawn = vi.mocked(spawn);
 const mockExecFile = vi.mocked(execFile);
 const mockFetchLatestVersion = vi.mocked(fetchLatestVersion);
 const mockDetectPackageManager = vi.mocked(detectPackageManager);
+const mockCompare = vi.mocked(compare);
+const mockValid = vi.mocked(valid);
 
 function createMockChildProcess(exitCode: number): ChildProcess {
   const cp = new EventEmitter() as ChildProcess;
@@ -371,5 +384,40 @@ describe('upgrade command', () => {
     const result = await runCLI('upgrade', '--format', 'markdown');
     expect(result.stdout).toContain('99.0.0');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('proceeds with upgrade when compare returns null (unparseable currentVersion)', async () => {
+    // Simulate dev build where currentVersion is not valid semver
+    mockCompare.mockReturnValue(null);
+    mockFetchLatestVersion.mockResolvedValue('99.0.0');
+    mockDetectPackageManager.mockReturnValue('npm');
+
+    mockSpawn.mockReturnValue(createMockChildProcess(0));
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+      (cb as (err: null, stdout: string) => void)(null, '99.0.0');
+      return {} as never;
+    });
+
+    const result = await runCLI('upgrade');
+    // Should NOT show "Already up to date" — should proceed with upgrade
+    expect(result.stdout).toContain('Upgrading @ant-design/cli');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('proceeds with upgrade when compare returns null (JSON format)', async () => {
+    mockCompare.mockReturnValue(null);
+    mockFetchLatestVersion.mockResolvedValue('99.0.0');
+    mockDetectPackageManager.mockReturnValue('npm');
+
+    mockSpawn.mockReturnValue(createMockChildProcess(0));
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+      (cb as (err: null, stdout: string) => void)(null, '99.0.0');
+      return {} as never;
+    });
+
+    const result = await runCLI('upgrade', '--format', 'json');
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.stdout);
+    expect(data.newVersion).toBe('99.0.0');
   });
 });

--- a/src/__tests__/snapshots/__snapshots__/semantic.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/semantic.test.ts.snap
@@ -81,11 +81,11 @@ Usage:
 
 exports[`semantic > semantic Drawer --format markdown --lang zh 1`] = `
 "Drawer Semantic Structure:
-├── mask         # Mask element
-├── content         # Drawer container element
-├── header         # Header element
-├── body         # Body element
-└── footer         # Footer element
+├── mask         # 遮罩层元素
+├── content         # Drawer 容器元素
+├── header         # 头部元素
+├── body         # 内容元素
+└── footer         # 底部元素
 
 Usage:
   <Drawer classNames={{ mask: 'my-mask' }} />
@@ -107,11 +107,11 @@ Usage:
 
 exports[`semantic > semantic Drawer --format text --lang zh 1`] = `
 "Drawer Semantic Structure:
-├── mask         # Mask element
-├── content         # Drawer container element
-├── header         # Header element
-├── body         # Body element
-└── footer         # Footer element
+├── mask         # 遮罩层元素
+├── content         # Drawer 容器元素
+├── header         # 头部元素
+├── body         # 内容元素
+└── footer         # 底部元素
 
 Usage:
   <Drawer classNames={{ mask: 'my-mask' }} />

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -44,6 +44,13 @@ describe('data/version', () => {
     expect(v.majorVersion).toBe('v5');
   });
 
+  it('preserves prerelease from non-strict-semver flag via coerce (e.g. "5-beta.1")', () => {
+    const v = detectVersion('5-beta.1');
+    expect(v.source).toBe('flag');
+    expect(v.version).toBe('5.0.0-beta.1');
+    expect(v.majorVersion).toBe('v5');
+  });
+
   it('coerces partial version in --version flag (e.g. "5" → "5.0.0")', () => {
     const v = detectVersion('5');
     expect(v.source).toBe('flag');
@@ -136,6 +143,14 @@ describe('data/version', () => {
     const v = detectVersion();
     expect(v.source).toBe('package.json');
     expect(v.version).toBe('5.0.0');
+  });
+
+  it('preserves prerelease from range-prefixed package.json dependency (e.g. "^5.18.0-beta.1")', () => {
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ dependencies: { antd: '^5.18.0-beta.1' } }));
+    const v = detectVersion();
+    expect(v.source).toBe('package.json');
+    expect(v.version).toBe('5.18.0-beta.1');
+    expect(v.majorVersion).toBe('v5');
   });
 
   it('falls back if node_modules/antd has invalid package.json', () => {

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -37,6 +37,37 @@ describe('data/version', () => {
     expect(v.majorVersion).toBe('v5');
   });
 
+  it('preserves prerelease tag in --version flag', () => {
+    const v = detectVersion('5.0.0-beta.1');
+    expect(v.source).toBe('flag');
+    expect(v.version).toBe('5.0.0-beta.1');
+    expect(v.majorVersion).toBe('v5');
+  });
+
+  it('coerces partial version in --version flag (e.g. "5" → "5.0.0")', () => {
+    const v = detectVersion('5');
+    expect(v.source).toBe('flag');
+    expect(v.version).toBe('5.0.0');
+    expect(v.majorVersion).toBe('v5');
+  });
+
+  it('falls back when --version is non-semver (e.g. "*")', () => {
+    const v = detectVersion('*');
+    expect(v.source).toBe('fallback');
+  });
+
+  it('falls back when --version is non-semver (e.g. "workspace:*")', () => {
+    const v = detectVersion('workspace:*');
+    expect(v.source).toBe('fallback');
+  });
+
+  it('emits warning on stderr when --version is non-semver', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    detectVersion('not-a-version');
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Warning'));
+    spy.mockRestore();
+  });
+
   it('returns fallback when no antd info found', () => {
     const v = detectVersion();
     expect(v.source).toBe('fallback');
@@ -71,6 +102,40 @@ describe('data/version', () => {
     const v = detectVersion();
     expect(v.source).toBe('package.json');
     expect(v.version).toBe('5.16.0');
+  });
+
+  it('falls back when package.json has "*" as dependency', () => {
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ dependencies: { antd: '*' } }));
+    const v = detectVersion();
+    expect(v.source).toBe('fallback');
+  });
+
+  it('falls back when package.json has "workspace:*" as dependency', () => {
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ dependencies: { antd: 'workspace:*' } }));
+    const v = detectVersion();
+    expect(v.source).toBe('fallback');
+  });
+
+  it('parses "npm:antd@5.0.0" alias specifier from package.json', () => {
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ dependencies: { antd: 'npm:antd@5.0.0' } }));
+    const v = detectVersion();
+    expect(v.source).toBe('package.json');
+    expect(v.version).toBe('5.0.0');
+    expect(v.majorVersion).toBe('v5');
+  });
+
+  it('coerces version with "||" range from package.json', () => {
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ dependencies: { antd: '>=5.0.0 || >=6.0.0' } }));
+    const v = detectVersion();
+    expect(v.source).toBe('package.json');
+    expect(v.version).toBe('5.0.0');
+  });
+
+  it('coerces bare major version "5" from package.json', () => {
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ dependencies: { antd: '5' } }));
+    const v = detectVersion();
+    expect(v.source).toBe('package.json');
+    expect(v.version).toBe('5.0.0');
   });
 
   it('falls back if node_modules/antd has invalid package.json', () => {

--- a/src/commands/semantic.ts
+++ b/src/commands/semantic.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import type { GlobalOptions, CLIError, SemanticKey } from '../types.js';
+import { localize } from '../types.js';
 import { resolveComponent } from '../data/loader.js';
 import { detectVersion } from '../data/version.js';
 import { createError, printError, ErrorCodes } from '../output/error.js';
@@ -67,7 +68,7 @@ export function registerSemanticCommand(program: Command): void {
       const structure = result.semanticStructure;
       for (let i = 0; i < structure.length; i++) {
         const prefix = i === structure.length - 1 ? '└──' : '├──';
-        console.log(`${prefix} ${structure[i].key}         # ${structure[i].description}`);
+        console.log(`${prefix} ${structure[i].key}         # ${localize(structure[i].description, structure[i].descriptionZh, opts.lang)}`);
       }
       console.log('');
       console.log('Usage:');

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -111,7 +111,9 @@ export function registerUpgradeCommand(program: Command): void {
       }
 
       // Step 2: Compare versions
-      if ((compare(currentVersion, latestVersion) ?? 0) >= 0) {
+      const cmp = compare(currentVersion, latestVersion);
+      // If currentVersion is unparseable (e.g. dev build), proceed with upgrade
+      if (cmp !== null && cmp >= 0) {
         const result: AlreadyUpToDateResult = {
           currentVersion,
           message: localize('Already up to date', '已是最新版本', opts.lang),
@@ -193,7 +195,7 @@ export function registerUpgradeCommand(program: Command): void {
         // Verification failed but upgrade may have succeeded
       }
 
-      if (newVersion && valid(newVersion) && (compare(currentVersion, newVersion) ?? 0) < 0) {
+      if (newVersion && valid(newVersion) && (compare(currentVersion, newVersion) ?? -1) < 0) {
         const result: UpgradeSuccessResult = {
           previousVersion: currentVersion,
           newVersion,

--- a/src/data/version.ts
+++ b/src/data/version.ts
@@ -17,7 +17,7 @@ export function detectVersion(flagVersion?: string): VersionInfo {
   if (flagVersion) {
     // Try parse first to preserve prerelease tags (e.g. "5.0.0-beta.1"),
     // then fall back to coerce for partial versions (e.g. "5" → "5.0.0")
-    const parsed = semver.parse(flagVersion) ?? semver.coerce(flagVersion);
+    const parsed = semver.parse(flagVersion) ?? semver.coerce(flagVersion, { includePrerelease: true });
     if (parsed) {
       return {
         version: parsed.version,
@@ -54,7 +54,7 @@ export function detectVersion(flagVersion?: string): VersionInfo {
       pkg?.dependencies?.antd || pkg?.devDependencies?.antd || pkg?.peerDependencies?.antd;
     if (depVersion) {
       // Try parse first to preserve prerelease, then coerce for partial versions
-      const parsed = semver.parse(depVersion) ?? semver.coerce(depVersion);
+      const parsed = semver.parse(depVersion) ?? semver.coerce(depVersion, { includePrerelease: true });
       if (parsed) {
         return {
           version: parsed.version,
@@ -62,7 +62,8 @@ export function detectVersion(flagVersion?: string): VersionInfo {
           source: 'package.json',
         };
       }
-      // Non-semver specifier (e.g. '*', 'workspace:*', 'npm:antd@5.0.0')
+      // Non-semver specifier (e.g. '*', 'workspace:*')
+      // Note: 'npm:antd@5.0.0' is handled by coerce above, not here
       // Fall through to fallback
     }
   }

--- a/src/data/version.ts
+++ b/src/data/version.ts
@@ -15,11 +15,18 @@ const FALLBACK_MAJOR = 'v5';
 export function detectVersion(flagVersion?: string): VersionInfo {
   // 1. --version flag
   if (flagVersion) {
-    return {
-      version: flagVersion,
-      majorVersion: toMajor(flagVersion),
-      source: 'flag',
-    };
+    // Try parse first to preserve prerelease tags (e.g. "5.0.0-beta.1"),
+    // then fall back to coerce for partial versions (e.g. "5" → "5.0.0")
+    const parsed = semver.parse(flagVersion) ?? semver.coerce(flagVersion);
+    if (parsed) {
+      return {
+        version: parsed.version,
+        majorVersion: `v${parsed.major}`,
+        source: 'flag',
+      };
+    }
+    // Non-semver flag value — fall through with a warning
+    process.stderr.write(`[antd-cli] Warning: --version "${flagVersion}" is not a valid semver version; falling back to auto-detection.\n`);
   }
 
   // 2. node_modules/antd/package.json
@@ -46,12 +53,17 @@ export function detectVersion(flagVersion?: string): VersionInfo {
     const depVersion =
       pkg?.dependencies?.antd || pkg?.devDependencies?.antd || pkg?.peerDependencies?.antd;
     if (depVersion) {
-      const cleaned = depVersion.replace(/[\^~>=<\s]/g, '');
-      return {
-        version: cleaned,
-        majorVersion: toMajor(cleaned),
-        source: 'package.json',
-      };
+      // Try parse first to preserve prerelease, then coerce for partial versions
+      const parsed = semver.parse(depVersion) ?? semver.coerce(depVersion);
+      if (parsed) {
+        return {
+          version: parsed.version,
+          majorVersion: `v${parsed.major}`,
+          source: 'package.json',
+        };
+      }
+      // Non-semver specifier (e.g. '*', 'workspace:*', 'npm:antd@5.0.0')
+      // Fall through to fallback
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the 3 most severe bugs identified in #126 (the other 6 lower-severity items are not included):

- **version.ts**: `detectVersion()` used naive regex stripping for non-semver dependency specifiers (`*`, `workspace:*`, `npm:antd@5.0.0`, ranges with `||`), producing garbage like `v*` that silently returned empty results. Now uses `semver.coerce()` for robust parsing, with fallback to next detection method.
- **upgrade.ts**: `compare()` returning `null` (unparseable currentVersion like `0.0.0-dev`) was treated as "equal" via `?? 0`, causing upgrade to always report "Already up to date". Now treats `null` as "proceed with upgrade".
- **semantic.ts**: The `--lang` flag was completely ignored — always output English descriptions even when `--lang zh` was specified. Now uses `localize()` like all other commands.

## Test plan

- [x] All 443 existing tests pass
- [x] Snapshot for `semantic --lang zh` updated (previously showed English, now correctly shows Chinese)
- [ ] Manual test: project with `"antd": "*"` in package.json no longer returns empty results
- [ ] Manual test: `antd upgrade` with dev build version no longer says "Already up to date"
- [ ] Manual test: `antd semantic Button --lang zh` outputs Chinese descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * semantic 命令的语义结构输出现已支持多语言描述展示

* **Bug 修复**
  * 改进升级命令的版本比较与升级判定逻辑，避免在不可比较版本时误判为“已是最新”
  * 增强版本检测对多种版本格式和预发布标记的解析，并在无法解析时输出警告

* **测试**
  * 补充升级与版本解析相关单元测试，覆盖不可比较版本与多种版本输入场景

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-cli/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->