### PR TITLE
fix: backfill empty props from doc when version snapshots have missing data

### DIFF
--- a/scripts/extract.ts
+++ b/scripts/extract.ts
@@ -131,7 +131,16 @@ function main() {
     changelog: changelog.length > 0 ? changelog : undefined,
   };
 
-  // 6. Output
+  // 6. Validate: components with API docs but no props are likely extraction bugs
+  const suspicious = components.filter(c => c.props.length === 0 && c.doc?.includes('## API'));
+  if (suspicious.length > 0) {
+    console.error(`\nError: ${suspicious.length} component(s) have API docs but no extracted props:`);
+    suspicious.forEach(c => console.error(`  - ${c.name}`));
+    console.error('This usually means the API table header was not recognized. Check the extraction logs above.');
+    process.exit(1);
+  }
+
+  // 7. Output
   const json = JSON.stringify(store, null, 2);
 
   if (output) {

--- a/scripts/extractors/props.ts
+++ b/scripts/extractors/props.ts
@@ -49,12 +49,12 @@ function parseTable(tableText: string, lang: 'en' | 'zh'): PropData[] {
   const typeIdx = headerRow.findIndex((h) => h === 'Type' || h === '类型');
   const defaultIdx = headerRow.findIndex((h) => h === 'Default' || h === '默认值');
   const versionIdx = headerRow.findIndex((h) => h === 'Version' || h === '版本');
-  // "Param" used in some components (e.g. Menu) alongside the standard "Property"
+  // "Param" used in some components (e.g. Menu), "Props" (e.g. Drawer), "Argument" alongside the standard "Property"
   const nameIdx = headerRow.findIndex((h) =>
     h === 'Property' || h === '属性' ||
     h === 'Name' || h === '参数' ||
     h === 'Option' || h === '字段' ||
-    h === 'Param'
+    h === 'Param' || h === 'Props' || h === 'Argument'
   );
 
   if (nameIdx === -1) return props;

--- a/scripts/extractors/props.ts
+++ b/scripts/extractors/props.ts
@@ -38,9 +38,8 @@ function parseDeprecation(name: string): { cleanName: string; deprecated: boolea
 
 /** Parse all props from a single markdown table block */
 function parseTable(tableText: string, lang: 'en' | 'zh'): PropData[] {
-  const props: PropData[] = [];
   const lines = tableText.trim().split('\n');
-  if (lines.length < 3) return props;
+  if (lines.length < 3) return [];
 
   const headerRow = parseTableRow(lines[0]);
   const descIdx = lang === 'zh'
@@ -50,14 +49,33 @@ function parseTable(tableText: string, lang: 'en' | 'zh'): PropData[] {
   const defaultIdx = headerRow.findIndex((h) => h === 'Default' || h === '默认值');
   const versionIdx = headerRow.findIndex((h) => h === 'Version' || h === '版本');
   // "Param" used in some components (e.g. Menu), "Props" (e.g. Drawer), "Argument" alongside the standard "Property"
-  const nameIdx = headerRow.findIndex((h) =>
+  let nameIdx = headerRow.findIndex((h) =>
     h === 'Property' || h === '属性' ||
     h === 'Name' || h === '参数' ||
     h === 'Option' || h === '字段' ||
     h === 'Param' || h === 'Props' || h === 'Argument'
   );
 
-  if (nameIdx === -1) return props;
+  if (nameIdx === -1) {
+    // Fallback: assume first column is the prop name so future antd headers don't silently produce empty props
+    console.warn(`[extract] Unknown API table header: [${headerRow.join(', ')}], using first column as name`);
+    nameIdx = 0;
+  }
+
+  return parseTableRows(lines, lang, nameIdx, descIdx, typeIdx, defaultIdx, versionIdx);
+}
+
+/** Parse table rows given resolved column indices */
+function parseTableRows(
+  lines: string[],
+  lang: 'en' | 'zh',
+  nameIdx: number,
+  descIdx: number,
+  typeIdx: number,
+  defaultIdx: number,
+  versionIdx: number,
+): PropData[] {
+  const props: PropData[] = [];
 
   for (let i = 2; i < lines.length; i++) {
     const row = lines[i];

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -57,6 +57,45 @@ function checkProps(props: PropData[], file: string, component: string, issues: 
   }
 }
 
+/** Check for components with API docs but no extracted props (extraction gap) */
+interface SnapshotIssue {
+  file: string;
+  component: string;
+  rule: string;
+}
+
+function checkEmptyPropsWithApi(files: string[]): SnapshotIssue[] {
+  const issues: SnapshotIssue[] = [];
+  const majorStores = new Map<string, MetadataStore>();
+
+  for (const file of files) {
+    const filePath = path.join(DATA_DIR, file);
+    const store: MetadataStore = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const majorKey = store.majorVersion;
+
+    // Load corresponding major version data for comparison
+    if (!majorStores.has(majorKey) && !file.replace(/\.json$/, '').includes('.')) {
+      majorStores.set(majorKey, store);
+    }
+    const majorStore = majorStores.get(majorKey);
+
+    for (const comp of store.components || []) {
+      if (comp.props.length === 0 && comp.doc?.includes('## API')) {
+        // Check if the major version has props for this component
+        const majorComp = majorStore?.components.find(c => c.name === comp.name);
+        const majorHasProps = majorComp && majorComp.props.length > 0;
+        issues.push({
+          file,
+          component: comp.name,
+          rule: majorHasProps ? 'empty-props-vs-major' : 'empty-props-with-api',
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
 function main() {
   const files = fs.readdirSync(DATA_DIR)
     .filter(f => /^v\d+.*\.json$/.test(f))
@@ -86,14 +125,26 @@ function main() {
   }
 
   const errorRules = ['trailing-backslash', 'html-entity', 'escape-remnant'];
-  const errorCount = issues.filter(i => errorRules.includes(i.rule)).length;
-  const warnCount = issues.length - errorCount;
+  let errorCount = issues.filter(i => errorRules.includes(i.rule)).length;
+  let warnCount = issues.length - errorCount;
 
   if (!quiet) {
     for (const issue of issues) {
       const level = errorRules.includes(issue.rule) ? 'ERROR' : 'WARN';
       console.log(`[${level}] [${issue.rule}] ${issue.file}:${issue.component}.${issue.prop} ${issue.field}=${JSON.stringify(issue.value)}`);
     }
+  }
+
+  // Check for empty props with API docs (extraction gap detection)
+  const snapshotIssues = checkEmptyPropsWithApi(files);
+  for (const si of snapshotIssues) {
+    const level = si.rule === 'empty-props-vs-major' ? 'ERROR' : 'WARN';
+    if (!quiet) {
+      console.log(`[${level}] [${si.rule}] ${si.file}:${si.component} has 0 props but API docs exist${si.rule === 'empty-props-vs-major' ? ' (major version has props)' : ''}`);
+    }
+    ruleCounts.set(si.rule, (ruleCounts.get(si.rule) || 0) + 1);
+    if (si.rule === 'empty-props-vs-major') errorCount++;
+    else warnCount++;
   }
 
   console.log(`\nSummary:`);

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -68,15 +68,21 @@ function checkEmptyPropsWithApi(files: string[]): SnapshotIssue[] {
   const issues: SnapshotIssue[] = [];
   const majorStores = new Map<string, MetadataStore>();
 
+  // Pass 1: load all major version stores first (e.g. v4.json, v5.json, v6.json)
+  // so they're available when checking snapshots
+  for (const file of files) {
+    if (!file.replace(/\.json$/, '').includes('.')) {
+      const filePath = path.join(DATA_DIR, file);
+      const store: MetadataStore = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      majorStores.set(store.majorVersion, store);
+    }
+  }
+
+  // Pass 2: check all files
   for (const file of files) {
     const filePath = path.join(DATA_DIR, file);
     const store: MetadataStore = JSON.parse(fs.readFileSync(filePath, 'utf8'));
     const majorKey = store.majorVersion;
-
-    // Load corresponding major version data for comparison
-    if (!majorStores.has(majorKey) && !file.replace(/\.json$/, '').includes('.')) {
-      majorStores.set(majorKey, store);
-    }
     const majorStore = majorStores.get(majorKey);
 
     for (const comp of store.components || []) {

--- a/src/__tests__/loader-internal.test.ts
+++ b/src/__tests__/loader-internal.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Direct tests for parsePropsFromDoc and backfillFromMajor.
+ *
+ * These test the internal parsing/backfill functions with realistic antd-style
+ * markdown docs, exercising code paths that bundled snapshot data cannot reach.
+ * The functions are exported for testing but are not part of the public CLI API.
+ */
+import { describe, it, expect } from 'vitest';
+import { parsePropsFromDoc, backfillFromMajor } from '../data/loader.js';
+import type { ComponentData, MetadataStore } from '../types.js';
+
+/** Helper to create a minimal ComponentData with doc */
+function withDoc(name: string, doc: string, docZh?: string): ComponentData {
+  return { name, category: 'test', description: '', props: [], doc, docZh } as ComponentData;
+}
+
+describe('parsePropsFromDoc', () => {
+  it('returns null when component has no doc', () => {
+    expect(parsePropsFromDoc({ name: 'X', category: 'test', description: '', props: [] } as ComponentData)).toBeNull();
+  });
+
+  it('returns null when doc has no ## API section', () => {
+    expect(parsePropsFromDoc(withDoc('X', '## Usage\n\nSome notes.'))).toBeNull();
+  });
+
+  it('returns null when API section has no tables', () => {
+    expect(parsePropsFromDoc(withDoc('X', '## API\n\nThis section has no tables, just prose text.\n\n## Design Token\n\nTokens here.'))).toBeNull();
+  });
+
+  it('parses main props from flat API table', () => {
+    const result = parsePropsFromDoc(withDoc('Widget', `## API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| visible | Whether visible | boolean | false |
+| size | Size | string | middle |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.length).toBe(2);
+    expect(result!.props[0].name).toBe('visible');
+    expect(result!.props[0].description).toBe('Whether visible');
+    expect(result!.props[1].name).toBe('size');
+    expect(Object.keys(result!.subComponentProps).length).toBe(0);
+  });
+
+  it('parses Chinese descriptions from docZh', () => {
+    const result = parsePropsFromDoc(withDoc('Widget',
+      `## API\n\n| Property | Description | Type | Default |\n| --- | --- | --- | --- |\n| visible | Whether visible | boolean | false |`,
+      `## API\n\n| 参数 | 说明 | 类型 | 默认值 |\n| --- | --- | --- | --- |\n| visible | 是否可见 | boolean | false |`,
+    ));
+
+    expect(result).not.toBeNull();
+    expect(result!.props[0].descriptionZh).toBe('是否可见');
+  });
+
+  it('parses Version column into since field', () => {
+    const result = parsePropsFromDoc(withDoc('Widget', `## API
+
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| newProp | New prop | string | - | 5.2.0 |
+| oldProp | Old prop | number | 0 | |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.find(p => p.name === 'newProp')!.since).toBe('5.2.0');
+    expect(result!.props.find(p => p.name === 'oldProp')!.since).toBeFalsy();
+  });
+
+  it('parses 版本 (Chinese version) column', () => {
+    const result = parsePropsFromDoc(withDoc('Widget',
+      `## API\n\n| Property | Description | Type | Default |\n| --- | --- | --- | --- |\n| foo | bar | string | - |`,
+      `## API\n\n| 参数 | 说明 | 类型 | 默认值 | 版本 |\n| --- | --- | --- | --- | --- |\n| foo | 中文 | string | - | 4.18.0 |`,
+    ));
+
+    expect(result).not.toBeNull();
+    expect(result!.props[0].descriptionZh).toBe('中文');
+  });
+
+  it('parses deprecated (strikethrough) props', () => {
+    const result = parsePropsFromDoc(withDoc('Widget', `## API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| ~~oldProp~~ | Deprecated | string | - |
+| newProp | Current | number | 0 |`));
+
+    expect(result).not.toBeNull();
+    const old = result!.props.find(p => p.name === 'oldProp');
+    expect(old).toBeDefined();
+    expect(old!.deprecated).toBe(true);
+    expect(result!.props.find(p => p.name === 'newProp')!.deprecated).toBeFalsy();
+  });
+
+  it('recognizes Props column header (Drawer-style)', () => {
+    const result = parsePropsFromDoc(withDoc('Drawer', `## API
+
+| Props | Description | Type | Default |
+| --- | --- | --- | --- |
+| open | Whether open | boolean | false |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props[0].name).toBe('open');
+  });
+
+  it('recognizes Argument column header', () => {
+    const result = parsePropsFromDoc(withDoc('Widget', `## API
+
+| Argument | Description | Type | Default |
+| --- | --- | --- | --- |
+| callback | Callback fn | function | - |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props[0].name).toBe('callback');
+  });
+
+  it('falls back to first column for unknown header', () => {
+    const result = parsePropsFromDoc(withDoc('Widget', `## API
+
+| Field | Description | Type | Default |
+| --- | --- | --- | --- |
+| alpha | First field | string | - |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props[0].name).toBe('alpha');
+  });
+
+  it('skips tables with fewer than 3 lines', () => {
+    const result = parsePropsFromDoc(withDoc('Widget', `## API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |`));
+
+    expect(result).toBeNull();
+  });
+
+  it('stops at terminal sections (## Note)', () => {
+    const result = parsePropsFromDoc(withDoc('Widget', `## API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| visible | Whether visible | boolean | false |
+
+## Note
+
+| Column | Value |
+| --- | --- |
+| note1 | Should NOT be parsed |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.length).toBe(1);
+    expect(result!.props[0].name).toBe('visible');
+  });
+
+  it('stops at Design Token terminal section', () => {
+    const result = parsePropsFromDoc(withDoc('Widget', `## API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| color | Token color | string | blue |
+
+## Design Token
+
+| Token | Value |
+| --- | --- |
+| --widget-color | #1890ff |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.length).toBe(1);
+  });
+
+  it('separates sub-component ### sections: slash format is main', () => {
+    const result = parsePropsFromDoc(withDoc('Radio', `## API
+
+### Radio/Radio.Button
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| checked | Whether checked | boolean | false |
+
+### Radio.Group
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| size | Size | string | - |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.some(p => p.name === 'checked')).toBe(true);
+    expect(result!.subComponentProps['Radio.Group']).toBeDefined();
+    expect(result!.subComponentProps['Radio.Group'].some(p => p.name === 'size')).toBe(true);
+  });
+
+  it('uses dot-prefixed label as-is for subComponentProps', () => {
+    const result = parsePropsFromDoc(withDoc('ConfigProvider', `## API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| locale | Locale | object | - |
+
+### ConfigProvider.useConfig()
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| componentConfig | Config | object | - |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.some(p => p.name === 'locale')).toBe(true);
+    const keys = Object.keys(result!.subComponentProps);
+    expect(keys.some(k => k.includes('useConfig'))).toBe(true);
+  });
+
+  it('prepends component name to non-dotted sub-section labels', () => {
+    const result = parsePropsFromDoc(withDoc('Wizard', `## API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| active | Active step | number | 0 |
+
+### Step
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| title | Step title | string | - |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.some(p => p.name === 'active')).toBe(true);
+    expect(result!.subComponentProps['Wizard.Step']).toBeDefined();
+  });
+
+  it('recognizes "common API" as main section', () => {
+    const result = parsePropsFromDoc(withDoc('FloatButton', `## API
+
+### common API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| type | Button type | string | default |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.some(p => p.name === 'type')).toBe(true);
+    expect(Object.keys(result!.subComponentProps).length).toBe(0);
+  });
+
+  it('recognizes prefix match (Tree props for TreeSelect)', () => {
+    const result = parsePropsFromDoc(withDoc('TreeSelect', `## API
+
+### Tree props
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| treeData | Tree data | array | - |
+
+### TreeSelect props
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| value | Selected value | string | - |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.some(p => p.name === 'treeData')).toBe(true);
+    expect(result!.props.some(p => p.name === 'value')).toBe(true);
+  });
+
+  it('recognizes singular/plural name (Mention for Mentions)', () => {
+    const result = parsePropsFromDoc(withDoc('Mentions', `## API
+
+### Mention
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| prefix | Prefix char | string | @ |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.some(p => p.name === 'prefix')).toBe(true);
+  });
+
+  it('strips Badge text and anchors from headings via cleanLabel', () => {
+    const result = parsePropsFromDoc(withDoc('Avatar', `## API
+
+### Avatar.Group <Badge>4.5.0+</Badge>
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| gap | Gap | number | - |
+
+### Avatar {#avatar-anchor}
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| shape | Shape | string | circle |`));
+
+    expect(result).not.toBeNull();
+    // "Avatar.Group" (after Badge stripped) is not a slash format, so it's a sub-component.
+    // "Avatar" (after anchor stripped) matches the component name exactly, so it's main.
+    expect(result!.props.some(p => p.name === 'shape')).toBe(true);
+    expect(result!.subComponentProps).toBeDefined();
+    // "Avatar.Group" goes to subComponentProps since it doesn't match any isMainSection rule
+    expect(Object.keys(result!.subComponentProps).some(k => k.includes('Avatar.Group'))).toBe(true);
+  });
+
+  it('handles h2 sub-sections as non-main subComponentProps', () => {
+    const result = parsePropsFromDoc(withDoc('DatePicker', `## API
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| value | Current value | Dayjs | - |
+
+## Methods
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| focus | Focus input | () => void | - |`));
+
+    expect(result).not.toBeNull();
+    expect(result!.props.some(p => p.name === 'value')).toBe(true);
+    expect(result!.subComponentProps['DatePicker.Methods']).toBeDefined();
+  });
+});
+
+describe('backfillFromMajor', () => {
+  it('copies props and subComponentProps from major version', () => {
+    const comp: ComponentData = { name: 'TestComp', category: 'test', description: '', props: [] };
+    const majorStore: MetadataStore = {
+      version: '5', majorVersion: 'v5',
+      components: [{
+        name: 'TestComp', category: 'test', description: 'Test', descriptionZh: '测试',
+        props: [{ name: 'alpha', type: 'string', default: '-' }],
+        subComponentProps: { 'TestComp.Sub': [{ name: 'beta', type: 'number', default: '0' }] },
+      }],
+    };
+
+    backfillFromMajor(comp, majorStore);
+    expect(comp.props.length).toBe(1);
+    expect(comp.props[0].name).toBe('alpha');
+    expect(comp.description).toBe('Test');
+    expect(comp.descriptionZh).toBe('测试');
+    expect(comp.subComponentProps).toBeDefined();
+    expect('TestComp.Sub' in comp.subComponentProps!).toBe(true);
+    // Shallow copy: arrays are independent
+    expect(comp.subComponentProps!['TestComp.Sub']).not.toBe(
+      majorStore.components[0].subComponentProps!['TestComp.Sub'],
+    );
+  });
+
+  it('does not overwrite existing props', () => {
+    const comp: ComponentData = {
+      name: 'TestComp', category: 'test', description: '',
+      props: [{ name: 'existing', type: 'string', default: '-' }],
+    };
+    const majorStore: MetadataStore = {
+      version: '5', majorVersion: 'v5',
+      components: [{ name: 'TestComp', category: 'test', description: 'Major', props: [{ name: 'alpha', type: 'string', default: '-' }] }],
+    };
+
+    backfillFromMajor(comp, majorStore);
+    expect(comp.props.length).toBe(1);
+    expect(comp.props[0].name).toBe('existing');
+    expect(comp.description).toBe('Major'); // description backfilled
+  });
+
+  it('does not overwrite existing description or descriptionZh', () => {
+    const comp: ComponentData = {
+      name: 'TestComp', category: 'test',
+      description: 'Existing', descriptionZh: '现有',
+      props: [],
+    };
+    const majorStore: MetadataStore = {
+      version: '5', majorVersion: 'v5',
+      components: [{ name: 'TestComp', category: 'test', description: 'Major', descriptionZh: '主要', props: [{ name: 'x', type: 'string', default: '-' }] }],
+    };
+
+    backfillFromMajor(comp, majorStore);
+    expect(comp.description).toBe('Existing');
+    expect(comp.descriptionZh).toBe('现有');
+  });
+
+  it('backfills descriptionZh independently when description exists', () => {
+    const comp: ComponentData = {
+      name: 'TestComp', category: 'test',
+      description: 'Existing', descriptionZh: '',
+      props: [{ name: 'x', type: 'string', default: '-' }],
+    };
+    const majorStore: MetadataStore = {
+      version: '5', majorVersion: 'v5',
+      components: [{ name: 'TestComp', category: 'test', description: 'Major', descriptionZh: '主要', props: [] }],
+    };
+
+    backfillFromMajor(comp, majorStore);
+    expect(comp.description).toBe('Existing');
+    expect(comp.descriptionZh).toBe('主要');
+  });
+
+  it('does nothing when major store has no matching component', () => {
+    const comp: ComponentData = { name: 'Nonexistent', category: 'test', description: '', props: [] };
+    const majorStore: MetadataStore = {
+      version: '5', majorVersion: 'v5',
+      components: [{ name: 'Other', category: 'test', description: 'Other', props: [{ name: 'x', type: 'string', default: '-' }] }],
+    };
+
+    backfillFromMajor(comp, majorStore);
+    expect(comp.props.length).toBe(0);
+    expect(comp.description).toBe('');
+  });
+});

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -260,6 +260,43 @@ describe('data/loader', () => {
     }
   });
 
+  it('resolveComponent backfills props from doc when snapshot has empty props', () => {
+    // Popconfirm in v5.0.x snapshots has 0 props but doc has API tables
+    const result = resolveComponent('Popconfirm', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+      expect(result.comp.props.some((p) => p.name === 'title')).toBe(true);
+    }
+  });
+
+  it('resolveComponent backfills description from major version when snapshot has empty description', () => {
+    // Popconfirm in v5.0.x snapshots has empty description, v5.json has it
+    const result = resolveComponent('Popconfirm', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent backfills props for Drawer (Props column header)', () => {
+    // Drawer uses "Props" as the API table header instead of "Property"
+    const result = resolveComponent('Drawer', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent does not overwrite non-empty snapshot props', () => {
+    // Button should have its own props already, backfill should not change them
+    const result = resolveComponent('Button', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+    }
+  });
+
   it('falls back to loadMetadata when versions.json cannot be read', () => {
     // First call: returns null (simulating unreadable versions.json)
     // Subsequent calls (loadMetadata reads no JSON files, only readDataFile) — but

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -316,8 +316,8 @@ describe('data/loader', () => {
     }
   });
 
-  it('resolveComponent does not load major store when snapshot has all data', () => {
-    // Button in v5.0.0 has props and description — no need for major store
+  it('resolveComponent returns complete data for snapshot with all fields', () => {
+    // Button in v5.0.0 has props and description — verify data completeness
     const result = resolveComponent('Button', '5.0.0');
     expect('error' in result).toBe(false);
     if (!('error' in result)) {
@@ -349,6 +349,12 @@ describe('data/loader', () => {
     // Select has Option sub-component with props
     if (!('error' in result)) {
       expect(result.comp.props.length).toBeGreaterThan(0);
+      // Select doc has "Select props" heading (main) and separate sub-sections
+      // Verify subComponentProps exist from doc backfill
+      if (result.comp.subComponentProps) {
+        const keys = Object.keys(result.comp.subComponentProps);
+        expect(keys.length).toBeGreaterThan(0);
+      }
     }
   });
 

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -297,6 +297,192 @@ describe('data/loader', () => {
     }
   });
 
+  it('resolveComponent backfills descriptionZh independently from description', () => {
+    // Ensure Chinese description is backfilled even if English description exists
+    const result = resolveComponent('Popconfirm', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      // Popconfirm snapshot has empty descriptionZh, major version has it
+      expect(result.comp.descriptionZh.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent backfills props from major version when doc has no API section', () => {
+    // Some components may have empty props and no ## API in doc — fall back to major
+    const result = resolveComponent('Popover', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent does not load major store when snapshot has all data', () => {
+    // Button in v5.0.0 has props and description — no need for major store
+    const result = resolveComponent('Button', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      // Verify it still has complete data
+      expect(result.comp.props.length).toBeGreaterThan(0);
+      expect(result.comp.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('backfillFromMajor uses shallow copy to avoid shared references', () => {
+    // Popconfirm in snapshot has empty props — backfilled from major should not share array
+    const result = resolveComponent('Popconfirm', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      const props1 = result.comp.props;
+      // Resolving same component from major version should return different array
+      const major = resolveComponent('Popconfirm', '5');
+      if (!('error' in major)) {
+        // If both routes return data, arrays should be independent
+        expect(props1).not.toBe(major.comp.props);
+      }
+    }
+  });
+
+  it('resolveComponent handles components with sub-component props in doc', () => {
+    // Check that subComponentProps are extracted from doc when present
+    const result = resolveComponent('Select', '5.0.0');
+    expect('error' in result).toBe(false);
+    // Select has Option sub-component with props
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent populates since field from doc API table version column', () => {
+    // Popconfirm's doc has a "Version" / "版本" column in its API table
+    const result = resolveComponent('Popconfirm', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      const withSince = result.comp.props.filter((p) => p.since);
+      expect(withSince.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent parses Chinese descriptions from docZh', () => {
+    // Popconfirm snapshot has empty descriptionZh; doc backfill parses docZh
+    const result = resolveComponent('Popconfirm', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      // At least some props should have Chinese descriptions from docZh parsing
+      const withZhDesc = result.comp.props.filter((p) => p.descriptionZh && p.descriptionZh.length > 0);
+      expect(withZhDesc.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent populates subComponentProps from major version extraction', () => {
+    // Major version files have subComponentProps extracted at build time
+    const result = resolveComponent('Input', '5');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      // Input has TextArea, Search, Password, OTP sub-components
+      expect(result.comp.props.length).toBeGreaterThan(0);
+      expect(result.comp.subComponentProps).toBeDefined();
+      const keys = Object.keys(result.comp.subComponentProps!);
+      expect(keys.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent preserves deprecated props from extraction', () => {
+    // AutoComplete in v5.json has deprecated props with ~~strikethrough~~
+    const result = resolveComponent('AutoComplete', '5');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      const deprecated = result.comp.props.filter((p) => p.deprecated);
+      expect(deprecated.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent handles terminal sections in API doc', () => {
+    // Popconfirm doc has "## Note" after "## API" which terminates the API section
+    const result = resolveComponent('Popconfirm', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      // Should still have props parsed from the API section before "## Note"
+      expect(result.comp.props.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent handles Popover with empty snapshot props', () => {
+    // Popover in v5.0.x snapshot has empty props, should be backfilled from doc
+    const result = resolveComponent('Popover', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+      expect(result.comp.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent backfills descriptionZh from major version', () => {
+    // Popover snapshot has empty description and descriptionZh; doc + major backfill should fill them
+    const result = resolveComponent('Popover', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.descriptionZh!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent handles major version request without snapshot', () => {
+    // Requesting just "5" uses the major version file directly
+    const result = resolveComponent('Button', '5');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent doc backfill parses Chinese API table with 版本 column', () => {
+    // Popconfirm Chinese doc has "版本" (version) column header
+    const result = resolveComponent('Popconfirm', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      const sinceProps = result.comp.props.filter((p) => p.since);
+      // Chinese "版本" is mapped to versionIdx, so since should be populated from both langs
+      expect(sinceProps.length).toBeGreaterThan(0);
+      // Also verify Chinese descriptions are merged correctly
+      const okButton = result.comp.props.find((p) => p.name === 'okText');
+      if (okButton) {
+        expect(okButton.description).toBeTruthy();
+        expect(okButton.descriptionZh).toBeTruthy();
+      }
+    }
+  });
+
+  it('resolveComponent with Drawer uses Props column header from doc', () => {
+    // Drawer's API table uses "Props" as the name column header instead of "Property"
+    const result = resolveComponent('Drawer', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolveComponent does not backfill doc when major version already has data', () => {
+    // Button in v5.20.0 has complete props from extraction; doc backfill should be skipped
+    const result = resolveComponent('Button', '5.20.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.props.length).toBeGreaterThan(0);
+      // Button's props should match the extraction data, not be duplicated from doc
+      const propNames = result.comp.props.map((p) => p.name);
+      const uniqueNames = new Set(propNames);
+      expect(propNames.length).toBe(uniqueNames.size);
+    }
+  });
+
+  it('resolveComponent backfills both english and chinese descriptions independently', () => {
+    // Test that description and descriptionZh are backfilled from different sources independently
+    const result = resolveComponent('Popover', '5.0.0');
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.comp.description!.length).toBeGreaterThan(0);
+      expect(result.comp.descriptionZh!.length).toBeGreaterThan(0);
+    }
+  });
+
   it('falls back to loadMetadata when versions.json cannot be read', () => {
     // First call: returns null (simulating unreadable versions.json)
     // Subsequent calls (loadMetadata reads no JSON files, only readDataFile) — but

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -201,8 +201,24 @@ function parseTableProps(tableText: string, lang: 'en' | 'zh'): PropData[] {
     h === 'Property' || h === '属性' || h === 'Name' || h === '参数' || h === 'Option' || h === '字段' || h === 'Param' || h === 'Props' || h === 'Argument',
   );
 
-  if (nameIdx === -1) return [];
+  if (nameIdx === -1) {
+    // Fallback: assume first column is the prop name (matches extraction script behavior)
+    return parseTablePropsRows(lines, lang, 0, descIdx, typeIdx, defaultIdx, versionIdx);
+  }
 
+  return parseTablePropsRows(lines, lang, nameIdx, descIdx, typeIdx, defaultIdx, versionIdx);
+}
+
+/** Parse table rows given resolved column indices. */
+function parseTablePropsRows(
+  lines: string[],
+  lang: 'en' | 'zh',
+  nameIdx: number,
+  descIdx: number,
+  typeIdx: number,
+  defaultIdx: number,
+  versionIdx: number,
+): PropData[] {
   const props: PropData[] = [];
   for (let i = 2; i < lines.length; i++) {
     if (!lines[i].trim()) continue;
@@ -388,18 +404,21 @@ function backfillComponent(comp: ComponentData, majorStore: MetadataStore | null
 
   // 2. If still empty and major version data is available, fall back to major
   if (comp.props.length === 0 && majorStore) {
-    const majorComp = majorStore.components.find((c) => c.name === comp.name);
+    const majorComp = findComponent(majorStore, comp.name);
     if (majorComp && majorComp.props.length > 0) {
-      comp.props = majorComp.props;
+      comp.props = [...majorComp.props];
       if (!comp.subComponentProps && majorComp.subComponentProps) {
-        comp.subComponentProps = majorComp.subComponentProps;
+        comp.subComponentProps = { ...majorComp.subComponentProps };
+        for (const key of Object.keys(comp.subComponentProps)) {
+          comp.subComponentProps[key] = [...majorComp.subComponentProps[key]];
+        }
       }
     }
   }
 
   // 3. Backfill description from major if empty
   if (!comp.description && majorStore) {
-    const majorComp = majorStore.components.find((c) => c.name === comp.name);
+    const majorComp = findComponent(majorStore, comp.name);
     if (majorComp?.description) comp.description = majorComp.description;
     if (!comp.descriptionZh && majorComp?.descriptionZh) comp.descriptionZh = majorComp.descriptionZh;
   }
@@ -426,10 +445,14 @@ export function resolveComponent(
   }
 
   // Backfill empty fields from doc and/or major version data
+  // A "snapshot" is a version-specific file (e.g. v5.0.7.json), as opposed to
+  // the major-version aggregation file (v5.json). We detect this by checking
+  // whether the requested version includes a minor version number.
   const majorVersion = `v${version.split('.')[0]}`;
-  const isSnapshot = store.version !== majorVersion.slice(1);
-  if (isSnapshot || comp.props.length === 0 || !comp.description) {
-    const majorStore = isSnapshot ? loadMetadata(majorVersion) : null;
+  const parts = version.split('.');
+  const requestedSnapshot = parts.length > 1;
+  if (requestedSnapshot || comp.props.length === 0 || !comp.description) {
+    const majorStore = requestedSnapshot ? loadMetadata(majorVersion) : null;
     backfillComponent(comp, majorStore);
   }
 

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -283,8 +283,10 @@ function isMainSection(label: string, componentName: string): boolean {
 /**
  * Parse props from the `doc`/`docZh` markdown fields of a component.
  * Returns { props, subComponentProps } or null if no API section found.
+ *
+ * Exported for testing. Not part of the public CLI API.
  */
-function parsePropsFromDoc(comp: ComponentData): { props: PropData[]; subComponentProps: Record<string, PropData[]> } | null {
+export function parsePropsFromDoc(comp: ComponentData): { props: PropData[]; subComponentProps: Record<string, PropData[]> } | null {
   if (!comp.doc) return null;
 
   const apiMatch = comp.doc.match(/^## API\b/m);
@@ -388,8 +390,14 @@ function parsePropsFromDoc(comp: ComponentData): { props: PropData[]; subCompone
 /**
  * Backfill a component's empty fields from the major-version data.
  * Called only when doc-based backfill was insufficient.
+ *
+ * ⚠️ Mutates `comp` in place — the component object comes from metadataCache,
+ * so this intentionally updates cached data. The mutation is idempotent
+ * (only fills empty props/description/subComponentProps).
+ *
+ * Exported for testing. Not part of the public CLI API.
  */
-function backfillFromMajor(comp: ComponentData, majorStore: MetadataStore): void {
+export function backfillFromMajor(comp: ComponentData, majorStore: MetadataStore): void {
   const majorComp = findComponent(majorStore, comp.name);
   if (!majorComp) return;
 
@@ -434,12 +442,7 @@ export function resolveComponent(
   }
 
   // Backfill empty fields from doc and/or major version data
-  // A "snapshot" is a version-specific file (e.g. v5.0.7.json), as opposed to
-  // the major-version aggregation file (v5.json). We detect this by checking
-  // whether the requested version includes a minor version number.
   const majorVersion = `v${version.split('.')[0]}`;
-  const parts = version.split('.');
-  const requestedSnapshot = parts.length > 1;
 
   // 1. Try to backfill props from the component's own doc (no disk I/O)
   if (comp.props.length === 0 && comp.doc) {
@@ -454,7 +457,7 @@ export function resolveComponent(
 
   // 2. Only load major store if props or localized descriptions are still missing
   const needsMajorBackfill = comp.props.length === 0 || !comp.description || !comp.descriptionZh;
-  if ((requestedSnapshot || needsMajorBackfill) && needsMajorBackfill) {
+  if (needsMajorBackfill) {
     const majorStore = loadMetadata(majorVersion);
     backfillFromMajor(comp, majorStore);
   }

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -313,8 +313,8 @@ function parsePropsFromDoc(comp: ComponentData): { props: PropData[]; subCompone
         : cleanLabel(h3Match[1].trim());
 
       let m: RegExpExecArray | null;
-      const localRegex = new RegExp(tableRegex.source, 'g');
-      while ((m = localRegex.exec(part)) !== null) {
+      tableRegex.lastIndex = 0;
+      while ((m = tableRegex.exec(part)) !== null) {
         const parsed = parseTableProps(m[0], 'en');
         if (parsed.length > 0) {
           const existing = enSections.get(sectionLabel) || [];
@@ -347,8 +347,8 @@ function parsePropsFromDoc(comp: ComponentData): { props: PropData[]; subCompone
             : cleanLabel(h3Match[1].trim());
 
           let m: RegExpExecArray | null;
-          const localRegex = new RegExp(tableRegex.source, 'g');
-          while ((m = localRegex.exec(part)) !== null) {
+          tableRegex.lastIndex = 0;
+          while ((m = tableRegex.exec(part)) !== null) {
             const parsed = parseTableProps(m[0], 'zh');
             if (parsed.length > 0) {
               const existing = zhSections.get(sectionLabel) || [];
@@ -386,41 +386,30 @@ function parsePropsFromDoc(comp: ComponentData): { props: PropData[]; subCompone
 }
 
 /**
- * Backfill a component's empty fields from its own doc markdown and from the
- * major-version data. Version snapshots sometimes have missing props when the
- * extraction script failed to parse a component's API table.
+ * Backfill a component's empty fields from the major-version data.
+ * Called only when doc-based backfill was insufficient.
  */
-function backfillComponent(comp: ComponentData, majorStore: MetadataStore | null): void {
-  // 1. If props is empty but doc contains an API section, parse props from doc
-  if (comp.props.length === 0 && comp.doc) {
-    const parsed = parsePropsFromDoc(comp);
-    if (parsed && parsed.props.length > 0) {
-      comp.props = parsed.props;
-      if (Object.keys(parsed.subComponentProps).length > 0 && !comp.subComponentProps) {
-        comp.subComponentProps = parsed.subComponentProps;
+function backfillFromMajor(comp: ComponentData, majorStore: MetadataStore): void {
+  const majorComp = findComponent(majorStore, comp.name);
+  if (!majorComp) return;
+
+  // 1. If still empty after doc parsing, fall back to major version props
+  if (comp.props.length === 0 && majorComp.props.length > 0) {
+    comp.props = [...majorComp.props];
+    if (!comp.subComponentProps && majorComp.subComponentProps) {
+      comp.subComponentProps = { ...majorComp.subComponentProps };
+      for (const key of Object.keys(comp.subComponentProps)) {
+        comp.subComponentProps[key] = [...majorComp.subComponentProps[key]];
       }
     }
   }
 
-  // 2. If still empty and major version data is available, fall back to major
-  if (comp.props.length === 0 && majorStore) {
-    const majorComp = findComponent(majorStore, comp.name);
-    if (majorComp && majorComp.props.length > 0) {
-      comp.props = [...majorComp.props];
-      if (!comp.subComponentProps && majorComp.subComponentProps) {
-        comp.subComponentProps = { ...majorComp.subComponentProps };
-        for (const key of Object.keys(comp.subComponentProps)) {
-          comp.subComponentProps[key] = [...majorComp.subComponentProps[key]];
-        }
-      }
-    }
+  // 2. Backfill descriptions independently (en may exist without zh)
+  if (!comp.description && majorComp.description) {
+    comp.description = majorComp.description;
   }
-
-  // 3. Backfill description from major if empty
-  if (!comp.description && majorStore) {
-    const majorComp = findComponent(majorStore, comp.name);
-    if (majorComp?.description) comp.description = majorComp.description;
-    if (!comp.descriptionZh && majorComp?.descriptionZh) comp.descriptionZh = majorComp.descriptionZh;
+  if (!comp.descriptionZh && majorComp.descriptionZh) {
+    comp.descriptionZh = majorComp.descriptionZh;
   }
 }
 
@@ -451,9 +440,23 @@ export function resolveComponent(
   const majorVersion = `v${version.split('.')[0]}`;
   const parts = version.split('.');
   const requestedSnapshot = parts.length > 1;
-  if (requestedSnapshot || comp.props.length === 0 || !comp.description) {
-    const majorStore = requestedSnapshot ? loadMetadata(majorVersion) : null;
-    backfillComponent(comp, majorStore);
+
+  // 1. Try to backfill props from the component's own doc (no disk I/O)
+  if (comp.props.length === 0 && comp.doc) {
+    const parsed = parsePropsFromDoc(comp);
+    if (parsed && parsed.props.length > 0) {
+      comp.props = parsed.props;
+      if (Object.keys(parsed.subComponentProps).length > 0 && !comp.subComponentProps) {
+        comp.subComponentProps = parsed.subComponentProps;
+      }
+    }
+  }
+
+  // 2. Only load major store if props or localized descriptions are still missing
+  const needsMajorBackfill = comp.props.length === 0 || !comp.description || !comp.descriptionZh;
+  if ((requestedSnapshot || needsMajorBackfill) && needsMajorBackfill) {
+    const majorStore = loadMetadata(majorVersion);
+    backfillFromMajor(comp, majorStore);
   }
 
   return { store, comp };

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { gunzipSync } from 'node:zlib';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { MetadataStore, ComponentData, CLIError } from '../types.js';
+import type { MetadataStore, ComponentData, PropData, CLIError } from '../types.js';
 import { createError, fuzzyMatch, ErrorCodes } from '../output/error.js';
 import { readJson } from '../utils/json.js';
 
@@ -158,6 +158,253 @@ export function getAllComponentNames(store: MetadataStore): string[] {
   return store.components.map((c) => c.name);
 }
 
+// ---------------------------------------------------------------------------
+// Runtime backfill: parse props from doc markdown when snapshot data is empty
+// ---------------------------------------------------------------------------
+
+/** Parse a markdown table row into cells, handling escaped pipes. */
+function parseTableRow(row: string): string[] {
+  const PIPE = '\x00PIPE\x00';
+  return row
+    .replace(/\\\|/g, PIPE)
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) =>
+      cell
+        .trim()
+        .replace(new RegExp(PIPE, 'g'), '|')
+        .replace(/\\\[/g, '[')
+        .replace(/\\\]/g, ']')
+        .replace(/\\</g, '<')
+        .replace(/\\>/g, '>')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&amp;/g, '&'),
+    );
+}
+
+/** Parse props from a single markdown API table. */
+function parseTableProps(tableText: string, lang: 'en' | 'zh'): PropData[] {
+  const lines = tableText.trim().split('\n');
+  if (lines.length < 3) return [];
+
+  const header = parseTableRow(lines[0]);
+  const descIdx =
+    lang === 'zh'
+      ? header.findIndex((h) => h === '说明' || h === '描述')
+      : header.findIndex((h) => h === 'Description');
+  const typeIdx = header.findIndex((h) => h === 'Type' || h === '类型');
+  const defaultIdx = header.findIndex((h) => h === 'Default' || h === '默认值');
+  const versionIdx = header.findIndex((h) => h === 'Version' || h === '版本');
+  const nameIdx = header.findIndex((h) =>
+    h === 'Property' || h === '属性' || h === 'Name' || h === '参数' || h === 'Option' || h === '字段' || h === 'Param' || h === 'Props' || h === 'Argument',
+  );
+
+  if (nameIdx === -1) return [];
+
+  const props: PropData[] = [];
+  for (let i = 2; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    const cells = parseTableRow(lines[i]);
+    const rawName = cells[nameIdx] || '';
+    const strikethrough = rawName.match(/^~~(.+?)~~$/);
+    const cleanName = strikethrough ? strikethrough[1] : rawName;
+    if (!cleanName) continue;
+
+    const prop: PropData = {
+      name: cleanName,
+      type: cells[typeIdx] || '',
+      default: cells[defaultIdx] || '-',
+    };
+
+    const desc = descIdx >= 0 ? cells[descIdx] : '';
+    if (lang === 'zh') {
+      prop.descriptionZh = desc;
+    } else {
+      prop.description = desc;
+    }
+
+    if (versionIdx >= 0 && cells[versionIdx]) prop.since = cells[versionIdx];
+    if (strikethrough) prop.deprecated = true;
+
+    props.push(prop);
+  }
+  return props;
+}
+
+/**
+ * Strip heading noise like "<Badge>4.5.0+</Badge>" and "{#anchor}".
+ */
+function cleanLabel(raw: string): string {
+  return raw
+    .replace(/<Badge>[^<]*<\/Badge>/gi, '')
+    .replace(/\{#[^}]+\}/g, '')
+    .trim();
+}
+
+/**
+ * Determine whether a heading represents the main component's props.
+ */
+function isMainSection(label: string, componentName: string): boolean {
+  if (label === '__main__') return true;
+  const lcLabel = label.toLowerCase();
+  const lcName = componentName.toLowerCase();
+  if (lcLabel === lcName) return true;
+
+  const lcBase = lcLabel
+    .replace(/\s+(props?|api|options?|config(?:uration)?|ref|methods?|types?)$/, '')
+    .trim();
+  if (lcBase === lcName) return true;
+  if (lcBase.length >= 4 && lcName.startsWith(lcBase)) return true;
+  if (lcName.startsWith(lcLabel) && lcLabel.length >= lcName.length - 2) return true;
+  if (lcLabel.startsWith(lcName + '/')) return true;
+  if (/^common\s+(api|props?|options?)$/i.test(label)) return true;
+
+  return false;
+}
+
+/**
+ * Parse props from the `doc`/`docZh` markdown fields of a component.
+ * Returns { props, subComponentProps } or null if no API section found.
+ */
+function parsePropsFromDoc(comp: ComponentData): { props: PropData[]; subComponentProps: Record<string, PropData[]> } | null {
+  if (!comp.doc) return null;
+
+  const apiMatch = comp.doc.match(/^## API\b/m);
+  if (!apiMatch || apiMatch.index === undefined) return null;
+
+  const afterApi = comp.doc.slice(apiMatch.index);
+  const terminalRe = /^## (?:Design Token|FAQ|Note|Examples?|When To Use|When to use|Best Practices?|Semantic DOM)\b/im;
+  const terminalMatch = afterApi.match(terminalRe);
+  const apiBlock = terminalMatch?.index !== undefined ? afterApi.slice(0, terminalMatch.index) : afterApi;
+
+  // Parse English props
+  const enSections = new Map<string, PropData[]>();
+  const tableRegex = /\|(.+)\|\n\|[\s:|-]+\|\n((?:\|.+\|\n?)*)/g;
+  const h2Chunks = apiBlock.split(/^(?=## )/m).filter(Boolean);
+
+  for (const chunk of h2Chunks) {
+    const h2Match = chunk.match(/^## (.+)$/m);
+    const rawH2 = h2Match ? h2Match[1].trim() : 'API';
+    const h2Label = rawH2 === 'API' ? '__api_root__' : cleanLabel(rawH2);
+    const h3Parts = chunk.split(/^(?=### )/m);
+
+    for (const part of h3Parts) {
+      const h3Match = part.match(/^### (.+)$/m);
+      const sectionLabel = !h3Match
+        ? h2Label === '__api_root__' ? '__main__' : h2Label
+        : cleanLabel(h3Match[1].trim());
+
+      let m: RegExpExecArray | null;
+      const localRegex = new RegExp(tableRegex.source, 'g');
+      while ((m = localRegex.exec(part)) !== null) {
+        const parsed = parseTableProps(m[0], 'en');
+        if (parsed.length > 0) {
+          const existing = enSections.get(sectionLabel) || [];
+          enSections.set(sectionLabel, [...existing, ...parsed]);
+        }
+      }
+    }
+  }
+
+  // Parse Chinese props
+  const zhSections = new Map<string, PropData[]>();
+  if (comp.docZh) {
+    const zhApiMatch = comp.docZh.match(/^## API\b/m);
+    if (zhApiMatch?.index !== undefined) {
+      const zhAfterApi = comp.docZh.slice(zhApiMatch.index);
+      const zhTerminal = zhAfterApi.match(terminalRe);
+      const zhBlock = zhTerminal?.index !== undefined ? zhAfterApi.slice(0, zhTerminal.index) : zhAfterApi;
+      const zhH2Chunks = zhBlock.split(/^(?=## )/m).filter(Boolean);
+
+      for (const chunk of zhH2Chunks) {
+        const h2Match = chunk.match(/^## (.+)$/m);
+        const rawH2 = h2Match ? h2Match[1].trim() : 'API';
+        const h2Label = rawH2 === 'API' ? '__api_root__' : cleanLabel(rawH2);
+        const h3Parts = chunk.split(/^(?=### )/m);
+
+        for (const part of h3Parts) {
+          const h3Match = part.match(/^### (.+)$/m);
+          const sectionLabel = !h3Match
+            ? h2Label === '__api_root__' ? '__main__' : h2Label
+            : cleanLabel(h3Match[1].trim());
+
+          let m: RegExpExecArray | null;
+          const localRegex = new RegExp(tableRegex.source, 'g');
+          while ((m = localRegex.exec(part)) !== null) {
+            const parsed = parseTableProps(m[0], 'zh');
+            if (parsed.length > 0) {
+              const existing = zhSections.get(sectionLabel) || [];
+              zhSections.set(sectionLabel, [...existing, ...parsed]);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (enSections.size === 0) return null;
+
+  // Merge English + Chinese and separate main / sub-component
+  const props: PropData[] = [];
+  const subComponentProps: Record<string, PropData[]> = {};
+
+  for (const [label, enProps] of enSections) {
+    const zhProps = zhSections.get(label) || [];
+    const zhMap = new Map(zhProps.map((p) => [p.name, p]));
+    const merged = enProps.map((enProp) => ({
+      ...enProp,
+      descriptionZh: zhMap.get(enProp.name)?.descriptionZh || zhMap.get(enProp.name)?.description || '',
+    }));
+
+    if (isMainSection(label, comp.name)) {
+      props.push(...merged);
+    } else {
+      const fullName = label.includes('.') ? label : `${comp.name}.${label}`;
+      subComponentProps[fullName] = [...(subComponentProps[fullName] || []), ...merged];
+    }
+  }
+
+  return { props, subComponentProps };
+}
+
+/**
+ * Backfill a component's empty fields from its own doc markdown and from the
+ * major-version data. Version snapshots sometimes have missing props when the
+ * extraction script failed to parse a component's API table.
+ */
+function backfillComponent(comp: ComponentData, majorStore: MetadataStore | null): void {
+  // 1. If props is empty but doc contains an API section, parse props from doc
+  if (comp.props.length === 0 && comp.doc) {
+    const parsed = parsePropsFromDoc(comp);
+    if (parsed && parsed.props.length > 0) {
+      comp.props = parsed.props;
+      if (Object.keys(parsed.subComponentProps).length > 0 && !comp.subComponentProps) {
+        comp.subComponentProps = parsed.subComponentProps;
+      }
+    }
+  }
+
+  // 2. If still empty and major version data is available, fall back to major
+  if (comp.props.length === 0 && majorStore) {
+    const majorComp = majorStore.components.find((c) => c.name === comp.name);
+    if (majorComp && majorComp.props.length > 0) {
+      comp.props = majorComp.props;
+      if (!comp.subComponentProps && majorComp.subComponentProps) {
+        comp.subComponentProps = majorComp.subComponentProps;
+      }
+    }
+  }
+
+  // 3. Backfill description from major if empty
+  if (!comp.description && majorStore) {
+    const majorComp = majorStore.components.find((c) => c.name === comp.name);
+    if (majorComp?.description) comp.description = majorComp.description;
+    if (!comp.descriptionZh && majorComp?.descriptionZh) comp.descriptionZh = majorComp.descriptionZh;
+  }
+}
+
 /**
  * Load metadata for a version, find a component, and return both.
  * Returns CLIError with fuzzy-match suggestion if the component is not found.
@@ -177,5 +424,14 @@ export function resolveComponent(
       suggestion ? `Did you mean '${suggestion}'?` : undefined,
     );
   }
+
+  // Backfill empty fields from doc and/or major version data
+  const majorVersion = `v${version.split('.')[0]}`;
+  const isSnapshot = store.version !== majorVersion.slice(1);
+  if (isSnapshot || comp.props.length === 0 || !comp.description) {
+    const majorStore = isSnapshot ? loadMetadata(majorVersion) : null;
+    backfillComponent(comp, majorStore);
+  }
+
   return { store, comp };
 }


### PR DESCRIPTION
## Summary

Fixes #129 — `antd info Popconfirm --version 5.0.0` returning empty props.

**Root cause**: Two issues combined:

1. **Extraction script missed two column headers**: The props extractor in `scripts/extractors/props.ts` only recognized `Property`/`Param`/`Name` as API table first-column headers, but antd docs also use `Props` (Drawer) and `Argument` (some components). This caused those components' props to be silently skipped during data extraction, producing empty `props: []` in all v5 version snapshot files (29 out of 30 affected).

2. **No runtime fallback**: `resolveComponent()` trusted snapshot data blindly — when `comp.props` was empty, it returned empty with no recovery mechanism, even though the `doc` field contained the full API table markdown.

**Fix**: 
- Added `Props` and `Argument` to the recognized column headers in the extraction script
- Added runtime backfill logic in `resolveComponent()`:
  1. If `comp.props` is empty but `comp.doc` has an `## API` section, parse props from the doc markdown (version-accurate)
  2. If doc parsing also fails, fall back to the major version data (e.g. `v5.json`)
  3. Backfill empty `description`/`descriptionZh` from the major version file

**Affected components across v5 snapshots**: Popconfirm, Popover, Drawer (and App in some versions)

## Test plan

- [x] `antd info Popconfirm --version 5.0.0 --format json` now returns 11 props
- [x] `antd info Popover --version 5.0.0 --format json` now returns 2 props
- [x] `antd info Drawer --version 5.0.0 --format json` now returns 30 props
- [x] `antd info Button --version 5.0.0` still works (no regression for components with existing props)
- [x] `antd info Popconfirm --version 5` still works (major version unaffected)
- [x] `--detail` and `--lang zh` modes work correctly
- [x] All 489 tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 扩展 API 表格表头识别，兼容更多表头变体，提升表格解析准确性。
  * 修正表格解析在行数不足时返回空数组，避免异常数据回传。

* **New Features**
  * 运行时自动回填：从文档（中/英）或主版本补全缺失的属性与描述，按语言合并并区分主/子组件区块。

* **Tests**
  * 大量新增用例覆盖回填、语言合并、表头差异与避免重复覆盖/共享引用的场景。

* **Chores**
  * 增加提取前与数据验证检测，发现异常时输出详情并影响脚本退出码。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->