### PR TITLE
fix: use execFileSync to avoid shell injection in sync.ts

### DIFF
--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -13,7 +13,7 @@
  *   npx tsx scripts/sync.ts --antd-dir antd-source
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -90,7 +90,7 @@ function checkout(antdDir: string, tag: string): boolean {
 }
 
 function extract(antdDir: string, output: string) {
-  execSync(`npx tsx ${EXTRACT_SCRIPT} --antd-dir ${antdDir} --output ${output}`, {
+  execFileSync('npx', ['tsx', EXTRACT_SCRIPT, '--antd-dir', antdDir, '--output', output], {
     stdio: 'inherit',
   });
 }
@@ -120,7 +120,7 @@ function fetchTokenMeta(antdDir: string, tag: string) {
     let extracted = false;
     for (const p of paths) {
       try {
-        execSync(`tar -xzf ${tarball} ${p}`, { cwd: tmpDir, stdio: 'pipe' });
+        execFileSync('tar', ['-xzf', tarball, p], { cwd: tmpDir, stdio: 'pipe' });
         const extractedPath = path.join(tmpDir, p);
         if (fs.existsSync(extractedPath)) {
           fs.mkdirSync(targetDir, { recursive: true });

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -90,7 +90,8 @@ function checkout(antdDir: string, tag: string): boolean {
 }
 
 function extract(antdDir: string, output: string) {
-  execFileSync('npx', ['tsx', EXTRACT_SCRIPT, '--antd-dir', antdDir, '--output', output], {
+  const npxCmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  execFileSync(npxCmd, ['tsx', EXTRACT_SCRIPT, '--antd-dir', antdDir, '--output', output], {
     stdio: 'inherit',
   });
 }


### PR DESCRIPTION
Fixes CodeQL alerts [#7](https://github.com/ant-design/ant-design-cli/security/code-scanning/7) and [#8](https://github.com/ant-design/ant-design-cli/security/code-scanning/8) (js/shell-command-injection-from-environment).

Two `execSync` calls interpolated dynamic paths (EXTRACT_SCRIPT, antdDir, output, tarball) directly into shell strings, which could break if paths contain spaces or special characters.

- Line 93 (extract): Replace `execSync` with `execFileSync` for npx/tsx
- Line 123 (fetchTokenMeta): Replace `execSync` with `execFileSync` for tar

This passes arguments without shell interpretation.