### PR TITLE
fix: use structured error path for changelog VERSION_NOT_FOUND without suggestion

### DIFF
--- a/src/__tests__/commands/changelog.test.ts
+++ b/src/__tests__/commands/changelog.test.ts
@@ -45,10 +45,19 @@ describe('changelog', () => {
     expect(out).toContain('API Diff:');
   });
 
-  it('should print "No changelog data" message for unknown major version', async () => {
-    // Version 999.x has no snapshot data
-    const out = await run('changelog', '999.0.0');
-    expect(out).toContain('No changelog data');
+  it('should error for unknown major version with no changelog data', async () => {
+    // Version 999.x has no snapshot data — should use structured error path
+    const result = await runCLI('changelog', '999.0.0');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('No changelog data available');
+  });
+
+  it('should error for unknown major version with JSON format', async () => {
+    const result = await runCLI('changelog', '999.0.0', '--format', 'json');
+    expect(result.exitCode).toBe(1);
+    const err = JSON.parse(result.stderr);
+    expect(err.code).toBe('VERSION_NOT_FOUND');
+    expect(err.error).toBe(true);
   });
 
   it('should error in diff mode when v1 version has no data (older major)', async () => {

--- a/src/__tests__/commands/changelog.test.ts
+++ b/src/__tests__/commands/changelog.test.ts
@@ -49,12 +49,14 @@ describe('changelog', () => {
     // Version 999.x has no snapshot data — should use structured error path
     const result = await runCLI('changelog', '999.0.0');
     expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
     expect(result.stderr).toContain('No changelog data available');
   });
 
   it('should error for unknown major version with JSON format', async () => {
     const result = await runCLI('changelog', '999.0.0', '--format', 'json');
     expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
     const err = JSON.parse(result.stderr);
     expect(err.code).toBe('VERSION_NOT_FOUND');
     expect(err.error).toBe(true);

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -262,11 +262,6 @@ export function registerChangelogCommand(program: Command): void {
         });
 
         if ('error' in result) {
-          // Special case: "No changelog data available" should just print a message, not a structured error
-          if (result.code === ErrorCodes.VERSION_NOT_FOUND && !result.suggestion) {
-            console.log('No changelog data available.');
-            return;
-          }
           printError(result, opts.format);
           process.exitCode = 1;
           return;


### PR DESCRIPTION
## Problem

When `antd changelog 999.0.0` hits a VERSION_NOT_FOUND error with no suggestion, it wrote a plain text message to **stdout** via `console.log()` and returned with exit code 0. This breaks AI agents parsing output with `--format json`, as they receive raw text instead of valid JSON on stdout.

## Fix

Removed the special-case branch that bypassed `printError()`. All changelog error paths now consistently:

- Write to **stderr** (not stdout)
- Output proper JSON when `--format json` is specified
- Set `process.exitCode = 1`

## Before

```bash
$ antd changelog 999.0.0 --format json
No changelog data available.    # ← plain text on stdout, exit code 0
```

## After

```bash
$ antd changelog 999.0.0 --format json
# stderr: {"error":true,"code":"VERSION_NOT_FOUND","message":"No changelog data available"}
# exit code: 1
```

## Test

- Updated existing test to check stderr + exitCode instead of stdout
- Added new test for JSON format error output
- All 15 changelog tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 统一了查询不存在版本时的错误处理流程，移除针对特定错误的例外分支，确保所有错误通过一致方式输出并设置退出状态。

* **测试**
  * 增强了错误场景测试：新增对非 JSON 与 JSON 格式错误响应的覆盖，验证退出码、标准输出/错误及错误码字段。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->