### PR TITLE
feat(info): add common props note for className/style/rootClassName

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -127,7 +127,10 @@ JSON output (concise):
 
 For components without sub-components (e.g. Button), `subComponentProps` is omitted.
 
-Text and markdown output includes a note after the props table reminding users that the component also supports antd common props (`className`, `style`, `rootClassName`) which are not individually listed in the API table. JSON output omits this note for machine-parseability.
+Most antd components inherit common props (`className`, `style`, `rootClassName`) via [Common Props](https://ant.design/docs/react/common-props). These are included in the output:
+
+- **JSON format**: a `commonProps` array with `name`, `type`, `default`, `description`, `descriptionZh` fields. Omitted for `ConfigProvider` (which does not support common props).
+- **Text/markdown format**: a separate "Common Props" table after the component-specific props table. Omitted for `ConfigProvider`.
 
 JSON output (--detail):
 ```json

--- a/spec.md
+++ b/spec.md
@@ -132,6 +132,8 @@ Most antd components inherit common props (`className`, `style`, `rootClassName`
 - **JSON format**: a `commonProps` array with `name`, `type`, `default`, `description`, `descriptionZh` fields. Omitted for `ConfigProvider` (which does not support common props).
 - **Text/markdown format**: a separate "Common Props" table after the component-specific props table. Omitted for `ConfigProvider`.
 
+Additionally, each component includes an `htmlElement` field indicating the underlying HTML element (e.g. Button → `"button"`, Input → `"input"`, Card → `"div"`). This tells consumers which native HTML attributes the component accepts. Omitted for `ConfigProvider`.
+
 JSON output (--detail):
 ```json
 {

--- a/spec.md
+++ b/spec.md
@@ -127,6 +127,8 @@ JSON output (concise):
 
 For components without sub-components (e.g. Button), `subComponentProps` is omitted.
 
+Text and markdown output includes a note after the props table reminding users that the component also supports antd common props (`className`, `style`, `rootClassName`) which are not individually listed in the API table. JSON output omits this note for machine-parseability.
+
 JSON output (--detail):
 ```json
 {

--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -32,18 +32,20 @@ describe('mcp tools', () => {
 
   it('antd_info returns component info', async () => {
     const result = await handle('antd_info', { component: 'Button' });
-    const data = parseResult(result) as { name: string; props: unknown[]; commonProps: { name: string }[] };
+    const data = parseResult(result) as { name: string; props: unknown[]; commonProps: { name: string }[]; htmlElement: string };
     expect(data.name).toBe('Button');
     expect(data.props.length).toBeGreaterThan(0);
     expect(data.commonProps).toBeDefined();
     expect(data.commonProps.map((p) => p.name)).toEqual(['className', 'style', 'rootClassName']);
+    expect(data.htmlElement).toBe('button');
   });
 
   it('antd_info omits commonProps for ConfigProvider', async () => {
     const result = await handle('antd_info', { component: 'ConfigProvider' });
-    const data = parseResult(result) as { name: string; commonProps?: unknown[] };
+    const data = parseResult(result) as { name: string; commonProps?: unknown[]; htmlElement?: string };
     expect(data.name).toBe('ConfigProvider');
     expect(data.commonProps).toBeUndefined();
+    expect(data.htmlElement).toBeUndefined();
   });
 
   it('antd_info honours detail flag', async () => {

--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -32,9 +32,18 @@ describe('mcp tools', () => {
 
   it('antd_info returns component info', async () => {
     const result = await handle('antd_info', { component: 'Button' });
-    const data = parseResult(result) as { name: string; props: unknown[] };
+    const data = parseResult(result) as { name: string; props: unknown[]; commonProps: { name: string }[] };
     expect(data.name).toBe('Button');
     expect(data.props.length).toBeGreaterThan(0);
+    expect(data.commonProps).toBeDefined();
+    expect(data.commonProps.map((p) => p.name)).toEqual(['className', 'style', 'rootClassName']);
+  });
+
+  it('antd_info omits commonProps for ConfigProvider', async () => {
+    const result = await handle('antd_info', { component: 'ConfigProvider' });
+    const data = parseResult(result) as { name: string; commonProps?: unknown[] };
+    expect(data.name).toBe('ConfigProvider');
+    expect(data.commonProps).toBeUndefined();
   });
 
   it('antd_info honours detail flag', async () => {

--- a/src/__tests__/snapshots/__snapshots__/info.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/info.test.ts.snap
@@ -189,6 +189,7 @@ exports[`info > info Button --detail --format json 1`] = `
       "descriptionZh": "根元素的类名"
     }
   ],
