### PR TITLE
test: keep update check cache mocked

### DIFF
--- a/src/__tests__/update-check.test.ts
+++ b/src/__tests__/update-check.test.ts
@@ -36,12 +36,10 @@ describe('update-check', () => {
     vi.restoreAllMocks();
     memStore = {};
     mockCacheStore();
-    cacheStore.delete('updateCache');
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
-    cacheStore.delete('updateCache');
     vi.restoreAllMocks();
     restoreCI();
   });

--- a/src/__tests__/update-check.test.ts
+++ b/src/__tests__/update-check.test.ts
@@ -5,16 +5,16 @@ import * as fetchModule from '../utils/fetch.js';
 
 // Replace the Conf-backed store with an in-memory shim to avoid cross-test on-disk races.
 let memStore: Record<string, unknown> = {};
-beforeEach(() => {
-  memStore = {};
-});
-vi.spyOn(cacheStore, 'get').mockImplementation(((key: string) => memStore[key]) as never);
-vi.spyOn(cacheStore, 'set').mockImplementation(((key: string, value: unknown) => {
-  memStore[key] = value;
-}) as never);
-vi.spyOn(cacheStore, 'delete').mockImplementation(((key: string) => {
-  delete memStore[key];
-}) as never);
+
+function mockCacheStore() {
+  vi.spyOn(cacheStore, 'get').mockImplementation(((key: string) => memStore[key]) as never);
+  vi.spyOn(cacheStore, 'set').mockImplementation(((key: string, value: unknown) => {
+    memStore[key] = value;
+  }) as never);
+  vi.spyOn(cacheStore, 'delete').mockImplementation(((key: string) => {
+    delete memStore[key];
+  }) as never);
+}
 
 const ORIG_CI = process.env.CI;
 const ORIG_NO_UPDATE = process.env.NO_UPDATE_CHECK;
@@ -34,13 +34,15 @@ describe('update-check', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    memStore = {};
+    mockCacheStore();
     cacheStore.delete('updateCache');
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     cacheStore.delete('updateCache');
+    vi.restoreAllMocks();
     restoreCI();
   });
 


### PR DESCRIPTION
## Summary
- keep update-check tests on the in-memory cacheStore mock after restoreAllMocks
- reset the mocked cache state with memStore = {} for each test
- remove redundant mocked cacheStore.delete calls so teardown cannot fall back to the real Conf-backed store

## Verification
- npx vitest run src/__tests__/update-check.test.ts
- npm run typecheck
- GitHub checks: ci, CodeQL, pkg-size, Socket, and codecov are passing

## Review Notes
- Gemini inline feedback was handled and the review thread is resolved
- The remaining non-green merge state is an external review-service credit status, not a code CI failure