### PR TITLE
fix: avoid stack traces for invalid global options

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -753,6 +753,8 @@ Exit codes:
 
 Common error codes: `COMPONENT_NOT_FOUND`, `VERSION_NOT_FOUND`, `NO_PROJECT_DETECTED`, `UNSUPPORTED_VERSION_FEATURE` (e.g. tokens for v3/v4), `NETWORK_ERROR`, `PM_NOT_FOUND`, `UPGRADE_FAILED`, `VERSION_UNCHANGED`.
 
+Invalid global options such as `--format` and `--lang` exit with code `1` and print only the validation message to stderr; internal sentinel errors or Node.js stack traces must not be shown to users.
+
 ## Technical Architecture
 
 ```

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
 import { run, runCLI } from './helper.js';
 
 describe('CLI', () => {
@@ -29,6 +30,21 @@ describe('CLI', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Invalid format 'csv'");
     expect(result.stderr).toContain('json, text, markdown');
+  });
+
+  it('should not print an internal stack trace for invalid global options', () => {
+    const env = { ...process.env };
+    delete env.VITEST;
+    const result = spawnSync(process.execPath, ['dist/index.js', 'list', '--format', 'csv'], {
+      cwd: process.cwd(),
+      env: { ...env, NO_UPDATE_CHECK: '1' },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Invalid format 'csv'");
+    expect(result.stderr).not.toContain('Error: EXIT:1');
+    expect(result.stderr).not.toContain('at Object.callback');
   });
 
   it('should reject invalid --lang values', async () => {

--- a/src/__tests__/helper.ts
+++ b/src/__tests__/helper.ts
@@ -29,6 +29,10 @@ export async function runCLI(...args: string[]): Promise<CLIRunResult> {
     stdout += String(data);
     return true;
   });
+  const errWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation((data: unknown) => {
+    stderr += String(data);
+    return true;
+  });
   const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
     forcedExitCode = typeof code === 'number' ? code : 0;
     // Throw to halt execution after process.exit, matching real behavior
@@ -50,6 +54,7 @@ export async function runCLI(...args: string[]): Promise<CLIRunResult> {
     logSpy.mockRestore();
     errSpy.mockRestore();
     writeSpy.mockRestore();
+    errWriteSpy.mockRestore();
     exitSpy.mockRestore();
     process.exitCode = origExitCode as number | undefined;
     forcedExitCode = capturedExitCode;

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,13 +75,11 @@ export function createProgram(): Command {
     const validLangs = ['en', 'zh'];
     if (opts.format && !validFormats.includes(opts.format)) {
       console.error(`Error: Invalid format '${opts.format}'. Must be one of: ${validFormats.join(', ')}`);
-      process.exitCode = 1;
-      throw new Error('EXIT:1');
+      process.exit(1);
     }
     if (opts.lang && !validLangs.includes(opts.lang)) {
       console.error(`Error: Invalid language '${opts.lang}'. Must be one of: ${validLangs.join(', ')}`);
-      process.exitCode = 1;
-      throw new Error('EXIT:1');
+      process.exit(1);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,12 +74,10 @@ export function createProgram(): Command {
     const validFormats = ['json', 'text', 'markdown'];
     const validLangs = ['en', 'zh'];
     if (opts.format && !validFormats.includes(opts.format)) {
-      console.error(`Error: Invalid format '${opts.format}'. Must be one of: ${validFormats.join(', ')}`);
-      process.exit(1);
+      program.error(`Error: Invalid format '${opts.format}'. Must be one of: ${validFormats.join(', ')}`);
     }
     if (opts.lang && !validLangs.includes(opts.lang)) {
-      console.error(`Error: Invalid language '${opts.lang}'. Must be one of: ${validLangs.join(', ')}`);
-      process.exit(1);
+      program.error(`Error: Invalid language '${opts.lang}'. Must be one of: ${validLangs.join(', ')}`);
     }
   });
 


### PR DESCRIPTION
## Summary
- validate invalid global --format and --lang values through Commander program.error()
- add a child-process regression test for the built CLI entrypoint
- document that invalid global options should not expose internal stack traces

## Verification
- npm run build
- npx vitest run src/__tests__/cli.test.ts
- npm run typecheck
- NO_UPDATE_CHECK=1 node dist/index.js list --format csv
- GitHub checks: ci, CodeQL, pkg-size, Socket, and codecov are passing

## Review Notes
- Gemini feedback to use program.error() was implemented
- The suggestion to run src/index.ts directly with tsx was not applied because the source entrypoint depends on the tsup-injected __CLI_VERSION__ constant; verified tsx fails with ReferenceError before command handling
- The remaining non-green merge state is an external review-service credit status, not a code CI failure