### PR TITLE
fix: skip validation for components with only subComponentProps

### DIFF
--- a/scripts/extract.ts
+++ b/scripts/extract.ts
@@ -132,7 +132,8 @@ function main() {
   };
 
   // 6. Validate: components with API docs but no props are likely extraction bugs
-  const suspicious = components.filter(c => c.props.length === 0 && c.doc?.includes('## API'));
+  // Exclude components that have subComponentProps (e.g. Grid→Row/Col, Typography→Text/Title/Paragraph)
+  const suspicious = components.filter(c => c.props.length === 0 && !c.subComponentProps && c.doc?.includes('## API'));
   if (suspicious.length > 0) {
     console.error(`\nError: ${suspicious.length} component(s) have API docs but no extracted props:`);
     suspicious.forEach(c => console.error(`  - ${c.name}`));


### PR DESCRIPTION
## Summary
- Fix sync action failure when extracting antd v6.4.4 metadata
- Components like Grid (Row/Col), Icon (Common/Custom Icon), and Typography (Text/Title/Paragraph) have all their API props in sub-sections with no main component props
- The validation check now excludes components that have `subComponentProps` from the "no props extracted" error

Fixes https://github.com/ant-design/ant-design-cli/actions/runs/27408542441/job/81003688769

## Test plan
- [x] All 585 tests pass
- [x] Verified locally that Grid, Icon, Typography extract correctly into subComponentProps

🤖 Generated with [Claude Code](https://claude.com/claude-code)