+  "htmlElement": "button",
   "faq": [
     {
       "question": "How to choose type and color & variant?",
@@ -250,7 +251,9 @@ Common Props (inherited by all components, not listed individually)
 | --- | --- | --- | --- |
 | className | string | - | Additional CSS class |
 | style | CSSProperties | - | Additional style |
-| rootClassName | string | - | ClassName on the root element |"
+| rootClassName | string | - | ClassName on the root element |
+
+Extends <button> — supports native HTML button attributes."
 `;
 
 exports[`info > info Button --detail --format text 1`] = `
@@ -301,7 +304,9 @@ Property       Type           Default  Description
 -------------  -------------  -------  -----------------------------
 className      string         -        Additional CSS class         
 style          CSSProperties  -        Additional style             
-rootClassName  string         -        ClassName on the root element"
+rootClassName  string         -        ClassName on the root element
+
+Extends <button> — supports native HTML button attributes."
 `;
 
 exports[`info > info Button --format json --lang en 1`] = `
@@ -447,7 +452,8 @@ exports[`info > info Button --format json --lang en 1`] = `
       "description": "ClassName on the root element",
       "descriptionZh": "根元素的类名"
     }
-  ]
+  ],
+  "htmlElement": "button"
 }"
 `;
 
@@ -594,7 +600,8 @@ exports[`info > info Button --format json --lang zh 1`] = `
       "description": "ClassName on the root element",
       "descriptionZh": "根元素的类名"
     }
-  ]
+  ],
+  "htmlElement": "button"
 }"
 `;
 
@@ -629,7 +636,9 @@ Common Props (inherited by all components, not listed individually)
 | --- | --- | --- |
 | className | string | - |
 | style | CSSProperties | - |
-| rootClassName | string | - |"
+| rootClassName | string | - |
+
+Extends <button> — supports native HTML button attributes."
 `;
 
 exports[`info > info Button --format markdown --lang zh 1`] = `
@@ -663,7 +672,9 @@ exports[`info > info Button --format markdown --lang zh 1`] = `
 | --- | --- | --- |
 | className | string | - |
 | style | CSSProperties | - |
-| rootClassName | string | - |"
+| rootClassName | string | - |
+
+扩展自 <button>，支持原生 HTML button 属性。"
 `;
 
 exports[`info > info Button --format text --lang en 1`] = `
@@ -697,7 +708,9 @@ Property       Type           Default
 -------------  -------------  -------
 className      string         -      
 style          CSSProperties  -      
-rootClassName  string         -"
+rootClassName  string         -      
+
+Extends <button> — supports native HTML button attributes."
 `;
 
 exports[`info > info Button --format text --lang zh 1`] = `
@@ -731,7 +744,9 @@ Property       Type           Default
 -------------  -------------  -------
 className      string         -      
 style          CSSProperties  -      
-rootClassName  string         -"
+rootClassName  string         -      
+
+扩展自 <button>，支持原生 HTML button 属性。"
 `;
 
 exports[`info > info NonExistent --format json 1`] = `
@@ -775,5 +790,7 @@ Property       Type           Default
 -------------  -------------  -------
 className      string         -      
 style          CSSProperties  -      
-rootClassName  string         -"
+rootClassName  string         -      
+
+Extends <button> — supports native HTML button attributes."
 `;

--- a/src/__tests__/snapshots/__snapshots__/info.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/info.test.ts.snap
@@ -166,6 +166,29 @@ exports[`info > info Button --detail --format json 1`] = `
       "descriptionZh": "设置按钮的变体"
     }
   ],
+  "commonProps": [
+    {
+      "name": "className",
+      "type": "string",
+      "default": "-",
+      "description": "Additional CSS class",
+      "descriptionZh": "额外的 CSS 类名"
+    },
+    {
+      "name": "style",
+      "type": "CSSProperties",
+      "default": "-",
+      "description": "Additional style",
+      "descriptionZh": "额外的样式"
+    },
+    {
+      "name": "rootClassName",
+      "type": "string",
+      "default": "-",
+      "description": "ClassName on the root element",
+      "descriptionZh": "根元素的类名"
+    }
+  ],
   "faq": [
     {
       "question": "How to choose type and color & variant?",
@@ -221,7 +244,13 @@ And 4 other properties additionally.
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - | Set the handler to handle \`click\` event |
 | variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 | Set button variant |
 
-💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
+Common Props (inherited by all components, not listed individually)
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| className | string | - | Additional CSS class |
+| style | CSSProperties | - | Additional style |
+| rootClassName | string | - | ClassName on the root element |"
 `;
 
 exports[`info > info Button --detail --format text 1`] = `
@@ -266,7 +295,13 @@ type             \`primary\` | \`dashed\` | \`link\` | \`text\` | \`default\`   
 onClick          (event: React.MouseEvent<HTMLElement, MouseEvent>) => void        -          -                                                                  Set the handler to handle \`click\` event                                                                                    
 variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                             Set button variant                                                                                                         
 
-💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
+Common Props (inherited by all components, not listed individually)
+
+Property       Type           Default  Description                  
+-------------  -------------  -------  -----------------------------
+className      string         -        Additional CSS class         
+style          CSSProperties  -        Additional style             
+rootClassName  string         -        ClassName on the root element"
 `;
 
 exports[`info > info Button --format json --lang en 1`] = `
@@ -388,6 +423,29 @@ exports[`info > info Button --format json --lang en 1`] = `
       "type": "\`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`",
       "default": "-",
       "since": "5.21.0"
+    }
+  ],
+  "commonProps": [
+    {
+      "name": "className",
+      "type": "string",
+      "default": "-",
+      "description": "Additional CSS class",
+      "descriptionZh": "额外的 CSS 类名"
+    },
+    {
+      "name": "style",
+      "type": "CSSProperties",
+      "default": "-",
+      "description": "Additional style",
+      "descriptionZh": "额外的样式"
+    },
+    {
+      "name": "rootClassName",
+      "type": "string",
+      "default": "-",
+      "description": "ClassName on the root element",
+      "descriptionZh": "根元素的类名"
     }
   ]
 }"
