### PR TITLE
fix: count antd subpath default imports in usage

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -382,7 +382,7 @@ JSON output:
 
 #### `antd usage [dir]`
 
-Scan project for antd component/API usage statistics using AST-based analysis (powered by `oxc-parser`). Detects direct imports (`import { Button } from 'antd'`), sub-component JSX usage (`<Form.Item>`, `<Table.Column>`), and named imports from sub-paths.
+Scan project for antd component/API usage statistics using AST-based analysis (powered by `oxc-parser`). Detects direct imports (`import { Button } from 'antd'`), default component imports from sub-paths (`import Button from 'antd/es/button'` / `antd/lib/button`), sub-component JSX usage (`<Form.Item>`, `<Table.Column>`), and named imports from sub-paths.
 
 ```bash
 antd usage                          # scan current directory

--- a/src/__tests__/commands/usage.test.ts
+++ b/src/__tests__/commands/usage.test.ts
@@ -27,6 +27,27 @@ describe('usage', () => {
     }
   });
 
+  it('should count default imports from antd component subpaths', async () => {
+    const tmpDir = join(__dirname, '__tmp_usage_subpath__');
+    const fixture = join(tmpDir, 'test.tsx');
+    try {
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(fixture, `import Button from 'antd/es/button';\nimport DatePicker from 'antd/lib/date-picker';\nimport Row from 'antd/es/grid/row';\nimport Col from 'antd/es/grid/col';\nimport InternalThing from 'antd/es/_util/thing';\nconst App = () => <><Button>Test</Button><DatePicker /><Row><Col /></Row></>;`);
+      const out = await run('usage', tmpDir, '--format', 'json');
+      const data = JSON.parse(out);
+      const components = data.components.map((c: { name: string }) => c.name);
+      expect(components).toContain('Button');
+      expect(components).toContain('DatePicker');
+      expect(components).toContain('Row');
+      expect(components).toContain('Col');
+      expect(components).not.toContain('Grid');
+      expect(components).not.toContain('InternalThing');
+      expect(data.summary.totalImports).toBe(4);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('should show message when no antd imports found', async () => {
     const tmpDir = join(__dirname, '__tmp_usage_empty__');
     const fixture = join(tmpDir, 'test.tsx');

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander';
 import type { GlobalOptions } from '../types.js';
 import { localize } from '../types.js';
 import { formatTable, output } from '../output/formatter.js';
-import { collectFiles, scanFile } from '../utils/scan.js';
+import { collectFiles, normalizeComponentKey, scanFile } from '../utils/scan.js';
 import { loadMetadataForVersion } from '../data/loader.js';
 import { detectVersion } from '../data/version.js';
 
@@ -26,10 +26,14 @@ export function registerUsageCommand(program: Command): void {
       const versionInfo = detectVersion(opts.version);
       const store = loadMetadataForVersion(versionInfo.version);
       const knownComponents = new Set(store.components.map((c) => c.name));
+      const componentBySubpath = new Map(store.components.map((c) => [normalizeComponentKey(c.name), c.name]));
       for (const comp of store.components) {
         for (const subKey of Object.keys(comp.subComponentProps ?? {})) {
           const leaf = subKey.split('.').pop();
-          if (leaf) knownComponents.add(leaf);
+          if (leaf) {
+            knownComponents.add(leaf);
+            componentBySubpath.set(normalizeComponentKey(leaf), leaf);
+          }
         }
       }
 
@@ -37,7 +41,7 @@ export function registerUsageCommand(program: Command): void {
       const aggregated = new Map<string, { imports: number; files: Set<string>; subComponents: Map<string, number> }>();
 
       for (const file of files) {
-        const { usage: fileUsage } = scanFile(file);
+        const { usage: fileUsage } = scanFile(file, { componentBySubpath });
         for (const [name, data] of fileUsage) {
           if (!aggregated.has(name)) {
             aggregated.set(name, { imports: 0, files: new Set(), subComponents: new Map() });

--- a/src/utils/scan.ts
+++ b/src/utils/scan.ts
@@ -50,8 +50,37 @@ export interface ScanFileResult {
   content: string | undefined;
 }
 
+export interface ScanFileOptions {
+  returnContent?: boolean;
+  componentBySubpath?: Map<string, string>;
+}
+
+export function normalizeComponentKey(name: string): string {
+  return name.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+function getSubpathComponentName(source: string, componentBySubpath?: Map<string, string>): string | undefined {
+  if (!componentBySubpath) return undefined;
+
+  const parts = source.split('/');
+  if (parts[0] !== 'antd') return undefined;
+
+  const startIndex = parts[1] === 'es' || parts[1] === 'lib' ? 2 : 1;
+  if (parts.length <= startIndex) return undefined;
+
+  const subpathParts = parts.slice(startIndex);
+  if (subpathParts.includes('style') || subpathParts.includes('locale')) return undefined;
+
+  for (let i = parts.length - 1; i >= startIndex; i--) {
+    const componentName = componentBySubpath.get(normalizeComponentKey(parts[i]));
+    if (componentName) return componentName;
+  }
+
+  return undefined;
+}
+
 /** Scan a single file for antd component imports and sub-component JSX usage. */
-export function scanFile(filePath: string, opts?: { returnContent?: boolean }): ScanFileResult {
+export function scanFile(filePath: string, opts?: ScanFileOptions): ScanFileResult {
   const usage = new Map<string, { count: number; subComponents: Map<string, number> }>();
 
   let content: string;
@@ -88,6 +117,16 @@ export function scanFile(filePath: string, opts?: { returnContent?: boolean }): 
             usage.get(name)!.count++;
           }
         }
+        if (spec.type === 'ImportDefaultSpecifier') {
+          const name = getSubpathComponentName(source, opts?.componentBySubpath);
+          if (name) {
+            importedNames.add(name);
+            if (!usage.has(name)) {
+              usage.set(name, { count: 0, subComponents: new Map() });
+            }
+            usage.get(name)!.count++;
+          }
+        }
       }
     },
 
@@ -107,4 +146,3 @@ export function scanFile(filePath: string, opts?: { returnContent?: boolean }): 
 
   return { usage, content: opts?.returnContent ? content : undefined };
 }
-


### PR DESCRIPTION
## Summary
- count default component imports from antd/es/* and antd/lib/* in usage scans
- resolve nested subpaths such as antd/es/grid/row from right to left
- normalize component names through bundled metadata instead of hardcoding component names
- document subpath default import detection

## Verification
- npx vitest run src/__tests__/commands/usage.test.ts
- npx vitest run src/__tests__/commands/usage.test.ts --coverage
- npx vitest run src/__tests__/commands/migrate.test.ts
- npm run typecheck
- npm run build
- NO_UPDATE_CHECK=1 node dist/index.js usage <fixture> --format json
- GitHub checks: ci, CodeQL, pkg-size, Socket, and codecov are passing

## Review Notes
- Gemini feedback for nested Row/Col subpath imports was implemented
- Patch coverage was restored by covering the unmapped internal subpath branch
- The remaining non-green merge state is an external review-service credit status, not a code CI failure