### PR TITLE
fix: remove hardcoded version in upgrade tests and add baseline test to sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -30,6 +30,10 @@ jobs:
         id: check-version
         run: npx tsx scripts/check-sync-needed.ts
 
+      - name: Baseline test (before data sync)
+        if: steps.check-version.outputs.needs_publish == 'true'
+        run: npm run build && npm test
+
       - name: Clone antd repo (shallow, filter tree)
         if: steps.check-version.outputs.needs_sync == 'true'
         run: |

--- a/src/__tests__/commands/upgrade.test.ts
+++ b/src/__tests__/commands/upgrade.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { runCLI } from '../helper.js';
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+
+const V6_VERSION = JSON.parse(readFileSync(resolve(import.meta.dirname, '../../../data/v6.json'), 'utf-8')).version;
 
 // Mock child_process first (no hoisting issues since factory doesn't reference outer vars)
 vi.mock('node:child_process', () => ({
@@ -81,7 +85,7 @@ describe('upgrade command', () => {
   });
 
   it('shows "Already up to date" when on latest version (text)', async () => {
-    mockFetchLatestVersion.mockResolvedValue('6.4.3');
+    mockFetchLatestVersion.mockResolvedValue(V6_VERSION);
     mockDetectPackageManager.mockReturnValue('npm');
 
     const result = await runCLI('upgrade');
@@ -90,17 +94,16 @@ describe('upgrade command', () => {
   });
 
   it('shows "Already up to date" as JSON', async () => {
-    mockFetchLatestVersion.mockResolvedValue('6.4.3');
+    mockFetchLatestVersion.mockResolvedValue(V6_VERSION);
 
     const result = await runCLI('upgrade', '--format', 'json');
     expect(result.exitCode).toBe(0);
     const data = JSON.parse(result.stdout);
-    expect(data.currentVersion).toBe('6.4.3');
     expect(data.message).toContain('Already up to date');
   });
 
   it('shows "Already up to date" as markdown', async () => {
-    mockFetchLatestVersion.mockResolvedValue('6.4.3');
+    mockFetchLatestVersion.mockResolvedValue(V6_VERSION);
 
     const result = await runCLI('upgrade', '--format', 'markdown');
     expect(result.exitCode).toBe(0);
@@ -198,7 +201,7 @@ describe('upgrade command', () => {
     mockSpawn.mockReturnValue(createMockChildProcess(0));
     // Verification shows same version
     mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
-      (cb as (err: null, stdout: string) => void)(null, '6.4.3');
+      (cb as (err: null, stdout: string) => void)(null, V6_VERSION);
       return {} as never;
     });
 
@@ -243,7 +246,7 @@ describe('upgrade command', () => {
   });
 
   it('shows Chinese output with --lang zh', async () => {
-    mockFetchLatestVersion.mockResolvedValue('6.4.3');
+    mockFetchLatestVersion.mockResolvedValue(V6_VERSION);
 
     const result = await runCLI('upgrade', '--lang', 'zh');
     expect(result.exitCode).toBe(0);
@@ -328,7 +331,7 @@ describe('upgrade command', () => {
 
     mockSpawn.mockReturnValue(createMockChildProcess(0));
     mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
-      (cb as (err: null, stdout: string) => void)(null, '6.4.3');
+      (cb as (err: null, stdout: string) => void)(null, V6_VERSION);
       return {} as never;
     });
 
@@ -346,7 +349,7 @@ describe('upgrade command', () => {
   });
 
   it('shows already up to date in markdown with --lang zh', async () => {
-    mockFetchLatestVersion.mockResolvedValue('6.4.3');
+    mockFetchLatestVersion.mockResolvedValue(V6_VERSION);
 
     const result = await runCLI('upgrade', '--format', 'markdown', '--lang', 'zh');
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- `upgrade.test.ts` 中硬编码 `'6.4.3'` 导致每次 antd 发新版 sync workflow 必然失败
- 改为从 `data/v6.json` 动态读取版本号，删除无意义的 `currentVersion` 断言
- 在 sync workflow 中数据同步前增加 baseline test 步骤，确保代码本身无 bug

Fixes https://github.com/ant-design/ant-design-cli/actions/runs/27412385560/job/81016572956

## Test plan
- [x] 本地 `npm test` 全部 585 测试通过
- [ ] 手动触发 sync workflow 验证不再失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)