### PR TITLE
feat(migrate): scan directory to generate targeted migration prompts

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -478,19 +478,19 @@ antd migrate 4 5                    # v4 → v5 migration checklist
 antd migrate 5 6                    # v5 → v6 migration checklist
 antd migrate v4 v5                  # v prefix is accepted and normalized
 antd migrate 4 5 --component Select # Select-specific migration
-antd migrate 4 5 --apply ./src      # auto-fix what can be auto-fixed
+antd migrate 4 5 --apply ./src      # scan ./src and generate targeted migration prompts
 antd migrate --format json
 ```
 
 **Available migration paths:** v3→v4, v4→v5, v5→v6. Multi-version migrations (e.g., v3→v6) are not supported directly — migrate step by step.
 
-Safety model for `--apply`:
-- Always runs in **dry-run mode** first, printing changes before applying
-- Requires explicit `--apply --confirm` to actually write files
-- Creates a git stash backup before writing (`antd-migrate-backup-<timestamp>`)
-- Reports every file changed with before/after diff
-- Delegates to existing `@ant-design/codemod-v5` / `@ant-design/codemod-v6` packages for actual transforms
-- If no codemod package is available for the target version, falls back to guide-only mode
+Behavior of `--apply <dir>`:
+- Scans the target directory for antd component imports (reuses the `usage` scanning logic)
+- Filters migration steps to only those relevant to the project's actual component usage
+- For steps with `searchPattern`, matches against file contents to identify affected files
+- Outputs a targeted, agent-consumable migration prompt with `**Affected files:**` listed per step
+- `Global` steps (design token migration, etc.) are always included regardless of component usage
+- Components not imported in the project are excluded from the output
 
 JSON output (guide mode):
 ```json

