### PR TITLE
fix: escape backslashes before pipes in markdown table output

### DIFF
--- a/src/__tests__/snapshots/__snapshots__/info.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/info.test.ts.snap
@@ -217,7 +217,7 @@ And 4 other properties additionally.
 | size | \`large\` \\| \`middle\` \\| \`small\` | \`middle\` | \`small\` | Set the size of button |
 | styles | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - | 5.4.0 | Semantic DOM style |
 | target | string | - | - | Same as target attribute of a, works when href is specified |
-| type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\ | Syntactic sugar. Set button type. Will follow \`variant\` & \`color\` if provided |
+| type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\\\ | Syntactic sugar. Set button type. Will follow \`variant\` & \`color\` if provided |
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - | Set the handler to handle \`click\` event |
 | variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 | Set button variant |"
 `;
@@ -534,7 +534,7 @@ exports[`info > info Button --format markdown --lang en 1`] = `
 | size | \`large\` \\| \`middle\` \\| \`small\` | \`middle\` | \`small\` |
 | styles | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - | 5.4.0 |
 | target | string | - | - |
-| type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\ |
+| type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\\\ |
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - |
 | variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 |"
 `;
@@ -560,7 +560,7 @@ exports[`info > info Button --format markdown --lang zh 1`] = `
 | size | \`large\` \\| \`middle\` \\| \`small\` | \`middle\` | \`small\` |
 | styles | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - | 5.4.0 |
 | target | string | - | - |
-| type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\ |
+| type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\\\ |
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - |
 | variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 |"
 `;

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -135,7 +135,7 @@ export function formatTable(
 
   if (format === 'markdown') {
     // Escape backslashes first, then pipe characters to avoid breaking markdown tables
-    const escPipe = (s: string) => s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+    const escPipe = (s: string) => (s || '').replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
     const headerLine = '| ' + headers.map(escPipe).join(' | ') + ' |';
     const separator = '| ' + headers.map(() => '---').join(' | ') + ' |';
     const bodyLines = rows.map((row) => '| ' + row.map(escPipe).join(' | ') + ' |');

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -134,8 +134,8 @@ export function formatTable(
   }
 
   if (format === 'markdown') {
-    // Escape pipe characters in cell content to avoid breaking markdown tables
-    const escPipe = (s: string) => s.replace(/\|/g, '\\|');
+    // Escape backslashes first, then pipe characters to avoid breaking markdown tables
+    const escPipe = (s: string) => s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
     const headerLine = '| ' + headers.map(escPipe).join(' | ') + ' |';
     const separator = '| ' + headers.map(() => '---').join(' | ') + ' |';
     const bodyLines = rows.map((row) => '| ' + row.map(escPipe).join(' | ') + ' |');


### PR DESCRIPTION
Fixes CodeQL alert [#5](https://github.com/ant-design/ant-design-cli/security/code-scanning/5) (js/incomplete-sanitization).

The escPipe function only escaped pipe characters but not backslashes. If a cell value contained a backslash before a pipe, the result would leave the pipe unescaped, breaking the markdown table.

Escape backslashes first, then pipes, so they render correctly in markdown.