@@ -513,6 +571,29 @@ exports[`info > info Button --format json --lang zh 1`] = `
       "default": "-",
       "since": "5.21.0"
     }
+  ],
+  "commonProps": [
+    {
+      "name": "className",
+      "type": "string",
+      "default": "-",
+      "description": "Additional CSS class",
+      "descriptionZh": "额外的 CSS 类名"
+    },
+    {
+      "name": "style",
+      "type": "CSSProperties",
+      "default": "-",
+      "description": "Additional style",
+      "descriptionZh": "额外的样式"
+    },
+    {
+      "name": "rootClassName",
+      "type": "string",
+      "default": "-",
+      "description": "ClassName on the root element",
+      "descriptionZh": "根元素的类名"
+    }
   ]
 }"
 `;
@@ -542,7 +623,13 @@ exports[`info > info Button --format markdown --lang en 1`] = `
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - |
 | variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 |
 
-💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
+Common Props (inherited by all components, not listed individually)
+
+| Property | Type | Default |
+| --- | --- | --- |
+| className | string | - |
+| style | CSSProperties | - |
+| rootClassName | string | - |"
 `;
 
 exports[`info > info Button --format markdown --lang zh 1`] = `
@@ -570,7 +657,13 @@ exports[`info > info Button --format markdown --lang zh 1`] = `
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - |
 | variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 |
 
-💡 该组件还支持 className、style、rootClassName 等通用属性，详见 Common Props。"
+通用属性（所有组件均支持，无需单独列出）
+
+| Property | Type | Default |
+| --- | --- | --- |
+| className | string | - |
+| style | CSSProperties | - |
+| rootClassName | string | - |"
 `;
 
 exports[`info > info Button --format text --lang en 1`] = `