--- a/src/__tests__/commands/migrate.test.ts
+++ b/src/__tests__/commands/migrate.test.ts
@@ -1,5 +1,30 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { run, runCLI } from '../helper.js';
+
+const FIXTURE_DIR = join(import.meta.dirname, '..', '__fixtures_migrate_tmp__');
+
+beforeAll(() => {
+  mkdirSync(FIXTURE_DIR, { recursive: true });
+  writeFileSync(join(FIXTURE_DIR, 'App.tsx'), `
+import { Button, Select, Form } from 'antd';
+const App = () => (
+  <Form>
+    <Select dropdownClassName="old" />
+    <Button type="primary">OK</Button>
+  </Form>
+);
+`);
+  writeFileSync(join(FIXTURE_DIR, 'Other.tsx'), `
+import { Input } from 'antd';
+const Other = () => <Input />;
+`);
+});
+
+afterAll(() => {
+  rmSync(FIXTURE_DIR, { recursive: true, force: true });
+});
 
 describe('migrate', () => {
   it('should show migration guide', async () => {
@@ -87,5 +112,57 @@ describe('migrate', () => {
     expect(result.exitCode).toBe(1);
     const err = JSON.parse(result.stderr);
     expect(err.code).toBe('COMPONENT_NOT_FOUND');
+  });
+
+  describe('--apply with antd components', () => {
+    it('should filter steps to only used components', async () => {
+      const out = await run('migrate', '5', '6', '--apply', FIXTURE_DIR);
+      expect(out).toContain('Detected antd components:');
+      expect(out).toContain('Button');
+      expect(out).toContain('Select');
+      expect(out).toContain('Form');
+      // DatePicker is not imported, should not appear as a step
+      expect(out).not.toContain('DatePicker:');
+      expect(out).not.toContain('Drawer:');
+    });
+
+    it('should list affected files for pattern-matched steps', async () => {
+      const out = await run('migrate', '5', '6', '--apply', FIXTURE_DIR);
+      // Button type="primary" pattern should match App.tsx
+      expect(out).toContain('App.tsx');
+      expect(out).toContain('Affected files:');
+    });
+
+    it('should list component files as fallback when no pattern match', async () => {
+      const out = await run('migrate', '5', '6', '--apply', FIXTURE_DIR);
+      expect(out).toContain('Files using this component:');
+    });
+
+    it('should include scan results in JSON format', async () => {
+      const out = await run('migrate', '5', '6', '--apply', FIXTURE_DIR, '--format', 'json');
+      const data = JSON.parse(out);
+      expect(data.scan.fileCount).toBe(2);
+      expect(data.scan.components).toHaveProperty('Button');
+      expect(data.scan.components).toHaveProperty('Select');
+      expect(data.scan.components).not.toHaveProperty('DatePicker');
+    });
+
+    it('should include affectedFiles in JSON steps', async () => {
+      const out = await run('migrate', '5', '6', '--apply', FIXTURE_DIR, '--format', 'json');
+      const data = JSON.parse(out);
+      const buttonStep = data.autoFixSteps.find((s: any) => s.component === 'Button');
+      expect(buttonStep).toBeDefined();
+      expect(buttonStep.affectedFiles.length).toBeGreaterThan(0);
+      expect(buttonStep.affectedFiles.some((f: string) => f.includes('App.tsx'))).toBe(true);
+    });
+
+    it('should work with --component filter combined with --apply', async () => {
+      const out = await run('migrate', '5', '6', '--apply', FIXTURE_DIR, '--component', 'Button');
+      expect(out).toContain('Button');
+      expect(out).not.toContain('Select:');
+      expect(out).not.toContain('Form:');
+      // Global steps should still be excluded when --component is used
+      expect(out).not.toContain('Global:');
+    });
   });
 });

--- a/src/__tests__/snapshots/__snapshots__/migrate.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/migrate.test.ts.snap
@@ -10,6 +10,10 @@ exports[`migrate > migrate 4 5 --apply /tmp --format json 1`] = `
   "from": "4",
   "to": "5",
   "targetDir": "/tmp",
+  "scan": {
+    "fileCount": 0,
+    "components": {}
+  },
   "autoFixSteps": [
     {
       "component": "Global",
@@ -17,7 +21,8 @@ exports[`migrate > migrate 4 5 --apply /tmp --format json 1`] = `
       "searchPattern": "import\\\\s+moment\\\\s+from\\\\s+['\\"]moment['\\"]",
       "before": "import moment from 'moment';\\n<DatePicker value={moment('2024-01-01')} />",
       "after": "import dayjs from 'dayjs';\\n<DatePicker value={dayjs('2024-01-01')} />",
-      "migrationGuide": "1. Replace moment imports with dayjs\\n2. dayjs API is mostly compatible with moment\\n3. If you need locale support, import dayjs locale separately\\n4. If you need plugins (isBetween, etc.), import and extend dayjs"
+      "migrationGuide": "1. Replace moment imports with dayjs\\n2. dayjs API is mostly compatible with moment\\n3. If you need locale support, import dayjs locale separately\\n4. If you need plugins (isBetween, etc.), import and extend dayjs",
+      "affectedFiles": []
     },
     {
       "component": "Global",
@@ -25,129 +30,8 @@ exports[`migrate > migrate 4 5 --apply /tmp --format json 1`] = `
       "searchPattern": "import\\\\s+['\\"]antd/dist/antd\\\\.(css|less)['\\"]",
       "before": "import 'antd/dist/antd.css';\\n// or\\nimport 'antd/dist/antd.less';",
       "after": "// No global import needed — styles are auto-injected",
-      "migrationGuide": "Remove the global CSS/Less import. Styles are now injected via CSS-in-JS automatically."
-    },
-    {
-      "component": "Modal",
-      "description": "Prop \`visible\` renamed to \`open\`",
-      "searchPattern": "<Modal[^>]*\\\\bvisible\\\\b",
-      "before": "<Modal visible={show} onCancel={onClose}>",
-      "after": "<Modal open={show} onCancel={onClose}>",
-      "migrationGuide": "Search for \`<Modal\` with \`visible\` prop and rename to \`open\`. Also applies to Modal.confirm, Modal.info, etc."
-    },
-    {
-      "component": "Drawer",
-      "description": "Prop \`visible\` renamed to \`open\`",
-      "searchPattern": "<Drawer[^>]*\\\\bvisible\\\\b",
-      "before": "<Drawer visible={show} onClose={onClose}>",
-      "after": "<Drawer open={show} onClose={onClose}>"
-    },
-    {
-      "component": "Tooltip",
-      "description": "Prop \`visible\` renamed to \`open\`",
-      "searchPattern": "<Tooltip[^>]*\\\\bvisible\\\\b",
-      "before": "<Tooltip visible={show}>",
-      "after": "<Tooltip open={show}>"
-    },
-    {
-      "component": "Popover",
-      "description": "Prop \`visible\` renamed to \`open\`",
-      "searchPattern": "<Popover[^>]*\\\\bvisible\\\\b",
-      "before": "<Popover visible={show}>",
-      "after": "<Popover open={show}>"
-    },
-    {
-      "component": "Popconfirm",
-      "description": "Prop \`visible\` renamed to \`open\`",
-      "searchPattern": "<Popconfirm[^>]*\\\\bvisible\\\\b",
-      "before": "<Popconfirm visible={show}>",
-      "after": "<Popconfirm open={show}>"
-    },
-    {
-      "component": "Dropdown",
-      "description": "Prop \`visible\` renamed to \`open\`",
-      "searchPattern": "<Dropdown[^>]*\\\\bvisible\\\\b",
-      "before": "<Dropdown visible={show}>",
-      "after": "<Dropdown open={show}>"
-    },
-    {
-      "component": "Select",
-      "description": "Prop \`dropdownClassName\` renamed to \`popupClassName\`",
-      "searchPattern": "<Select[^>]*\\\\bdropdownClassName\\\\b",
-      "before": "<Select dropdownClassName=\\"my-dropdown\\" />",
-      "after": "<Select popupClassName=\\"my-dropdown\\" />"
-    },
-    {
-      "component": "Select",
-      "description": "Prop \`dropdownMatchSelectWidth\` renamed to \`popupMatchSelectWidth\`",
-      "searchPattern": "<Select[^>]*\\\\bdropdownMatchSelectWidth\\\\b",
-      "before": "<Select dropdownMatchSelectWidth={false} />",
-      "after": "<Select popupMatchSelectWidth={false} />"
-    },
-    {
-      "component": "TreeSelect",
-      "description": "Prop \`dropdownClassName\` renamed to \`popupClassName\`",
-      "searchPattern": "<TreeSelect[^>]*\\\\bdropdownClassName\\\\b",
-      "before": "<TreeSelect dropdownClassName=\\"my-dropdown\\" />",
-      "after": "<TreeSelect popupClassName=\\"my-dropdown\\" />"
-    },
-    {
-      "component": "Cascader",
-      "description": "Prop \`dropdownClassName\` renamed to \`popupClassName\`",
-      "searchPattern": "<Cascader[^>]*\\\\bdropdownClassName\\\\b",
-      "before": "<Cascader dropdownClassName=\\"my-dropdown\\" />",
-      "after": "<Cascader popupClassName=\\"my-dropdown\\" />"
-    },
-    {
-      "component": "AutoComplete",
-      "description": "Prop \`dropdownClassName\` renamed to \`popupClassName\`",
-      "searchPattern": "<AutoComplete[^>]*\\\\bdropdownClassName\\\\b",
-      "before": "<AutoComplete dropdownClassName=\\"my-dropdown\\" />",
-      "after": "<AutoComplete popupClassName=\\"my-dropdown\\" />"
-    },
-    {
-      "component": "DatePicker",
-      "description": "Prop \`dropdownClassName\` renamed to \`popupClassName\`",
-      "searchPattern": "<DatePicker[^>]*\\\\bdropdownClassName\\\\b",
-      "before": "<DatePicker dropdownClassName=\\"my-popup\\" />",
-      "after": "<DatePicker popupClassName=\\"my-popup\\" />"
-    },
-    {
-      "component": "TimePicker",
-      "description": "Prop \`dropdownClassName\` renamed to \`popupClassName\`",
-      "searchPattern": "<TimePicker[^>]*\\\\bdropdownClassName\\\\b",
-      "before": "<TimePicker dropdownClassName=\\"my-popup\\" />",
-      "after": "<TimePicker popupClassName=\\"my-popup\\" />"
-    },
-    {
-      "component": "Mentions",
-      "description": "Prop \`dropdownClassName\` renamed to \`popupClassName\`",
-      "searchPattern": "<Mentions[^>]*\\\\bdropdownClassName\\\\b",
-      "before": "<Mentions dropdownClassName=\\"my-dropdown\\" />",
-      "after": "<Mentions popupClassName=\\"my-dropdown\\" />"
-    },
-    {
-      "component": "BackTop",
-      "description": "Removed. Use FloatButton.BackTop instead.",
-      "searchPattern": "import\\\\s*\\\\{[^}]*\\\\bBackTop\\\\b[^}]*\\\\}\\\\s*from\\\\s*['\\"]antd['\\"]",
-      "before": "import { BackTop } from 'antd';\\n<BackTop />",
-      "after": "import { FloatButton } from 'antd';\\n<FloatButton.BackTop />"
-    },
-    {
-      "component": "Table",
-      "description": "Column prop \`filterDropdownVisible\` renamed to \`filterDropdownOpen\`.",
-      "searchPattern": "filterDropdownVisible",
-      "before": "{ title: 'Name', dataIndex: 'name', filterDropdownVisible: visible }",
-      "after": "{ title: 'Name', dataIndex: 'name', filterDropdownOpen: visible }",
-      "migrationGuide": "Search for \`filterDropdownVisible\` in Table column definitions and rename to \`filterDropdownOpen\`."
-    },
-    {
-      "component": "message",
-      "description": "\`message.warn()\` completely removed. Use \`message.warning()\` instead.",
-      "searchPattern": "\\\\bmessage\\\\.warn\\\\(",
-      "before": "message.warn('Something went wrong');",
-      "after": "message.warning('Something went wrong');",
-      "migrationGuide": "Search for \`message.warn(\` and replace with \`message.warning(\`."
+      "migrationGuide": "Remove the global CSS/Less import. Styles are now injected via CSS-in-JS automatically.",
+      "affectedFiles": []
     }
   ],
   "manualSteps": [
@@ -157,7 +41,8 @@ exports[`migrate > migrate 4 5 --apply /tmp --format json 1`] = `
       "guide": "https://ant.design/docs/react/migrate-less-variables",
       "migrationGuide": "1. Remove all Less variable overrides (modifyVars, less-loader theme config)\\n2. Wrap your app with ConfigProvider and pass a theme object\\n3. Map Less variables to Design Tokens (e.g. @primary-color → token.colorPrimary)\\n4. Remove babel-plugin-import if present (v5 supports tree-shaking natively)",
       "before": "// webpack.config.js or .umirc.ts\\ntheme: { '@primary-color': '#1890ff' }\\n\\n// or .less file\\n@import '~antd/dist/antd.less';\\n@primary-color: #1890ff;",
-      "after": "import { ConfigProvider } from 'antd';\\n<ConfigProvider theme={{ token: { colorPrimary: '#1890ff' } }}>\\n  <App />\\n</ConfigProvider>"
+      "after": "import { ConfigProvider } from 'antd';\\n<ConfigProvider theme={{ token: { colorPrimary: '#1890ff' } }}>\\n  <App />\\n</ConfigProvider>",
+      "affectedFiles": []
     },
     {
       "component": "Global",
@@ -165,99 +50,25 @@ exports[`migrate > migrate 4 5 --apply /tmp --format json 1`] = `
       "guide": "https://ant.design/components/app",
       "migrationGuide": "1. Import App component from antd\\n2. Wrap your root component with <App />\\n3. Use App.useApp() hook to access message, notification, modal instances",
       "before": "import { Button } from 'antd';\\n\\nconst MyApp = () => <Button>Click</Button>;",
-      "after": "import { App, Button } from 'antd';\\n\\nconst MyApp = () => (\\n  <App>\\n    <Button>Click</Button>\\n  </App>\\n);"
+      "after": "import { App, Button } from 'antd';\\n\\nconst MyApp = () => (\\n  <App>\\n    <Button>Click</Button>\\n  </App>\\n);",
+      "affectedFiles": []
     },
     {
       "component": "Global",
       "description": "babel-plugin-import is no longer needed. antd v5 supports tree-shaking natively.",
-      "migrationGuide": "1. Remove babel-plugin-import from babel config\\n2. Remove related configuration in .babelrc, babel.config.js, or package.json\\n3. Direct imports like \`import { Button } from 'antd'\` work without the plugin"
-    },
-    {
-      "component": "Tag",
-      "description": "Prop \`visible\` removed. Use conditional rendering instead.",
-      "migrationGuide": "Replace \`visible\` prop with conditional rendering using \`{condition && <Tag>...</Tag>}\`.",
-      "before": "<Tag visible={show}>Tag</Tag>",
-      "after": "{show && <Tag>Tag</Tag>}"
-    },
-    {
-      "component": "Comment",
-      "description": "Removed from antd. Use @ant-design/compatible instead.",
-      "guide": "https://ant.design/docs/react/migration-v5",
-      "migrationGuide": "1. Install @ant-design/compatible: npm install @ant-design/compatible\\n2. Change import from 'antd' to '@ant-design/compatible'",
-      "before": "import { Comment } from 'antd';",
-      "after": "import { Comment } from '@ant-design/compatible';"
-    },
-    {
-      "component": "PageHeader",
-      "description": "Removed from antd. Use @ant-design/pro-components instead.",
-      "guide": "https://ant.design/docs/react/migration-v5",
-      "migrationGuide": "1. Install @ant-design/pro-components: npm install @ant-design/pro-components\\n2. Change import from 'antd' to '@ant-design/pro-components'",
-      "before": "import { PageHeader } from 'antd';",
-      "after": "import { PageHeader } from '@ant-design/pro-components';"
-    },
-    {
-      "component": "message",
-      "description": "Static methods \`message.xxx()\` deprecated. Use \`App.useApp()\` hook instead for context support.",
-      "migrationGuide": "1. Wrap app with <App /> component\\n2. Use const { message } = App.useApp(); in functional components\\n3. Replace static message.xxx() calls with the hook-provided instance",
-      "before": "import { message } from 'antd';\\nmessage.success('Done!');",
-      "after": "import { App } from 'antd';\\nconst MyComponent = () => {\\n  const { message } = App.useApp();\\n  message.success('Done!');\\n};"
-    },
-    {
-      "component": "notification",
-      "description": "Static methods \`notification.xxx()\` deprecated. Use \`App.useApp()\` hook instead.",
-      "migrationGuide": "Same pattern as message — use App.useApp() to get notification instance.",
-      "before": "import { notification } from 'antd';\\nnotification.success({ message: 'Done!' });",
-      "after": "import { App } from 'antd';\\nconst MyComponent = () => {\\n  const { notification } = App.useApp();\\n  notification.success({ message: 'Done!' });\\n};"
-    },
-    {
-      "component": "Modal",
-      "description": "Static methods \`Modal.confirm()\` etc. deprecated. Use \`App.useApp()\` hook instead.",
-      "migrationGuide": "Same pattern as message/notification — use App.useApp() to get modal instance.",
-      "before": "import { Modal } from 'antd';\\nModal.confirm({ title: 'Sure?' });",
-      "after": "import { App } from 'antd';\\nconst MyComponent = () => {\\n  const { modal } = App.useApp();\\n  modal.confirm({ title: 'Sure?' });\\n};"
-    },
-    {
-      "component": "Table",
-      "description": "Column \`filterDropdown\` render args changed. \`confirm({ closeDropdown: false })\` replaced by separate \`close\` function.",
-      "migrationGuide": "Update filterDropdown render function signature to use the new \`close\` parameter instead of \`confirm({ closeDropdown: false })\`.",
-      "before": "filterDropdown: ({ confirm }) => (\\n  <Button onClick={() => confirm({ closeDropdown: false })}>Filter</Button>\\n)",
-      "after": "filterDropdown: ({ confirm, close }) => (\\n  <Button onClick={() => close()}>Filter</Button>\\n)"
-    },
-    {
-      "component": "Form",
-      "description": "Prop \`labelCol\` and \`wrapperCol\` can now be set globally via ConfigProvider.",
-      "migrationGuide": "Optional improvement: move repeated labelCol/wrapperCol config to ConfigProvider for consistency."
-    },
-    {
-      "component": "Slider",
-      "description": "Tooltip-related APIs converged into \`tooltip\` property. \`tooltipVisible\` → \`tooltip.open\`, \`tipFormatter\` → \`tooltip.formatter\`, etc.",
-      "migrationGuide": "Migrate Slider tooltip props:\\n- tooltipVisible → tooltip.open\\n- tipFormatter → tooltip.formatter\\n- tooltipPlacement → tooltip.placement\\n- getTooltipPopupContainer → tooltip.getPopupContainer",
-      "before": "<Slider tooltipVisible={show} tipFormatter={(v) => \`\${v}%\`} />",
-      "after": "<Slider tooltip={{ open: show, formatter: (v) => \`\${v}%\` }} />"
-    },
-    {
-      "component": "Drawer",
-      "description": "Drawer \`style\` and \`className\` now apply to the panel node. Use \`rootStyle\` and \`rootClassName\` for the wrapper.",
-      "migrationGuide": "In v5, Drawer \`style\` and \`className\` are migrated to the Drawer panel node.\\nIf you were using them to style the wrapper/mask, replace with \`rootStyle\` and \`rootClassName\`.",
-      "before": "<Drawer className=\\"my-drawer\\" style={{ zIndex: 1000 }}>",
-      "after": "<Drawer rootClassName=\\"my-drawer\\" rootStyle={{ zIndex: 1000 }}>"
-    },
-    {
-      "component": "notification",
-      "description": "Static method \`notification.close()\` renamed to \`notification.destroy()\`. Static config options restricted.",
-      "migrationGuide": "1. Rename notification.close() to notification.destroy()\\n2. Static methods no longer allow dynamic prefixCls, maxCount, top, bottom, getContainer in open()\\n3. Use useNotification hook if you need different configurations",
-      "before": "notification.close(key);",
-      "after": "notification.destroy(key);"
+      "migrationGuide": "1. Remove babel-plugin-import from babel config\\n2. Remove related configuration in .babelrc, babel.config.js, or package.json\\n3. Direct imports like \`import { Button } from 'antd'\` work without the plugin",
+      "affectedFiles": []
     },
     {
       "component": "Global",
       "description": "IE browser is no longer supported. v5 uses CSS-in-JS and modern CSS features.",
-      "migrationGuide": "If your project needs IE support, you cannot upgrade to v5. Consider using @ant-design/cssinjs StyleProvider for :where selector compatibility with older browsers."
+      "migrationGuide": "If your project needs IE support, you cannot upgrade to v5. Consider using @ant-design/cssinjs StyleProvider for :where selector compatibility with older browsers.",
+      "affectedFiles": []
     }
   ],
   "summary": {
-    "totalAutoFix": 19,
-    "totalManual": 15
+    "totalAutoFix": 2,
+    "totalManual": 4
   }
 }"
 `;
@@ -266,9 +77,15 @@ exports[`migrate > migrate 4 5 --apply /tmp 1`] = `
 "# Auto-Migration Prompt: antd v4 → v5
 # Target directory: /tmp
 
+## Scan Results
+
+Scanned 0 files in \`/tmp\`
+
+**No antd component imports detected.**
+
 ## Instructions for Code Agent
 
-Scan all .ts/.tsx/.js/.jsx files in \`/tmp\` and apply the following migrations.
+Apply the following migrations to the files listed below.
 For each file changed, verify the fix compiles correctly before moving on.
 
 ## Auto-fixable Changes
@@ -308,235 +125,6 @@ import 'antd/dist/antd.less';
 **After:**
 \`\`\`tsx
 // No global import needed — styles are auto-injected
-\`\`\`
-
-### 3. Modal: Prop \`visible\` renamed to \`open\`
-
-**Search regex:** \`<Modal[^>]*\\bvisible\\b\`
-
-Search for \`<Modal\` with \`visible\` prop and rename to \`open\`. Also applies to Modal.confirm, Modal.info, etc.
-
-**Before:**
-\`\`\`tsx
-<Modal visible={show} onCancel={onClose}>
-\`\`\`
-**After:**
-\`\`\`tsx
-<Modal open={show} onCancel={onClose}>
-\`\`\`
-
-### 4. Drawer: Prop \`visible\` renamed to \`open\`
-
-**Search regex:** \`<Drawer[^>]*\\bvisible\\b\`
-
-**Before:**
-\`\`\`tsx
-<Drawer visible={show} onClose={onClose}>
-\`\`\`
-**After:**
-\`\`\`tsx
-<Drawer open={show} onClose={onClose}>
-\`\`\`
-
-### 5. Tooltip: Prop \`visible\` renamed to \`open\`
-
-**Search regex:** \`<Tooltip[^>]*\\bvisible\\b\`
-
-**Before:**
-\`\`\`tsx
-<Tooltip visible={show}>
-\`\`\`
-**After:**
-\`\`\`tsx
-<Tooltip open={show}>
-\`\`\`
-
-### 6. Popover: Prop \`visible\` renamed to \`open\`
-
-**Search regex:** \`<Popover[^>]*\\bvisible\\b\`
-
-**Before:**
-\`\`\`tsx
-<Popover visible={show}>
-\`\`\`
-**After:**
-\`\`\`tsx
-<Popover open={show}>
-\`\`\`
-
-### 7. Popconfirm: Prop \`visible\` renamed to \`open\`
-
-**Search regex:** \`<Popconfirm[^>]*\\bvisible\\b\`
-
-**Before:**
-\`\`\`tsx
-<Popconfirm visible={show}>
-\`\`\`
-**After:**
-\`\`\`tsx
-<Popconfirm open={show}>
-\`\`\`
-
-### 8. Dropdown: Prop \`visible\` renamed to \`open\`
-
-**Search regex:** \`<Dropdown[^>]*\\bvisible\\b\`
-
-**Before:**
-\`\`\`tsx
-<Dropdown visible={show}>
-\`\`\`
-**After:**
-\`\`\`tsx
-<Dropdown open={show}>
-\`\`\`
-
-### 9. Select: Prop \`dropdownClassName\` renamed to \`popupClassName\`
-
-**Search regex:** \`<Select[^>]*\\bdropdownClassName\\b\`
-
-**Before:**
-\`\`\`tsx
-<Select dropdownClassName="my-dropdown" />
-\`\`\`
-**After:**
-\`\`\`tsx
-<Select popupClassName="my-dropdown" />
-\`\`\`
-
-### 10. Select: Prop \`dropdownMatchSelectWidth\` renamed to \`popupMatchSelectWidth\`
-
-**Search regex:** \`<Select[^>]*\\bdropdownMatchSelectWidth\\b\`
-
-**Before:**
-\`\`\`tsx
-<Select dropdownMatchSelectWidth={false} />
-\`\`\`
-**After:**
-\`\`\`tsx
-<Select popupMatchSelectWidth={false} />
-\`\`\`
-
-### 11. TreeSelect: Prop \`dropdownClassName\` renamed to \`popupClassName\`
-
-**Search regex:** \`<TreeSelect[^>]*\\bdropdownClassName\\b\`
-
-**Before:**
-\`\`\`tsx
-<TreeSelect dropdownClassName="my-dropdown" />
-\`\`\`
-**After:**
-\`\`\`tsx
-<TreeSelect popupClassName="my-dropdown" />
-\`\`\`
-
-### 12. Cascader: Prop \`dropdownClassName\` renamed to \`popupClassName\`
-
-**Search regex:** \`<Cascader[^>]*\\bdropdownClassName\\b\`
-
-**Before:**
-\`\`\`tsx
-<Cascader dropdownClassName="my-dropdown" />
-\`\`\`
-**After:**
-\`\`\`tsx
-<Cascader popupClassName="my-dropdown" />
-\`\`\`
-
-### 13. AutoComplete: Prop \`dropdownClassName\` renamed to \`popupClassName\`
-
-**Search regex:** \`<AutoComplete[^>]*\\bdropdownClassName\\b\`
-
-**Before:**
-\`\`\`tsx
-<AutoComplete dropdownClassName="my-dropdown" />
-\`\`\`
-**After:**
-\`\`\`tsx
-<AutoComplete popupClassName="my-dropdown" />
-\`\`\`
-
-### 14. DatePicker: Prop \`dropdownClassName\` renamed to \`popupClassName\`
-
-**Search regex:** \`<DatePicker[^>]*\\bdropdownClassName\\b\`
-
-**Before:**
-\`\`\`tsx
-<DatePicker dropdownClassName="my-popup" />
-\`\`\`
-**After:**
-\`\`\`tsx
-<DatePicker popupClassName="my-popup" />
-\`\`\`
-
-### 15. TimePicker: Prop \`dropdownClassName\` renamed to \`popupClassName\`
-
-**Search regex:** \`<TimePicker[^>]*\\bdropdownClassName\\b\`
-
-**Before:**
-\`\`\`tsx
-<TimePicker dropdownClassName="my-popup" />
-\`\`\`
-**After:**
-\`\`\`tsx
-<TimePicker popupClassName="my-popup" />
-\`\`\`
-
-### 16. Mentions: Prop \`dropdownClassName\` renamed to \`popupClassName\`
-
-**Search regex:** \`<Mentions[^>]*\\bdropdownClassName\\b\`
-
-**Before:**
-\`\`\`tsx
-<Mentions dropdownClassName="my-dropdown" />
-\`\`\`
-**After:**
-\`\`\`tsx
-<Mentions popupClassName="my-dropdown" />
-\`\`\`
-
-### 17. BackTop: Removed. Use FloatButton.BackTop instead.
-
-**Search regex:** \`import\\s*\\{[^}]*\\bBackTop\\b[^}]*\\}\\s*from\\s*['"]antd['"]\`
-
-**Before:**
-\`\`\`tsx
-import { BackTop } from 'antd';
-<BackTop />
-\`\`\`
-**After:**
-\`\`\`tsx
-import { FloatButton } from 'antd';
-<FloatButton.BackTop />
-\`\`\`
-
-### 18. Table: Column prop \`filterDropdownVisible\` renamed to \`filterDropdownOpen\`.
-
-**Search regex:** \`filterDropdownVisible\`
-
-Search for \`filterDropdownVisible\` in Table column definitions and rename to \`filterDropdownOpen\`.
-
-**Before:**
-\`\`\`tsx
-{ title: 'Name', dataIndex: 'name', filterDropdownVisible: visible }
-\`\`\`
-**After:**
-\`\`\`tsx
-{ title: 'Name', dataIndex: 'name', filterDropdownOpen: visible }
-\`\`\`
-
-### 19. message: \`message.warn()\` completely removed. Use \`message.warning()\` instead.
-
-**Search regex:** \`\\bmessage\\.warn\\(\`
-
-Search for \`message.warn(\` and replace with \`message.warning(\`.
-
-**Before:**
-\`\`\`tsx
-message.warn('Something went wrong');
-\`\`\`
-**After:**
-\`\`\`tsx
-message.warning('Something went wrong');
 \`\`\`
 
 ## Manual Changes (require human review)
@@ -598,175 +186,7 @@ const MyApp = () => (
 2. Remove related configuration in .babelrc, babel.config.js, or package.json
 3. Direct imports like \`import { Button } from 'antd'\` work without the plugin
 
-### 4. Tag: Prop \`visible\` removed. Use conditional rendering instead.
-
-Replace \`visible\` prop with conditional rendering using \`{condition && <Tag>...</Tag>}\`.
-
-**Before:**
-\`\`\`tsx
-<Tag visible={show}>Tag</Tag>
-\`\`\`
-**After:**
-\`\`\`tsx
-{show && <Tag>Tag</Tag>}
-\`\`\`
-
-### 5. Comment: Removed from antd. Use @ant-design/compatible instead.
-
-1. Install @ant-design/compatible: npm install @ant-design/compatible
-2. Change import from 'antd' to '@ant-design/compatible'
-
-**Before:**
-\`\`\`tsx
-import { Comment } from 'antd';
-\`\`\`
-**After:**
-\`\`\`tsx
-import { Comment } from '@ant-design/compatible';
-\`\`\`
-
-**Reference:** https://ant.design/docs/react/migration-v5
-
-### 6. PageHeader: Removed from antd. Use @ant-design/pro-components instead.
-
-1. Install @ant-design/pro-components: npm install @ant-design/pro-components
-2. Change import from 'antd' to '@ant-design/pro-components'
-
-**Before:**
-\`\`\`tsx
-import { PageHeader } from 'antd';
-\`\`\`
-**After:**
-\`\`\`tsx
-import { PageHeader } from '@ant-design/pro-components';
-\`\`\`
-
-**Reference:** https://ant.design/docs/react/migration-v5
-
-### 7. message: Static methods \`message.xxx()\` deprecated. Use \`App.useApp()\` hook instead for context support.
-
-1. Wrap app with <App /> component
-2. Use const { message } = App.useApp(); in functional components
-3. Replace static message.xxx() calls with the hook-provided instance
-
-**Before:**
-\`\`\`tsx
-import { message } from 'antd';
-message.success('Done!');
-\`\`\`
-**After:**
-\`\`\`tsx
-import { App } from 'antd';
-const MyComponent = () => {
-  const { message } = App.useApp();
-  message.success('Done!');
-};
-\`\`\`
-
-### 8. notification: Static methods \`notification.xxx()\` deprecated. Use \`App.useApp()\` hook instead.
-
-Same pattern as message — use App.useApp() to get notification instance.
-
-**Before:**
-\`\`\`tsx
-import { notification } from 'antd';
-notification.success({ message: 'Done!' });
-\`\`\`
-**After:**
-\`\`\`tsx
-import { App } from 'antd';
-const MyComponent = () => {
-  const { notification } = App.useApp();
-  notification.success({ message: 'Done!' });
-};
-\`\`\`
-
-### 9. Modal: Static methods \`Modal.confirm()\` etc. deprecated. Use \`App.useApp()\` hook instead.
-
-Same pattern as message/notification — use App.useApp() to get modal instance.
-
-**Before:**
-\`\`\`tsx
-import { Modal } from 'antd';
-Modal.confirm({ title: 'Sure?' });
-\`\`\`
-**After:**
-\`\`\`tsx
-import { App } from 'antd';
-const MyComponent = () => {
-  const { modal } = App.useApp();
-  modal.confirm({ title: 'Sure?' });
-};
-\`\`\`
-
-### 10. Table: Column \`filterDropdown\` render args changed. \`confirm({ closeDropdown: false })\` replaced by separate \`close\` function.
-
-Update filterDropdown render function signature to use the new \`close\` parameter instead of \`confirm({ closeDropdown: false })\`.
-
-**Before:**
-\`\`\`tsx
-filterDropdown: ({ confirm }) => (
-  <Button onClick={() => confirm({ closeDropdown: false })}>Filter</Button>
-)
-\`\`\`
-**After:**
-\`\`\`tsx
-filterDropdown: ({ confirm, close }) => (
-  <Button onClick={() => close()}>Filter</Button>
-)
-\`\`\`
-
-### 11. Form: Prop \`labelCol\` and \`wrapperCol\` can now be set globally via ConfigProvider.
-
-Optional improvement: move repeated labelCol/wrapperCol config to ConfigProvider for consistency.
-
-### 12. Slider: Tooltip-related APIs converged into \`tooltip\` property. \`tooltipVisible\` → \`tooltip.open\`, \`tipFormatter\` → \`tooltip.formatter\`, etc.
-
-Migrate Slider tooltip props:
-- tooltipVisible → tooltip.open
-- tipFormatter → tooltip.formatter
-- tooltipPlacement → tooltip.placement
-- getTooltipPopupContainer → tooltip.getPopupContainer
-
-**Before:**
-\`\`\`tsx
-<Slider tooltipVisible={show} tipFormatter={(v) => \`\${v}%\`} />
-\`\`\`
-**After:**
-\`\`\`tsx
-<Slider tooltip={{ open: show, formatter: (v) => \`\${v}%\` }} />
-\`\`\`
-
-### 13. Drawer: Drawer \`style\` and \`className\` now apply to the panel node. Use \`rootStyle\` and \`rootClassName\` for the wrapper.
-
-In v5, Drawer \`style\` and \`className\` are migrated to the Drawer panel node.
-If you were using them to style the wrapper/mask, replace with \`rootStyle\` and \`rootClassName\`.
-
-**Before:**
-\`\`\`tsx
-<Drawer className="my-drawer" style={{ zIndex: 1000 }}>
-\`\`\`
-**After:**
-\`\`\`tsx
-<Drawer rootClassName="my-drawer" rootStyle={{ zIndex: 1000 }}>
-\`\`\`
-
-### 14. notification: Static method \`notification.close()\` renamed to \`notification.destroy()\`. Static config options restricted.
-
-1. Rename notification.close() to notification.destroy()
-2. Static methods no longer allow dynamic prefixCls, maxCount, top, bottom, getContainer in open()
-3. Use useNotification hook if you need different configurations
-
-**Before:**
-\`\`\`tsx
-notification.close(key);
-\`\`\`
-**After:**
-\`\`\`tsx
-notification.destroy(key);
-\`\`\`
-
-### 15. Global: IE browser is no longer supported. v5 uses CSS-in-JS and modern CSS features.
+### 4. Global: IE browser is no longer supported. v5 uses CSS-in-JS and modern CSS features.
 
 If your project needs IE support, you cannot upgrade to v5. Consider using @ant-design/cssinjs StyleProvider for :where selector compatibility with older browsers."
 `;

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,6 +1,5 @@
 import type { Command } from 'commander';
 import type { GlobalOptions, OutputFormat } from '../types.js';
-import { readFileSync } from 'node:fs';
 import { relative } from 'node:path';
 import { localize } from '../types.js';
 import { output } from '../output/formatter.js';
@@ -128,6 +127,8 @@ function formatJson(from: string, to: string, steps: MigrationStep[]): void {
   }, 'json');
 }
 
