### PR TITLE
fix: use execFileSync to avoid shell injection in patch-token-names

### DIFF
--- a/scripts/patch-token-names.ts
+++ b/scripts/patch-token-names.ts
@@ -11,7 +11,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { execFileSync, execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import os from 'node:os';
 
 const dataDir = path.resolve('data');
@@ -39,7 +39,7 @@ function fetchTokenMeta(version: string): Record<string, { descEn?: string; type
 
   console.log(`  Downloading antd@${version}...`);
   try {
-    execSync(`npm pack antd@${version} --quiet 2>/dev/null`, { cwd: tmpDir, stdio: 'pipe' });
+    execFileSync('npm', ['pack', `antd@${version}`, '--quiet'], { cwd: tmpDir, stdio: 'pipe' });
     const tarball = fs.readdirSync(tmpDir).find((f) => f.endsWith('.tgz'));
     if (!tarball) throw new Error('tarball not found');
     execFileSync('tar', ['-xzf', tarball, 'package/es/version/token-meta.json'], {

--- a/scripts/patch-token-names.ts
+++ b/scripts/patch-token-names.ts
@@ -11,7 +11,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import os from 'node:os';
 
 const dataDir = path.resolve('data');
@@ -42,7 +42,7 @@ function fetchTokenMeta(version: string): Record<string, { descEn?: string; type
     execSync(`npm pack antd@${version} --quiet 2>/dev/null`, { cwd: tmpDir, stdio: 'pipe' });
     const tarball = fs.readdirSync(tmpDir).find((f) => f.endsWith('.tgz'));
     if (!tarball) throw new Error('tarball not found');
-    execSync(`tar -xzf ${tarball} package/es/version/token-meta.json`, {
+    execFileSync('tar', ['-xzf', tarball, 'package/es/version/token-meta.json'], {
       cwd: tmpDir,
       stdio: 'pipe',
     });


### PR DESCRIPTION
Fixes CodeQL alert 2 - js/shell-command-injection-from-environment. Replace execSync with execFileSync to avoid shell injection from uncontrolled filename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 提高了 token 元数据处理流程的可靠性与稳健性。
  * 精准化了元数据提取与缓存行为，减少临时文件残留并改进异常情况下的清理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->