### PR TITLE
fix: replace process.exit() with process.exitCode in bug commands

### DIFF
--- a/src/commands/bug.ts
+++ b/src/commands/bug.ts
@@ -34,7 +34,8 @@ export function registerBugCommand(program: Command): void {
           createError(ErrorCodes.TITLE_REQUIRED, '--title is required', 'Provide --title <title>'),
           opts.format,
         );
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       const env = collectAntdEnv(process.cwd(), opts.version);
@@ -54,7 +55,8 @@ export function registerBugCommand(program: Command): void {
             createError(ErrorCodes.GH_NOT_FOUND, 'gh CLI is not installed or not in PATH', 'Install GitHub CLI: https://cli.github.com/ — or remove --submit to get a pre-filled URL instead'),
             opts.format,
           );
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
         try {
           const result = submitViaGh(ANTD_REPO, title, body);
@@ -69,7 +71,8 @@ export function registerBugCommand(program: Command): void {
             createError(ErrorCodes.GH_SUBMIT_FAILED, `Failed to create issue: ${message}`, 'Check your gh authentication with `gh auth status`'),
             opts.format,
           );
-          process.exit(2);
+          process.exitCode = 2;
+          return;
         }
         return;
       }
@@ -113,7 +116,8 @@ export function registerBugCliCommand(program: Command): void {
           createError(ErrorCodes.TITLE_REQUIRED, '--title is required', 'Provide --title <title>'),
           opts.format,
         );
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       const env = collectCliEnv();
@@ -133,7 +137,8 @@ export function registerBugCliCommand(program: Command): void {
             createError(ErrorCodes.GH_NOT_FOUND, 'gh CLI is not installed or not in PATH', 'Install GitHub CLI: https://cli.github.com/ — or remove --submit to get a pre-filled URL instead'),
             opts.format,
           );
-          process.exit(1);
+          process.exitCode = 1;
+          return;
         }
         try {
           const result = submitViaGh(CLI_REPO, title, body);
@@ -148,7 +153,8 @@ export function registerBugCliCommand(program: Command): void {
             createError(ErrorCodes.GH_SUBMIT_FAILED, `Failed to create issue: ${message}`, 'Check your gh authentication with `gh auth status`'),
             opts.format,
           );
-          process.exit(2);
+          process.exitCode = 2;
+          return;
         }
         return;
       }


### PR DESCRIPTION
## Problem

The `bug` and `bug-cli` commands were the **only** commands in the project that used `process.exit(N)` directly. All other commands use `process.exitCode = N; return;`.

Problems with `process.exit()`:
1. **Output truncation**: `process.exit()` terminates immediately. If stdout/stderr is piped (common for AI agents), the stream may not flush, causing truncated JSON output.
2. **Skips postAction hook**: The global `postAction` hook that calls `checkForUpdate()` is bypassed entirely, creating inconsistent behavior across commands.
3. **Pattern inconsistency**: Every other command (info, doc, demo, token, semantic, changelog, migrate, upgrade, etc.) uses the soft exit pattern.

## Fix

Replace all 6 `process.exit(N)` calls in `bug.ts` with `process.exitCode = N; return;`:

| Location | Before | After |
|----------|--------|-------|
| bug: missing title | `process.exit(1)` | `process.exitCode = 1; return;` |
| bug: gh not found | `process.exit(1)` | `process.exitCode = 1; return;` |
| bug: gh submit failed | `process.exit(2)` | `process.exitCode = 2; return;` |
| bug-cli: missing title | `process.exit(1)` | `process.exitCode = 1; return;` |
| bug-cli: gh not found | `process.exit(1)` | `process.exitCode = 1; return;` |
| bug-cli: gh submit failed | `process.exit(2)` | `process.exitCode = 2; return;` |

## Test

All 18 existing bug tests pass (exit codes verified via `runCLI` helper which captures both `process.exit` mock and `process.exitCode`).