+const GLOBAL_COMPONENT = 'Global';
+
 interface MigrationScanResult {
   fileCount: number;
   componentFiles: Map<string, string[]>;
@@ -138,16 +139,6 @@ function scanForMigration(dir: string, steps: MigrationStep[]): MigrationScanRes
   const files = collectFiles(dir);
   const componentFiles = new Map<string, string[]>();
   const patternMatches = new Map<string, string[]>();
-  const antdFiles = new Set<string>();
-
-  for (const file of files) {
-    const fileUsage = scanFile(file);
-    if (fileUsage.size > 0) antdFiles.add(file);
-    for (const [name] of fileUsage) {
-      if (!componentFiles.has(name)) componentFiles.set(name, []);
-      componentFiles.get(name)!.push(file);
-    }
-  }
 
   const patternsToSearch = new Map<string, RegExp>();
   for (const step of steps) {
@@ -158,13 +149,14 @@ function scanForMigration(dir: string, steps: MigrationStep[]): MigrationScanRes
     }
   }
 
-  if (patternsToSearch.size > 0) {
-    for (const file of antdFiles) {
-      let content: string;
-      try {
-        content = readFileSync(file, 'utf-8');
-      } catch { continue; }
+  for (const file of files) {
+    const { usage, content } = scanFile(file, { returnContent: patternsToSearch.size > 0 });
+    for (const [name] of usage) {
+      if (!componentFiles.has(name)) componentFiles.set(name, []);
+      componentFiles.get(name)!.push(file);
+    }
 
+    if (content && usage.size > 0) {
       for (const [pattern, regex] of patternsToSearch) {
         if (regex.test(content)) {
           if (!patternMatches.has(pattern)) patternMatches.set(pattern, []);
@@ -177,12 +169,26 @@ function scanForMigration(dir: string, steps: MigrationStep[]): MigrationScanRes
   return { fileCount: files.length, componentFiles, patternMatches };
 }
 
+function getAffectedFiles(
+  step: MigrationStep,
+  scan: MigrationScanResult,
+  relativePath: (f: string) => string,
+): string[] {
+  const patternFiles = step.searchPattern && scan.patternMatches.get(step.searchPattern);
+  if (patternFiles && patternFiles.length > 0) return patternFiles.map(relativePath);
+  if (step.component !== GLOBAL_COMPONENT) {
+    const compFiles = scan.componentFiles.get(step.component);
+    if (compFiles && compFiles.length > 0) return compFiles.map(relativePath);
+  }
+  return [];
+}
+
 function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir: string, format: OutputFormat): void {
   const scan = scanForMigration(dir, steps);
   const usedComponents = new Set(scan.componentFiles.keys());
 
   const relevantSteps = steps.filter((s) =>
-    s.component === 'Global' || usedComponents.has(s.component)
+    s.component === GLOBAL_COMPONENT || usedComponents.has(s.component)
   );
 
   const fixableSteps = relevantSteps.filter((s) => s.autoFixable && s.searchPattern);
@@ -210,7 +216,7 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
         before: s.before,
         after: s.after,
         migrationGuide: s.migrationGuide,
-        affectedFiles: ((s.searchPattern && scan.patternMatches.get(s.searchPattern)) || []).map(relativePath),
+        affectedFiles: getAffectedFiles(s, scan, relativePath),
       })),
       manualSteps: manualSteps.map((s) => ({
         component: s.component,
@@ -219,7 +225,7 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
         migrationGuide: s.migrationGuide,
         before: s.before,
         after: s.after,
-        affectedFiles: ((s.searchPattern && scan.patternMatches.get(s.searchPattern)) || []).map(relativePath),
+        affectedFiles: getAffectedFiles(s, scan, relativePath),
       })),
       summary: {
         totalAutoFix: fixableSteps.length,
@@ -234,7 +240,6 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
   lines.push(`# Target directory: ${dir}`);
   lines.push('');
 
-  // Scan results summary
   lines.push('## Scan Results');
   lines.push('');
   lines.push(`Scanned ${scan.fileCount} files in \`${dir}\``);
@@ -263,25 +268,7 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
       const step = fixableSteps[i];
       lines.push(`### ${i + 1}. ${step.component}: ${step.description}`);
       lines.push('');
-
-      const affected = step.searchPattern ? scan.patternMatches.get(step.searchPattern) : undefined;
-      if (affected && affected.length > 0) {
-        lines.push('**Affected files:**');
-        for (const file of affected) {
-          lines.push(`- ${relativePath(file)}`);
-        }
-        lines.push('');
-      } else if (step.component !== 'Global') {
-        const compFiles = scan.componentFiles.get(step.component);
-        if (compFiles && compFiles.length > 0) {
-          lines.push('**Files using this component:**');
-          for (const file of compFiles) {
-            lines.push(`- ${relativePath(file)}`);
-          }
-          lines.push('');
-        }
-      }
-
+      pushAffectedFileLines(lines, getAffectedFiles(step, scan, relativePath), step);
       if (step.searchPattern) {
         lines.push(`**Search regex:** \`${step.searchPattern}\``);
         lines.push('');
@@ -291,14 +278,8 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
         lines.push('');
       }
       if (step.before && step.after) {
-        lines.push('**Before:**');
-        lines.push('```tsx');
-        lines.push(step.before);
-        lines.push('```');
-        lines.push('**After:**');
-        lines.push('```tsx');
-        lines.push(step.after);
-        lines.push('```');
+        lines.push('**Before:**', '```tsx', step.before, '```');
+        lines.push('**After:**', '```tsx', step.after, '```');
         lines.push('');
       }
     }
@@ -311,38 +292,14 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
       const step = manualSteps[i];
       lines.push(`### ${i + 1}. ${step.component}: ${step.description}`);
       lines.push('');
-
-      const affected = step.searchPattern ? scan.patternMatches.get(step.searchPattern) : undefined;
-      if (affected && affected.length > 0) {
-        lines.push('**Affected files:**');
-        for (const file of affected) {
-          lines.push(`- ${relativePath(file)}`);
-        }
-        lines.push('');
-      } else if (step.component !== 'Global') {
-        const compFiles = scan.componentFiles.get(step.component);
-        if (compFiles && compFiles.length > 0) {
-          lines.push('**Files using this component:**');
-          for (const file of compFiles) {
-            lines.push(`- ${relativePath(file)}`);
-          }
-          lines.push('');
-        }
-      }
-
+      pushAffectedFileLines(lines, getAffectedFiles(step, scan, relativePath), step);
       if (step.migrationGuide) {
         lines.push(step.migrationGuide);
         lines.push('');
       }
       if (step.before && step.after) {
-        lines.push('**Before:**');
-        lines.push('```tsx');
-        lines.push(step.before);
-        lines.push('```');
-        lines.push('**After:**');
-        lines.push('```tsx');
-        lines.push(step.after);
-        lines.push('```');
+        lines.push('**Before:**', '```tsx', step.before, '```');
+        lines.push('**After:**', '```tsx', step.after, '```');
         lines.push('');
       }
       if (step.guide) {
@@ -353,6 +310,16 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
   }
 
   console.log(lines.join('\n'));
+}
+
+function pushAffectedFileLines(lines: string[], files: string[], step: MigrationStep): void {
+  if (files.length === 0) return;
+  const label = step.searchPattern ? '**Affected files:**' : '**Files using this component:**';
+  lines.push(label);
+  for (const file of files) {
+    lines.push(`- ${file}`);
+  }
+  lines.push('');
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,8 +1,11 @@
 import type { Command } from 'commander';
 import type { GlobalOptions, OutputFormat } from '../types.js';
+import { readFileSync } from 'node:fs';
+import { relative } from 'node:path';
 import { localize } from '../types.js';
 import { output } from '../output/formatter.js';
 import { printError, createError, ErrorCodes } from '../output/error.js';
+import { collectFiles, scanFile } from '../utils/scan.js';
 import { V3_TO_V4_STEPS } from './migrate-v3-to-v4.js';
 import { V4_TO_V5_STEPS } from './migrate-v4-to-v5.js';
 import { V5_TO_V6_STEPS } from './migrate-v5-to-v6.js';
@@ -125,15 +128,79 @@ function formatJson(from: string, to: string, steps: MigrationStep[]): void {
   }, 'json');
 }
 
