### PR TITLE
fix: validate --format and --lang global options

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -23,4 +23,25 @@ describe('CLI', () => {
     expect(data.code).toBe('COMPONENT_NOT_FOUND');
     expect(data.suggestion).toContain('Button');
   });
+
+  it('should reject invalid --format values', async () => {
+    const result = await runCLI('info', 'Button', '--format', 'csv');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid format 'csv'");
+    expect(result.stderr).toContain('json, text, markdown');
+  });
+
+  it('should reject invalid --lang values', async () => {
+    const result = await runCLI('info', 'Button', '--lang', 'fr');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid language 'fr'");
+    expect(result.stderr).toContain('en, zh');
+  });
+
+  it('should accept valid --format and --lang values', async () => {
+    const result = await runCLI('info', 'Button', '--format', 'json', '--lang', 'zh');
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.stdout);
+    expect(data.name).toBe('Button');
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { registerEnvCommand } from './commands/env.js';
 import { registerUpgradeCommand } from './commands/upgrade.js';
 import { registerMcpCommand } from './commands/mcp.js';
 import { checkForUpdate } from './utils/update-check.js';
+import type { GlobalOptions } from './types.js';
 declare const __CLI_VERSION__: string;
 const CLI_VERSION = __CLI_VERSION__;
 
@@ -64,6 +65,23 @@ export function createProgram(): Command {
   // Issue Reporting commands
   registerBugCommand(program);
   registerBugCliCommand(program);
+
+  // Validate global options before any command runs
+  program.hook('preAction', () => {
+    const opts = program.opts<GlobalOptions>();
+    const validFormats = ['json', 'text', 'markdown'];
+    const validLangs = ['en', 'zh'];
+    if (opts.format && !validFormats.includes(opts.format)) {
+      console.error(`Error: Invalid format '${opts.format}'. Must be one of: ${validFormats.join(', ')}`);
+      process.exitCode = 1;
+      throw new Error('EXIT:1');
+    }
+    if (opts.lang && !validLangs.includes(opts.lang)) {
+      console.error(`Error: Invalid language '${opts.lang}'. Must be one of: ${validLangs.join(', ')}`);
+      process.exitCode = 1;
+      throw new Error('EXIT:1');
+    }
+  });
 
   program.hook('postAction', async () => {
     await checkForUpdate();


### PR DESCRIPTION
## Problem

AI agents using this CLI with `--format json` expect machine-parseable output. Passing an invalid format like `--format csv` or invalid language like `--lang fr` was silently ignored — the command ran with the default `text`/`en` fallback, and agents received unexpected text output instead of JSON, causing ParseError failures.

Worse, the exit code was 0 (success), giving agents no signal that anything was wrong.

## Fix

Added a `preAction` hook that validates `--format` and `--lang` before any command runs:
- Invalid values → error message on stderr + exit code 1
- Valid values → pass through as before
- Prevents command execution when options are invalid (throws to stop Commander action)

## Before

```bash
$ antd info Button --format csv
# Returns text output on stdout, exit code 0 — silent degradation
```

## After

```bash
$ antd info Button --format csv
# stderr: Error: Invalid format 'csv'. Must be one of: json, text, markdown
# exit code: 1

$ antd info Button --lang fr
# stderr: Error: Invalid language 'fr'. Must be one of: en, zh
# exit code: 1
```

## Test

Added 3 new tests:
- Invalid `--format` → exit 1, stderr contains error
- Invalid `--lang` → exit 1, stderr contains error
- Valid `--format json --lang zh` → exit 0, valid JSON output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * CLI 工具现已验证 `--format` 和 `--lang` 参数的有效性，无效值会输出详细错误提示与允许的选项列表
  
* **测试**
  * 新增命令行参数验证的测试用例

<!-- end of auto-generated comment: release notes by coderabbit.ai -->