### PR TITLE
fix: escape all regex special chars in extract-changelog version input

### DIFF
--- a/scripts/extract-changelog.ts
+++ b/scripts/extract-changelog.ts
@@ -18,7 +18,7 @@ function escapeRegExp(s: string): string {
 
 const content = fs.readFileSync('CHANGELOG.md', 'utf8');
 const regex = new RegExp(
-  `^## .*?${escapeRegExp(version)}.*?\n(.*?)(?=^## |\\Z)`,
+  `^## .*?${escapeRegExp(version)}.*?\n(.*?)(?=^## |(?!\\.))`,
   'ms',
 );
 const match = regex.exec(content);

--- a/scripts/extract-changelog.ts
+++ b/scripts/extract-changelog.ts
@@ -18,7 +18,7 @@ function escapeRegExp(s: string): string {
 
 const content = fs.readFileSync('CHANGELOG.md', 'utf8');
 const regex = new RegExp(
-  `^## .*?${escapeRegExp(version)}.*?\n(.*?)(?=^## |(?!\\.))`,
+  `^## .*?${escapeRegExp(version)}.*?\n(.*?)(?=^## |(?!.))`,
   'ms',
 );
 const match = regex.exec(content);

--- a/scripts/extract-changelog.ts
+++ b/scripts/extract-changelog.ts
@@ -11,9 +11,14 @@ if (!version) {
   process.exit(1);
 }
 
+/** Escape all regex special characters in a string so it can be safely embedded in a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 const content = fs.readFileSync('CHANGELOG.md', 'utf8');
 const regex = new RegExp(
-  `^## .*?${version.replace(/\./g, '\\.')}.*?\n(.*?)(?=^## |\\Z)`,
+  `^## .*?${escapeRegExp(version)}.*?\n(.*?)(?=^## |\\Z)`,
   'ms',
 );
 const match = regex.exec(content);


### PR DESCRIPTION
Fixes CodeQL alerts [#4](https://github.com/ant-design/ant-design-cli/security/code-scanning/4) (js/incomplete-sanitization) and [#6](https://github.com/ant-design/ant-design-cli/security/code-scanning/6) (js/regex-injection).

The previous `version.replace(/\./g, '\\.')` only escaped dots but missed backslashes and other regex metacharacters. A version string with special characters could inject arbitrary regex patterns (ReDoS) or produce incorrect matches.

Replace with a proper `escapeRegExp()` that escapes all special characters before embedding in the RegExp constructor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 改进了版本信息提取的可靠性，确保正确处理版本号中包含特殊字符的情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->