+interface MigrationScanResult {
+  fileCount: number;
+  componentFiles: Map<string, string[]>;
+  patternMatches: Map<string, string[]>;
+}
+
+function scanForMigration(dir: string, steps: MigrationStep[]): MigrationScanResult {
+  const files = collectFiles(dir);
+  const componentFiles = new Map<string, string[]>();
+  const patternMatches = new Map<string, string[]>();
+
+  for (const file of files) {
+    const fileUsage = scanFile(file);
+    for (const [name] of fileUsage) {
+      if (!componentFiles.has(name)) componentFiles.set(name, []);
+      componentFiles.get(name)!.push(file);
+    }
+  }
+
+  const patternsToSearch = new Map<string, RegExp>();
+  for (const step of steps) {
+    if (step.searchPattern && !patternsToSearch.has(step.searchPattern)) {
+      try {
+        patternsToSearch.set(step.searchPattern, new RegExp(step.searchPattern));
+      } catch { /* skip invalid regex */ }
+    }
+  }
+
+  if (patternsToSearch.size > 0) {
+    for (const file of files) {
+      let content: string;
+      try {
+        content = readFileSync(file, 'utf-8');
+      } catch { continue; }
+
+      for (const [pattern, regex] of patternsToSearch) {
+        if (regex.test(content)) {
+          if (!patternMatches.has(pattern)) patternMatches.set(pattern, []);
+          patternMatches.get(pattern)!.push(file);
+        }
+      }
+    }
+  }
+
+  return { fileCount: files.length, componentFiles, patternMatches };
+}
+
 function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir: string, format: OutputFormat): void {
-  const fixableSteps = steps.filter((s) => s.autoFixable && s.searchPattern);
-  const manualSteps = steps.filter((s) => !s.autoFixable);
+  const scan = scanForMigration(dir, steps);
+  const usedComponents = new Set(scan.componentFiles.keys());
+
+  const relevantSteps = steps.filter((s) =>
+    s.component === 'Global' || usedComponents.has(s.component)
+  );
+
+  const fixableSteps = relevantSteps.filter((s) => s.autoFixable && s.searchPattern);
+  const manualSteps = relevantSteps.filter((s) => !s.autoFixable);
+
+  const relativePath = (file: string) => relative(process.cwd(), file);
 
   if (format === 'json') {
+    const componentSummary: Record<string, string[]> = {};
+    for (const [name, files] of scan.componentFiles) {
+      componentSummary[name] = files.map(relativePath);
+    }
     output({
       from,
       to,
       targetDir: dir,
+      scan: {
+        fileCount: scan.fileCount,
+        components: componentSummary,
+      },
       autoFixSteps: fixableSteps.map((s) => ({
         component: s.component,
         description: s.description,
@@ -141,6 +208,7 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
         before: s.before,
         after: s.after,
         migrationGuide: s.migrationGuide,
+        affectedFiles: (s.searchPattern && scan.patternMatches.get(s.searchPattern) || []).map(relativePath),
       })),
       manualSteps: manualSteps.map((s) => ({
         component: s.component,
@@ -149,6 +217,7 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
         migrationGuide: s.migrationGuide,
         before: s.before,
         after: s.after,
+        affectedFiles: (s.searchPattern && scan.patternMatches.get(s.searchPattern) || []).map(relativePath),
       })),
       summary: {
         totalAutoFix: fixableSteps.length,
@@ -162,9 +231,26 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
   lines.push(`# Auto-Migration Prompt: antd v${from} → v${to}`);
   lines.push(`# Target directory: ${dir}`);
   lines.push('');
+
+  // Scan results summary
+  lines.push('## Scan Results');
+  lines.push('');
+  lines.push(`Scanned ${scan.fileCount} files in \`${dir}\``);
+  lines.push('');
+  if (scan.componentFiles.size > 0) {
+    const compList = [...scan.componentFiles.entries()]
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([name, files]) => `${name} (${files.length} files)`)
+      .join(', ');
+    lines.push(`**Detected antd components:** ${compList}`);
+  } else {
+    lines.push('**No antd component imports detected.**');
+  }
+  lines.push('');
+
   lines.push('## Instructions for Code Agent');
   lines.push('');
-  lines.push(`Scan all .ts/.tsx/.js/.jsx files in \`${dir}\` and apply the following migrations.`);
+  lines.push('Apply the following migrations to the files listed below.');
   lines.push('For each file changed, verify the fix compiles correctly before moving on.');
   lines.push('');
 
@@ -175,6 +261,25 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
       const step = fixableSteps[i];
       lines.push(`### ${i + 1}. ${step.component}: ${step.description}`);
       lines.push('');
+
+      const affected = step.searchPattern ? scan.patternMatches.get(step.searchPattern) : undefined;
+      if (affected && affected.length > 0) {
+        lines.push('**Affected files:**');
+        for (const file of affected) {
+          lines.push(`- ${relativePath(file)}`);
+        }
+        lines.push('');
+      } else if (step.component !== 'Global') {
+        const compFiles = scan.componentFiles.get(step.component);
+        if (compFiles && compFiles.length > 0) {
+          lines.push('**Files using this component:**');
+          for (const file of compFiles) {
+            lines.push(`- ${relativePath(file)}`);
+          }
+          lines.push('');
+        }
+      }
+
       if (step.searchPattern) {
         lines.push(`**Search regex:** \`${step.searchPattern}\``);
         lines.push('');
@@ -204,6 +309,25 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
       const step = manualSteps[i];
       lines.push(`### ${i + 1}. ${step.component}: ${step.description}`);
       lines.push('');
+
+      const affected = step.searchPattern ? scan.patternMatches.get(step.searchPattern) : undefined;
+      if (affected && affected.length > 0) {
+        lines.push('**Affected files:**');
+        for (const file of affected) {
+          lines.push(`- ${relativePath(file)}`);
+        }
+        lines.push('');
+      } else if (step.component !== 'Global') {
+        const compFiles = scan.componentFiles.get(step.component);
+        if (compFiles && compFiles.length > 0) {
+          lines.push('**Files using this component:**');
+          for (const file of compFiles) {
+            lines.push(`- ${relativePath(file)}`);
+          }
+          lines.push('');
+        }
+      }
+
       if (step.migrationGuide) {
         lines.push(step.migrationGuide);
         lines.push('');
@@ -248,7 +372,7 @@ export function registerMigrateCommand(program: Command): void {
     .command('migrate <from> <to>')
     .description('Version migration guide with optional auto-fix')
     .option('--component <name>', 'Component-specific migration guide')
-    .option('--apply <dir>', 'Generate migration prompts for scanning a directory')
+    .option('--apply <dir>', 'Scan directory and generate targeted migration prompts with affected files')
     .option('--confirm', 'Confirm auto-fix (required with --apply)')
     .action((rawFrom: string, rawTo: string, cmdOpts: { component?: string; apply?: string; confirm?: boolean }) => {
       const opts = program.opts<GlobalOptions>();

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -138,9 +138,11 @@ function scanForMigration(dir: string, steps: MigrationStep[]): MigrationScanRes
   const files = collectFiles(dir);
   const componentFiles = new Map<string, string[]>();
   const patternMatches = new Map<string, string[]>();
+  const antdFiles = new Set<string>();
 
   for (const file of files) {
     const fileUsage = scanFile(file);
+    if (fileUsage.size > 0) antdFiles.add(file);
     for (const [name] of fileUsage) {
       if (!componentFiles.has(name)) componentFiles.set(name, []);
       componentFiles.get(name)!.push(file);
@@ -157,7 +159,7 @@ function scanForMigration(dir: string, steps: MigrationStep[]): MigrationScanRes
   }
 
   if (patternsToSearch.size > 0) {
-    for (const file of files) {
+    for (const file of antdFiles) {
       let content: string;
       try {
         content = readFileSync(file, 'utf-8');
@@ -208,7 +210,7 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
         before: s.before,
         after: s.after,
         migrationGuide: s.migrationGuide,
-        affectedFiles: (s.searchPattern && scan.patternMatches.get(s.searchPattern) || []).map(relativePath),
+        affectedFiles: ((s.searchPattern && scan.patternMatches.get(s.searchPattern)) || []).map(relativePath),
       })),
       manualSteps: manualSteps.map((s) => ({
         component: s.component,
@@ -217,7 +219,7 @@ function formatApplyPrompt(from: string, to: string, steps: MigrationStep[], dir
         migrationGuide: s.migrationGuide,
         before: s.before,
         after: s.after,
-        affectedFiles: (s.searchPattern && scan.patternMatches.get(s.searchPattern) || []).map(relativePath),
+        affectedFiles: ((s.searchPattern && scan.patternMatches.get(s.searchPattern)) || []).map(relativePath),
       })),
       summary: {
         totalAutoFix: fixableSteps.length,
@@ -371,7 +373,7 @@ export function registerMigrateCommand(program: Command): void {
   program
     .command('migrate <from> <to>')
     .description('Version migration guide with optional auto-fix')
-    .option('--component <name>', 'Component-specific migration guide')
+    .option('--component <name>', 'Component-specific migration guide (combinable with --apply)')
     .option('--apply <dir>', 'Scan directory and generate targeted migration prompts with affected files')
     .option('--confirm', 'Confirm auto-fix (required with --apply)')
     .action((rawFrom: string, rawTo: string, cmdOpts: { component?: string; apply?: string; confirm?: boolean }) => {

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -1,10 +1,8 @@
 import type { Command } from 'commander';
 import type { GlobalOptions } from '../types.js';
 import { localize } from '../types.js';
-import { readFileSync } from 'node:fs';
-import { parseSync, Visitor } from 'oxc-parser';
 import { formatTable, output } from '../output/formatter.js';
-import { collectFiles, getJSXElementName } from '../utils/scan.js';
+import { collectFiles, scanFile } from '../utils/scan.js';
 import { loadMetadataForVersion } from '../data/loader.js';
 import { detectVersion } from '../data/version.js';
 
@@ -13,64 +11,6 @@ interface ComponentUsage {
   imports: number;
   files: string[];
   subComponents?: Record<string, number>;
-}
-
-function scanFile(filePath: string): Map<string, { count: number; subComponents: Map<string, number> }> {
-  const result = new Map<string, { count: number; subComponents: Map<string, number> }>();
-
-  let content: string;
-  try {
-    content = readFileSync(filePath, 'utf-8');
-  /* v8 ignore start -- fs read error */
-  } catch {
-    return result;
-  }
-  /* v8 ignore stop */
-
-  if (!content.includes('antd')) return result;
-
-  const parsed = parseSync(filePath, content);
-  if (parsed.errors.length > 0) return result;
-
-  const importedNames = new Set<string>();
-
-  const visitor = new Visitor({
-    ImportDeclaration(node: any) {
-      const source = node.source.value;
-      if (source !== 'antd' && !source.startsWith('antd/')) return;
-      if (node.importKind === 'type') return;
-
-      for (const spec of node.specifiers) {
-        if (spec.type === 'ImportSpecifier') {
-          if (spec.importKind === 'type') continue;
-          const name = spec.imported?.name || spec.local?.name;
-          if (name) {
-            importedNames.add(name);
-            if (!result.has(name)) {
-              result.set(name, { count: 0, subComponents: new Map() });
-            }
-            result.get(name)!.count++;
-          }
-        }
-      }
-    },
-
-    // Detect sub-component JSX usage: <Form.Item>, <Table.Column>, etc.
-    JSXOpeningElement(node: any) {
-      const fullName = getJSXElementName(node.name);
-      if (!fullName.includes('.')) return;
-      const [parent] = fullName.split('.');
-      if (importedNames.has(parent)) {
-        const entry = result.get(parent);
-        if (entry) {
-          entry.subComponents.set(fullName, (entry.subComponents.get(fullName) || 0) + 1);
-        }
-      }
-    },
-  });
-  visitor.visit(parsed.program);
-
-  return result;
 }
 
 export function registerUsageCommand(program: Command): void {

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -37,7 +37,7 @@ export function registerUsageCommand(program: Command): void {
       const aggregated = new Map<string, { imports: number; files: Set<string>; subComponents: Map<string, number> }>();
 
       for (const file of files) {
-        const fileUsage = scanFile(file);
+        const { usage: fileUsage } = scanFile(file);
         for (const [name, data] of fileUsage) {
           if (!aggregated.has(name)) {
             aggregated.set(name, { imports: 0, files: new Set(), subComponents: new Map() });

--- a/src/utils/scan.ts
+++ b/src/utils/scan.ts
@@ -45,23 +45,28 @@ export function getJSXElementName(name: any): string {
   return '';
 }
 
+export interface ScanFileResult {
+  usage: Map<string, { count: number; subComponents: Map<string, number> }>;
+  content: string | undefined;
+}
+
 /** Scan a single file for antd component imports and sub-component JSX usage. */
-export function scanFile(filePath: string): Map<string, { count: number; subComponents: Map<string, number> }> {
-  const result = new Map<string, { count: number; subComponents: Map<string, number> }>();
+export function scanFile(filePath: string, opts?: { returnContent?: boolean }): ScanFileResult {
+  const usage = new Map<string, { count: number; subComponents: Map<string, number> }>();
 
   let content: string;
   try {
     content = readFileSync(filePath, 'utf-8');
   /* v8 ignore start -- fs read error */
   } catch {
-    return result;
+    return { usage, content: undefined };
   }
   /* v8 ignore stop */
 
-  if (!content.includes('antd')) return result;
+  if (!content.includes('antd')) return { usage, content: opts?.returnContent ? content : undefined };
 
   const parsed = parseSync(filePath, content);
-  if (parsed.errors.length > 0) return result;
+  if (parsed.errors.length > 0) return { usage, content: opts?.returnContent ? content : undefined };
 
   const importedNames = new Set<string>();
 
@@ -77,10 +82,10 @@ export function scanFile(filePath: string): Map<string, { count: number; subComp
           const name = spec.imported?.name || spec.local?.name;
           if (name) {
             importedNames.add(name);
-            if (!result.has(name)) {
-              result.set(name, { count: 0, subComponents: new Map() });
+            if (!usage.has(name)) {
+              usage.set(name, { count: 0, subComponents: new Map() });
             }
-            result.get(name)!.count++;
+            usage.get(name)!.count++;
           }
         }
       }
@@ -91,7 +96,7 @@ export function scanFile(filePath: string): Map<string, { count: number; subComp
       if (!fullName.includes('.')) return;
       const [parent] = fullName.split('.');
       if (importedNames.has(parent)) {
-        const entry = result.get(parent);
+        const entry = usage.get(parent);
         if (entry) {
           entry.subComponents.set(fullName, (entry.subComponents.get(fullName) || 0) + 1);
         }
@@ -100,6 +105,6 @@ export function scanFile(filePath: string): Map<string, { count: number; subComp
   });
   visitor.visit(parsed.program);
 
-  return result;
+  return { usage, content: opts?.returnContent ? content : undefined };
 }
 

--- a/src/utils/scan.ts
+++ b/src/utils/scan.ts
@@ -1,5 +1,4 @@
 import { statSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import fg from 'fast-glob';
 import { parseSync, Visitor } from 'oxc-parser';
 

--- a/src/utils/scan.ts
+++ b/src/utils/scan.ts
@@ -1,6 +1,7 @@
-import { statSync } from 'node:fs';
+import { statSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import fg from 'fast-glob';
+import { parseSync, Visitor } from 'oxc-parser';
 
 export const SCAN_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
 export const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.next']);
@@ -43,5 +44,63 @@ export function getJSXElementName(name: any): string {
     return name.name;
   }
   return '';
+}
+
+/** Scan a single file for antd component imports and sub-component JSX usage. */
+export function scanFile(filePath: string): Map<string, { count: number; subComponents: Map<string, number> }> {
+  const result = new Map<string, { count: number; subComponents: Map<string, number> }>();
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, 'utf-8');
+  /* v8 ignore start -- fs read error */
+  } catch {
+    return result;
+  }
+  /* v8 ignore stop */
+
+  if (!content.includes('antd')) return result;
+
+  const parsed = parseSync(filePath, content);
+  if (parsed.errors.length > 0) return result;
+
+  const importedNames = new Set<string>();
+
+  const visitor = new Visitor({
+    ImportDeclaration(node: any) {
+      const source = node.source.value;
+      if (source !== 'antd' && !source.startsWith('antd/')) return;
+      if (node.importKind === 'type') return;
+
+      for (const spec of node.specifiers) {
+        if (spec.type === 'ImportSpecifier') {
+          if (spec.importKind === 'type') continue;
+          const name = spec.imported?.name || spec.local?.name;
+          if (name) {
+            importedNames.add(name);
+            if (!result.has(name)) {
+              result.set(name, { count: 0, subComponents: new Map() });
+            }
+            result.get(name)!.count++;
+          }
+        }
+      }
+    },
+
+    JSXOpeningElement(node: any) {
+      const fullName = getJSXElementName(node.name);
+      if (!fullName.includes('.')) return;
+      const [parent] = fullName.split('.');
+      if (importedNames.has(parent)) {
+        const entry = result.get(parent);
+        if (entry) {
+          entry.subComponents.set(fullName, (entry.subComponents.get(fullName) || 0) + 1);
+        }
+      }
+    },
+  });
+  visitor.visit(parsed.program);
+
+  return result;
 }
 


### PR DESCRIPTION
## Summary

- `antd migrate 4 5 --apply ./src` now actually scans the target directory for antd component usage
- Only outputs migration steps relevant to the project's imported components (Global steps always included)
- Each migration step lists **Affected files** matched by `searchPattern` regex
- Extracted `scanFile()` from `usage.ts` into shared `src/utils/scan.ts` for reuse

Closes #88

## Example output

Given a project with two files:

```tsx
// App.tsx
import { Button, Select, Form, Table } from 'antd';
const App = () => (
  <Form>
    <Form.Item>
      <Select dropdownClassName="old-class" />
      <Button type="primary">Submit</Button>
    </Form.Item>
    <Table bordered />
  </Form>
);

// Login.tsx
import { Button, Input } from 'antd';
const Login = () => (
  <div>
    <Input />
    <Button type="link">Forgot?</Button>
  </div>
);
```

Running `antd migrate 5 6 --apply .` produces:

```markdown
# Auto-Migration Prompt: antd v5 → v6
# Target directory: .

## Scan Results

Scanned 2 files in `.`

**Detected antd components:** Button (2 files), Select (1 files), Form (1 files), Table (1 files), Input (1 files)

## Instructions for Code Agent

Apply the following migrations to the files listed below.
For each file changed, verify the fix compiles correctly before moving on.

## Auto-fixable Changes

### 1. Button: Prop `type` split into `color` and `variant` for styling.

**Affected files:**
- App.tsx
- Login.tsx

**Search regex:** `<Button[^>]*\btype\s*=\s*['"](?:primary|dashed|link|text)['"]`

Button type prop is decomposed:
- type="primary" → color="primary" variant="solid"
- type="dashed" → variant="dashed"
- type="link" → variant="link"
- type="text" → variant="text"

...

## Manual Changes (require human review)

### 1. Global: React >= 18 required.

...

### 5. Form: `onFinish` no longer includes all Form.List data.

**Files using this component:**
- App.tsx

...

### 6. Select: Multiple deprecated props.

**Affected files:**
- App.tsx

...
```

Key behaviors:
- Only components actually imported in the project appear (no DatePicker, Drawer, etc.)
- Steps with `searchPattern` show **Affected files** (files where the pattern matches)
- Steps without `searchPattern` show **Files using this component** (files that import it)
- `Global` steps always appear regardless of component usage

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — all 585 tests pass
- [x] Snapshots updated for new `--apply` output format
- [x] Manual test: run `antd migrate 5 6 --apply .` in a project with antd components, verified output lists affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)