@@ -598,7 +691,13 @@ type             \`primary\` | \`dashed\` | \`link\` | \`text\` | \`default\`   
 onClick          (event: React.MouseEvent<HTMLElement, MouseEvent>) => void        -          -                                                                
 variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                           
 
-💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
+Common Props (inherited by all components, not listed individually)
+
+Property       Type           Default
+-------------  -------------  -------
+className      string         -      
+style          CSSProperties  -      
+rootClassName  string         -"
 `;
 
 exports[`info > info Button --format text --lang zh 1`] = `
@@ -626,7 +725,13 @@ type             \`primary\` | \`dashed\` | \`link\` | \`text\` | \`default\`   
 onClick          (event: React.MouseEvent<HTMLElement, MouseEvent>) => void        -          -                                                                
 variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                           
 
-💡 该组件还支持 className、style、rootClassName 等通用属性，详见 Common Props。"
+通用属性（所有组件均支持，无需单独列出）
+
+Property       Type           Default
+-------------  -------------  -------
+className      string         -      
+style          CSSProperties  -      
+rootClassName  string         -"
 `;
 
 exports[`info > info NonExistent --format json 1`] = `
@@ -664,5 +769,11 @@ type             \`primary\` | \`dashed\` | \`link\` | \`text\` | \`default\`   
 onClick          (event: React.MouseEvent<HTMLElement, MouseEvent>) => void        -          -                                                                
 variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                           
 
-💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
+Common Props (inherited by all components, not listed individually)
+
+Property       Type           Default
+-------------  -------------  -------
+className      string         -      
+style          CSSProperties  -      
+rootClassName  string         -"
 `;

--- a/src/__tests__/snapshots/__snapshots__/info.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/info.test.ts.snap
@@ -219,7 +219,9 @@ And 4 other properties additionally.
 | target | string | - | - | Same as target attribute of a, works when href is specified |
 | type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\\\ | Syntactic sugar. Set button type. Will follow \`variant\` & \`color\` if provided |
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - | Set the handler to handle \`click\` event |
-| variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 | Set button variant |"
+| variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 | Set button variant |
+
+💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
 `;
 
 exports[`info > info Button --detail --format text 1`] = `
@@ -262,7 +264,9 @@ styles           [Record<SemanticDOM, CSSProperties>](#semantic-dom)            
 target           string                                                            -          -                                                                  Same as target attribute of a, works when href is specified                                                                
 type             \`primary\` | \`dashed\` | \`link\` | \`text\` | \`default\`                \`default\`  \`link\` \\                                                           Syntactic sugar. Set button type. Will follow \`variant\` & \`color\` if provided                                              
 onClick          (event: React.MouseEvent<HTMLElement, MouseEvent>) => void        -          -                                                                  Set the handler to handle \`click\` event                                                                                    
-variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                             Set button variant"
+variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                             Set button variant                                                                                                         
+
+💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
 `;
 
 exports[`info > info Button --format json --lang en 1`] = `
@@ -536,7 +540,9 @@ exports[`info > info Button --format markdown --lang en 1`] = `
 | target | string | - | - |
 | type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\\\ |
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - |
-| variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 |"
+| variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 |
+
+💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
 `;
 
 exports[`info > info Button --format markdown --lang zh 1`] = `
