### PR TITLE
fix: add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [#1](https://github.com/ant-design/ant-design-cli/security/code-scanning/1) — `actions/missing-workflow-permissions`.

The CI workflow does not specify explicit permissions for the `GITHUB_TOKEN`, which means it inherits the repository/organization default (potentially read-write). This violates the principle of least privilege.

### Changes
- Add `permissions: contents: read` to `.github/workflows/ci.yml`, which is the minimum required for checkout and running tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新日志

* **优化改进**
  * 加强了 CI 工作流的安全性配置，通过明确限制权限来降低自动化流程的访问权限风险，遵循最小权限原则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->