### PR TITLE
fix: add safe default mock for fetch in fetch-bug-versions tests

### DIFF
--- a/src/__tests__/fetch-bug-versions.test.ts
+++ b/src/__tests__/fetch-bug-versions.test.ts
@@ -20,7 +20,9 @@ describe('utils/fetch', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    fetchSpy = vi.spyOn(globalThis, 'fetch');
+    // Safe default: reject all real network calls to prevent accidental
+    // HTTP requests during tests (per CLAUDE.md Testing Safety rules).
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network calls not allowed in tests'));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Problem

The `beforeEach` spy on `globalThis.fetch` in `fetch-bug-versions.test.ts` had no default mock implementation:

```ts
fetchSpy = vi.spyOn(globalThis, 'fetch'); // no mockImplementation!
```

If a test failed unexpectedly or an async timing error occurred before per-test mocks were set up, the real `fetch` would be called, hitting actual network endpoints (`registry.npmmirror.com`, `unpkg.com`, `cdn.jsdelivr.net`).

This violates the CLAUDE.md Testing Safety rule: _"Network-calling functions (fetch, etc.) must be mocked to prevent real HTTP requests."_

## Fix

Added a safe default implementation that rejects all calls:

```ts
fetchSpy = vi.spyOn(globalThis, 'fetch')
  .mockRejectedValue(new Error('network calls not allowed in tests'));
```

Individual tests override with specific mocks as before. All 10 tests pass.