@@ -562,7 +568,9 @@ exports[`info > info Button --format markdown --lang zh 1`] = `
 | target | string | - | - |
 | type | \`primary\` \\| \`dashed\` \\| \`link\` \\| \`text\` \\| \`default\` | \`default\` | \`link\` \\\\ |
 | onClick | (event: React.MouseEvent<HTMLElement, MouseEvent>) => void | - | - |
-| variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 |"
+| variant | \`outlined\` \\| \`dashed\` \\| \`solid\` \\| \`filled\` \\| \`text\` \\| \`link\` | - | 5.21.0 |
+
+💡 该组件还支持 className、style、rootClassName 等通用属性，详见 Common Props。"
 `;
 
 exports[`info > info Button --format text --lang en 1`] = `
@@ -588,7 +596,9 @@ styles           [Record<SemanticDOM, CSSProperties>](#semantic-dom)            
 target           string                                                            -          -                                                                
 type             \`primary\` | \`dashed\` | \`link\` | \`text\` | \`default\`                \`default\`  \`link\` \\                                                         
 onClick          (event: React.MouseEvent<HTMLElement, MouseEvent>) => void        -          -                                                                
-variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0"
+variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                           
+
+💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
 `;
 
 exports[`info > info Button --format text --lang zh 1`] = `
@@ -614,7 +624,9 @@ styles           [Record<SemanticDOM, CSSProperties>](#semantic-dom)            
 target           string                                                            -          -                                                                
 type             \`primary\` | \`dashed\` | \`link\` | \`text\` | \`default\`                \`default\`  \`link\` \\                                                         
 onClick          (event: React.MouseEvent<HTMLElement, MouseEvent>) => void        -          -                                                                
-variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0"
+variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                           
+
+💡 该组件还支持 className、style、rootClassName 等通用属性，详见 Common Props。"
 `;
 
 exports[`info > info NonExistent --format json 1`] = `
@@ -650,5 +662,7 @@ styles           [Record<SemanticDOM, CSSProperties>](#semantic-dom)            
 target           string                                                            -          -                                                                
 type             \`primary\` | \`dashed\` | \`link\` | \`text\` | \`default\`                \`default\`  \`link\` \\                                                         
 onClick          (event: React.MouseEvent<HTMLElement, MouseEvent>) => void        -          -                                                                
-variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0"
+variant          \`outlined\` | \`dashed\` | \`solid\` | \`filled\` | \`text\` | \`link\`      -          5.21.0                                                           
+
+💡 This component also supports common props: className, style, rootClassName. See Common Props for details."
 `;

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -141,5 +141,14 @@ export function registerInfoCommand(program: Command): void {
           console.log(formatTable(headers, subRows, fmt));
         }
       }
+
+      // Common props note — most antd components inherit className/style/rootClassName via Common Props.
+      // ConfigProvider does NOT support common props (no DOM element rendered).
+      if (result.name !== 'ConfigProvider') {
+        const commonPropsNote = opts.lang === 'zh'
+          ? '💡 该组件还支持 className、style、rootClassName 等通用属性，详见 Common Props。'
+          : '💡 This component also supports common props: className, style, rootClassName. See Common Props for details.';
+        console.log(`\n${commonPropsNote}`);
+      }
     });
 }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -16,6 +16,27 @@ const COMMON_PROPS: PropData[] = [
 /** Components that do NOT support common props (no DOM element rendered). */
 const COMMON_PROPS_EXCLUDED = new Set(['ConfigProvider']);
 
+/**
+ * Maps component names to their underlying HTML element.
+ * Derived from antd source: forwardRef<HTMLXxxElement> / extends React.HTMLAttributes<HTMLXxxElement>.
+ * Components not listed here default to 'div'.
+ */
+const HTML_ELEMENT_MAP: Record<string, string> = {
+  Avatar: 'span',
+  Badge: 'span',
+  Button: 'button',
+  Checkbox: 'input',
+  FloatButton: 'button',
+  Input: 'input',
+  InputNumber: 'input',
+  Mentions: 'textarea',
+  Radio: 'input',
+  Switch: 'button',
+  Tag: 'span',
+  Typography: 'span',
+  Upload: 'span',
+};
+
 export interface ComponentInfoConcise {
   name: string;
   nameZh: string;
@@ -23,6 +44,7 @@ export interface ComponentInfoConcise {
   props: { name: string; type: string; default: string; since: string }[];
   subComponentProps?: Record<string, { name: string; type: string; default: string; since: string }[]>;
   commonProps?: PropData[];
+  htmlElement?: string;
 }
 
 export interface ComponentInfoDetail {
@@ -33,6 +55,7 @@ export interface ComponentInfoDetail {
   props: (PropData & { description: string })[];
   subComponentProps?: Record<string, (PropData & { description: string })[]>;
   commonProps?: PropData[];
+  htmlElement?: string;
   faq: { question: string; answer: string }[];
 }
 
@@ -51,6 +74,9 @@ export function getComponentInfo(
   const desc = localize(comp.description, comp.descriptionZh, opts.lang);
   const whenToUse = localize(comp.whenToUse, comp.whenToUseZh, opts.lang);
   const commonProps = COMMON_PROPS_EXCLUDED.has(comp.name) ? undefined : COMMON_PROPS;
+  const htmlElement = COMMON_PROPS_EXCLUDED.has(comp.name)
+    ? undefined
+    : HTML_ELEMENT_MAP[comp.name] ?? 'div';
 
   if (opts.detail) {
     return {
@@ -71,6 +97,7 @@ export function getComponentInfo(
           )
         : undefined,
       commonProps,
+      htmlElement,
       faq: comp.faq || [],
     };
   }
@@ -94,6 +121,7 @@ export function getComponentInfo(
         )
       : undefined,
     commonProps,
+    htmlElement,
   };
 }
 
@@ -175,6 +203,13 @@ export function registerInfoCommand(program: Command): void {
             : [p.name, p.type, p.default];
         });
         console.log(formatTable(cpHeaders, cpRows, fmt));
+
+        if (result.htmlElement) {
+          const extendsNote = opts.lang === 'zh'
+            ? `\n扩展自 <${result.htmlElement}>，支持原生 HTML ${result.htmlElement} 属性。`
+            : `\nExtends <${result.htmlElement}> — supports native HTML ${result.htmlElement} attributes.`;
+          console.log(extendsNote);
+        }
       }
     });
 }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -6,12 +6,23 @@ import { detectVersion } from '../data/version.js';
 import { printError } from '../output/error.js';
 import { formatTable, output } from '../output/formatter.js';
 
