### PR TITLE
fix: show helpful message when `antd mcp` is run in a terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npx skills add ant-design/ant-design-cli    # install as an agent skill
 - 🌍 **Bilingual** — Every component name, description, and doc has both English and Chinese. Switch with `--lang zh`.
 - 🔮 **Smart matching** — Typo `Buttn`? The CLI suggests `Button` using Levenshtein distance, with first-letter preference.
 - 🧩 **17 commands** — From prop lookup to project-wide lint, from design token queries to cross-version API diffing.
-- 🔌 **MCP server** — `antd mcp` starts a stdio server for native IDE integration (Claude Desktop, Cursor).
+- 🔌 **MCP server** — `antd mcp` starts a stdio server for native IDE integration (Claude Code, Cursor, VS Code, etc.).
 
 <br>
 
@@ -83,6 +83,19 @@ Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.sh), [
 ### MCP Server
 
 For IDEs that support [Model Context Protocol](https://modelcontextprotocol.io), the CLI can run as an MCP server:
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "npx",
+      "args": ["-y", "@ant-design/cli", "mcp"]
+    }
+  }
+}
+```
+
+Or if you have the CLI installed globally (`npm i -g @ant-design/cli`):
 
 ```json
 {
@@ -414,21 +427,21 @@ antd bug-cli --title "..." --submit
 
 ### `antd mcp`
 
-Start an MCP (Model Context Protocol) stdio server for IDE agent integration. Exposes 8 tools and 2 prompts for native IDE integration (Claude Desktop, Cursor, etc.).
+Start an MCP (Model Context Protocol) stdio server for IDE agent integration. Exposes 8 tools and 2 prompts for native IDE integration (Claude Code, Cursor, VS Code, Windsurf, Codex, etc.).
 
 ```bash
 antd mcp                                # start with auto-detected version
 antd mcp --version 5.20.0 --lang zh     # pin version and language
 ```
 
-IDE configuration (`claude_desktop_config.json`):
+Configuration:
 
 ```json
 {
   "mcpServers": {
     "antd": {
-      "command": "antd",
-      "args": ["mcp"]
+      "command": "npx",
+      "args": ["-y", "@ant-design/cli", "mcp"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ antd bug-cli --title "..." --submit
 
 ### `antd mcp`
 
-Start an MCP (Model Context Protocol) stdio server for IDE agent integration. Exposes 8 tools and 2 prompts for native IDE integration (Claude Code, Cursor, VS Code, Windsurf, Codex, etc.).
+Start an MCP (Model Context Protocol) stdio server for IDE agent integration. Exposes 8 tools and 2 prompts for native IDE integration (Claude Code, Cursor, VS Code, Codex, etc.).
 
 ```bash
 antd mcp                                # start with auto-detected version

--- a/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
@@ -39,8 +39,9 @@ Commands:
                                    auto-fix
   env [dir]                        Collect antd-related environment information
                                    for bug reporting
-  mcp                              Start MCP (Model Context Protocol) server for
-                                   AI assistant integration
+  mcp                              Start MCP (Model Context Protocol) server for AI assistant integration.
+  Not meant to be run directly. Configure your AI tool with:
+    { "mcpServers": { "antd": { "command": "npx", "args": ["-y", "@ant-design/cli", "mcp"] } } }
   upgrade                          Upgrade the CLI to the latest version
   bug [options]                    Report a bug to the antd repository
   bug-cli [options]                Report a bug to the ant-design-cli repository

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -17,8 +17,35 @@ declare const __CLI_VERSION__: string;
 export function registerMcpCommand(program: Command): void {
   program
     .command('mcp')
-    .description('Start MCP (Model Context Protocol) server for AI assistant integration')
+    .description(
+      'Start MCP (Model Context Protocol) server for AI assistant integration.\n' +
+      'Not meant to be run directly. Configure your AI tool with:\n' +
+      '  { "mcpServers": { "antd": { "command": "npx", "args": ["-y", "@ant-design/cli", "mcp"] } } }',
+    )
     .action(/* v8 ignore start */ async () => {
+      if (process.stdin.isTTY) {
+        console.error('Ant Design MCP Server');
+        console.error('');
+        console.error('This command starts an MCP (Model Context Protocol) server that communicates via stdio.');
+        console.error('It is not meant to be run directly in a terminal.');
+        console.error('');
+        console.error('To use it, configure your AI tool with:');
+        console.error('');
+        console.error('  {');
+        console.error('    "mcpServers": {');
+        console.error('      "antd": {');
+        console.error('        "command": "npx",');
+        console.error('        "args": ["-y", "@ant-design/cli", "mcp"]');
+        console.error('      }');
+        console.error('    }');
+        console.error('  }');
+        console.error('');
+        console.error('Supported tools: Claude Code, Cursor, VS Code, Windsurf, Codex, etc.');
+        console.error('');
+        console.error('Starting MCP server on stdio...');
+        console.error('');
+      }
+
       const opts = program.opts<GlobalOptions>();
       const versionInfo = detectVersion(opts.version);
 

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -40,7 +40,7 @@ export function registerMcpCommand(program: Command): void {
         console.error('    }');
         console.error('  }');
         console.error('');
-        console.error('Supported tools: Claude Code, Cursor, VS Code, Windsurf, Codex, etc.');
+        console.error('Supported tools: Claude Code, Cursor, VS Code, Codex, etc.');
         console.error('');
         console.error('Starting MCP server on stdio...');
         console.error('');


### PR DESCRIPTION
## Summary

- When users run `antd mcp` directly in a terminal (TTY), display helpful usage instructions instead of silently hanging
- Update README and help text to recommend `npx` invocation over global install
- Update supported tools list (Claude Code, Cursor, VS Code, Windsurf, Codex)

Closes #153

## Test plan

- [x] All 585 tests pass
- [x] `antd mcp -h` shows configuration example
- [x] MCP server still functions normally when invoked by AI tools (non-TTY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 📝 发布说明

* **新功能**
  * MCP 命令增强了用户提示和配置指导，提供更详细的命令说明和示例

* **Bug 修复**
  * 优化了组件验证逻辑，减少复合组件的误报

* **文档更新**
  * 补充了 `antd mcp` 集成场景说明
  * 更新了 MCP 服务器配置示例和命令用法文档

<!-- end of auto-generated comment: release notes by coderabbit.ai -->