### PR TITLE
fix: exclude skills node_modules from npm package

### DIFF
--- a/skills/.npmignore
+++ b/skills/.npmignore
@@ -1,0 +1,1 @@
+**/node_modules


### PR DESCRIPTION
## Problem

The `files` field in package.json includes `"skills"`, which tells npm to include the entire `skills/` directory. npm only excludes **top-level** `node_modules/` — nested `node_modules` within `files`-listed directories are included.

This means `skills/antd/node_modules/` (~488K, containing `commander`, `chalk`, `@agentskill/installer`, etc.) would be published to npm, bloating the package unnecessarily.

## Fix

Added `skills/.npmignore` with `**/node_modules` to explicitly exclude nested node_modules from the published package.

## Verification

```bash
$ npm pack --dry-run 2>&1 | grep skills/
npm notice 9.4kB skills/antd/SKILL.md
```

Only `SKILL.md` is included — the 488K node_modules is excluded.