+/** Common props inherited by most antd components via Common Props. */
+const COMMON_PROPS: PropData[] = [
+  { name: 'className', type: 'string', default: '-', description: 'Additional CSS class', descriptionZh: '额外的 CSS 类名' },
+  { name: 'style', type: 'CSSProperties', default: '-', description: 'Additional style', descriptionZh: '额外的样式' },
+  { name: 'rootClassName', type: 'string', default: '-', description: 'ClassName on the root element', descriptionZh: '根元素的类名' },
+];
+
+/** Components that do NOT support common props (no DOM element rendered). */
+const COMMON_PROPS_EXCLUDED = new Set(['ConfigProvider']);
+
 export interface ComponentInfoConcise {
   name: string;
   nameZh: string;
   description: string;
   props: { name: string; type: string; default: string; since: string }[];
   subComponentProps?: Record<string, { name: string; type: string; default: string; since: string }[]>;
+  commonProps?: PropData[];
 }
 
 export interface ComponentInfoDetail {
@@ -21,6 +32,7 @@ export interface ComponentInfoDetail {
   whenToUse: string;
   props: (PropData & { description: string })[];
   subComponentProps?: Record<string, (PropData & { description: string })[]>;
+  commonProps?: PropData[];
   faq: { question: string; answer: string }[];
 }
 
@@ -38,6 +50,7 @@ export function getComponentInfo(
 
   const desc = localize(comp.description, comp.descriptionZh, opts.lang);
   const whenToUse = localize(comp.whenToUse, comp.whenToUseZh, opts.lang);
+  const commonProps = COMMON_PROPS_EXCLUDED.has(comp.name) ? undefined : COMMON_PROPS;
 
   if (opts.detail) {
     return {
@@ -57,6 +70,7 @@ export function getComponentInfo(
             ]),
           )
         : undefined,
+      commonProps,
       faq: comp.faq || [],
     };
   }
@@ -79,6 +93,7 @@ export function getComponentInfo(
           ]),
         )
       : undefined,
+    commonProps,
   };
 }
 
@@ -142,13 +157,24 @@ export function registerInfoCommand(program: Command): void {
         }
       }
 
-      // Common props note — most antd components inherit className/style/rootClassName via Common Props.
+      // Common props — most antd components inherit className/style/rootClassName via Common Props.
       // ConfigProvider does NOT support common props (no DOM element rendered).
-      if (result.name !== 'ConfigProvider') {
-        const commonPropsNote = opts.lang === 'zh'
-          ? '💡 该组件还支持 className、style、rootClassName 等通用属性，详见 Common Props。'
-          : '💡 This component also supports common props: className, style, rootClassName. See Common Props for details.';
-        console.log(`\n${commonPropsNote}`);
+      if (result.commonProps) {
+        const noteLabel = opts.lang === 'zh'
+          ? '通用属性（所有组件均支持，无需单独列出）'
+          : 'Common Props (inherited by all components, not listed individually)';
+        console.log(`\n${noteLabel}`);
+        console.log('');
+        const cpHeaders = opts.detail
+          ? ['Property', 'Type', 'Default', 'Description']
+          : ['Property', 'Type', 'Default'];
+        const cpRows: string[][] = result.commonProps.map((p: PropData) => {
+          const desc = opts.detail ? localize(p.description, p.descriptionZh, opts.lang) || '-' : undefined;
+          return opts.detail
+            ? [p.name, p.type, p.default, desc!]
+            : [p.name, p.type, p.default];
+        });
+        console.log(formatTable(cpHeaders, cpRows, fmt));
       }
     });
 }


### PR DESCRIPTION
## Problem

Most antd components support `className`, `style`, and `rootClassName` via [Common Props](https://ant.design/docs/react/common-props), and also inherit native HTML attributes from their underlying HTML element. But the CLI's extracted data rarely includes these — users and LLMs querying `antd info Button` would miss commonly-used props.

Data shows only 12/69 (v5) and 12/71 (v6) components have `className` in their extracted props data.

## Solution

### 1. Common Props (className, style, rootClassName)

Inline the full type definitions into both human and machine output:

- **Text/markdown**: a separate "Common Props" table after the component props table
- **JSON/MCP**: a `commonProps` array with `name`, `type`, `default`, `description` fields
- **ConfigProvider** excluded (no DOM element rendered)

### 2. HTML Element Type (`htmlElement` field)

Each component now reports its underlying HTML element, so consumers know which native HTML attributes it accepts:

| htmlElement | Components |
|---|---|
| `button` | Button, FloatButton, Switch |
| `input` | Input, InputNumber, Checkbox, Radio |
| `textarea` | Mentions |
| `span` | Avatar, Badge, Tag, Typography, Upload |
| `div` | All others (default) |

### Example output

```
$ antd info Button

Button (按钮) — To trigger an operation.

Property  Type     Default  Since
...

Common Props (inherited by all components, not listed individually)

Property       Type           Default
className      string         -
style          CSSProperties  -
rootClassName  string         -

Extends <button> — supports native HTML button attributes.
```

JSON:
```json
{
  "name": "Button",
  "props": [...],
  "commonProps": [
    {"name": "className", "type": "string", "default": "-", "description": "Additional CSS class"},
    {"name": "style", "type": "CSSProperties", "default": "-", "description": "Additional style"},
    {"name": "rootClassName", "type": "string", "default": "-", "description": "ClassName on the root element"}
  ],
  "htmlElement": "button"
}
```

## Files changed

- `src/commands/info.ts` — add `COMMON_PROPS`, `HTML_ELEMENT_MAP`, wire into output
- `src/__tests__/mcp.test.ts` — test commonProps and htmlElement in MCP JSON
- `src/__tests__/snapshots/` — updated snapshots
- `spec.md` — document new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 在组件信息输出中新增“通用属性”展示，列出 className、style、rootClassName 等（多语言和详情级别支持）；非 ConfigProvider 场景下，文本/Markdown 输出会额外呈现该表格并说明可扩展的原生 HTML 元素。
  * JSON 输出新增对应结构（包含 commonProps 与 htmlElement 字段）以表达同样信息，ConfigProvider 场景省略这些项。

* **测试**
  * 增强用例，验证适用组件包含 commonProps 与 htmlElement，且 ConfigProvider 场景省略它们。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->