### PR TITLE
fix: keep doctor bug checks offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ antd changelog 4.24.0 5.0.0 Select  # API diff for Select only
 
 ### `antd doctor`
 
-Runs 10 checks against your project: antd installed, React version compat, duplicate antd/dayjs/cssinjs installs, peer dependency satisfaction, theme config, babel-plugin-import usage, and CSS-in-JS setup.
+Runs 10 checks against your project: antd installed and bundled known-bug version data, React version compat, duplicate antd/dayjs/cssinjs installs, peer dependency satisfaction, theme config, babel-plugin-import usage, and CSS-in-JS setup. All checks use bundled/local data and do not make network calls.
 
 ```bash
 antd doctor

--- a/data/bug-versions.json
+++ b/data/bug-versions.json
@@ -1,0 +1,85 @@
+{
+  "3.9.3": [
+    "https://github.com/ant-design/ant-design/commit/6550df34b639ab0b3bf2c1cbf9b9828735c1fd41"
+  ],
+  ">= 3.10.0 <=3.10.9": [
+    "https://github.com/ant-design/ant-design/commit/6550df34b639ab0b3bf2c1cbf9b9828735c1fd41"
+  ],
+  ">= 3.11.0 <=3.11.5": [
+    "https://github.com/ant-design/ant-design/commit/6550df34b639ab0b3bf2c1cbf9b9828735c1fd41"
+  ],
+  ">= 4.21.6 < 4.22.0": ["https://github.com/ant-design/ant-design/pull/36682"],
+  ">= 4.22.2 <= 4.22.5": [
+    "https://github.com/ant-design/ant-design/issues/36932",
+    "https://github.com/ant-design/ant-design/pull/36800",
+    "https://github.com/ant-design/ant-design/issues/37024"
+  ],
+  "4.23.0": ["https://github.com/ant-design/ant-design/issues/37461"],
+  "4.23.5": [
+    "https://github.com/ant-design/ant-design/issues/37929",
+    "https://github.com/ant-design/ant-design/issues/37931"
+  ],
+  "4.24.0": ["https://github.com/ant-design/ant-design/issues/38371"],
+  "5.0.4": ["https://github.com/ant-design/ant-design/issues/39284"],
+  "5.0.6": ["https://github.com/ant-design/ant-design/issues/39807"],
+  "5.1.0": ["https://github.com/react-component/drawer/pull/370"],
+  "5.1.2": ["https://github.com/ant-design/ant-design/issues/39949"],
+  "5.1.3": ["https://github.com/ant-design/ant-design/issues/40113"],
+  "5.1.4": ["https://github.com/ant-design/ant-design/issues/40186"],
+  ">= 5.2.3 <= 5.3.0": [
+    "https://github.com/ant-design/ant-design/pull/40719#issuecomment-1453418135"
+  ],
+  "5.4.1": ["https://github.com/ant-design/ant-design/issues/41751"],
+  ">= 5.4.3 <= 5.4.5": [
+    "https://github.com/ant-design/cssinjs/pull/108",
+    "https://github.com/ant-design/ant-design/pull/41993"
+  ],
+  "5.6.2": ["https://github.com/ant-design/ant-design/issues/43113"],
+  "5.6.3": ["https://github.com/ant-design/ant-design/issues/43190"],
+  "5.7.0": ["https://github.com/ant-design/ant-design/issues/43684"],
+  "5.7.1": [
+    "https://github.com/ant-design/ant-design/issues/43654",
+    "https://github.com/ant-design/ant-design/issues/43684"
+  ],
+  "5.8.0": ["https://github.com/ant-design/ant-design/issues/43943"],
+  "5.9.1": ["https://github.com/ant-design/ant-design/issues/44907"],
+  "5.10.0": ["https://github.com/ant-design/ant-design/issues/45289"],
+  "5.11.0": ["https://github.com/ant-design/ant-design/issues/45742"],
+  "5.11.1": ["https://github.com/ant-design/ant-design/issues/45883"],
+  "5.11.2": ["https://github.com/ant-design/ant-design/issues/46005"],
+  "5.11.4": ["https://github.com/ant-design/ant-design/pull/46103"],
+  "5.12.3": ["https://github.com/ant-design/ant-design/issues/46525"],
+  "5.12.6": ["https://github.com/ant-design/ant-design/issues/46719"],
+  "5.13.0": ["https://github.com/ant-design/ant-design/pull/46962"],
+  "5.14.0": ["https://github.com/ant-design/ant-design/issues/47354"],
+  "5.15.0": ["https://github.com/ant-design/ant-design/pull/47504#issuecomment-1980459433"],
+  ">= 5.16.0 <= 5.16.1": ["https://github.com/ant-design/ant-design/issues/48200"],
+  "5.16.3": ["https://github.com/ant-design/ant-design/issues/48568"],
+  "5.17.1": ["https://github.com/ant-design/ant-design/issues/48913"],
+  "5.18.2": ["https://github.com/ant-design/ant-design/pull/49487"],
+  "5.20.4": ["https://github.com/ant-design/ant-design/issues/50687"],
+  "5.21.0": [
+    "https://github.com/ant-design/ant-design/issues/50960",
+    "https://github.com/ant-design/ant-design/issues/50969"
+  ],
+  "5.21.6": [
+    "https://github.com/ant-design/ant-design/issues/51420",
+    "https://github.com/ant-design/ant-design/issues/51430"
+  ],
+  "5.22.0": [
+    "https://github.com/ant-design/ant-design/issues/51601",
+    "https://github.com/ant-design/ant-design/issues/51420",
+    "https://github.com/ant-design/ant-design/issues/51430"
+  ],
+  "5.22.1": [
+    "https://github.com/ant-design/ant-design/issues/51420",
+    "https://github.com/ant-design/ant-design/issues/51430"
+  ],
+  "5.22.6": ["https://github.com/ant-design/ant-design/issues/52124"],
+  "5.24.8": ["https://github.com/ant-design/ant-design/issues/53652"],
+  "5.25.0": ["https://github.com/ant-design/ant-design/issues/53764"],
+  ">= 5.28.1 <= 5.29.0": ["https://github.com/ant-design/ant-design/issues/55755"],
+  "6.3.0": ["https://github.com/ant-design/ant-design/pull/56946"],
+  "6.4.0": ["https://github.com/ant-design/ant-design/issues/56858"],
+  "6.4.1": ["https://github.com/ant-design/ant-design/issues/57975"]
+}

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -28,7 +28,9 @@ const DATA_DIR = path.join(PROJECT_ROOT, 'data');
 // It is major-grained (rewritten only across major releases), so we sync it per
 // major into data/design-v{major}.md. See syncDesignDocs().
 const DESIGN_SOURCE = 'DESIGN.md';
+const BUG_VERSIONS_SOURCE = 'BUG_VERSIONS.json';
 const designTarget = (major: number) => path.join(DATA_DIR, `design-v${major}.md`);
+const bugVersionsTarget = () => path.join(DATA_DIR, 'bug-versions.json');
 
 function parseArgs(args: string[]): { antdDir: string } {
   let antdDir = '';
@@ -266,6 +268,25 @@ function validateData() {
       errors++;
     }
   }
+
+  const bugVersionsFile = bugVersionsTarget();
+  try {
+    const data = JSON.parse(fs.readFileSync(bugVersionsFile, 'utf8')) as Record<string, unknown>;
+    if (Object.keys(data).length === 0) {
+      console.error(`  FAIL: ${bugVersionsFile} is empty`);
+      errors++;
+    }
+    for (const [range, urls] of Object.entries(data)) {
+      if (!Array.isArray(urls) || urls.some((url) => typeof url !== 'string')) {
+        console.error(`  FAIL: ${bugVersionsFile} has invalid URLs for range "${range}"`);
+        errors++;
+      }
+    }
+  } catch (err) {
+    console.error(`  FAIL: ${bugVersionsFile} is not valid JSON: ${err instanceof Error ? err.message : err}`);
+    errors++;
+  }
+
   if (errors > 0) {
     console.error(`\nValidation failed with ${errors} error(s)`);
     process.exit(1);
@@ -307,6 +328,35 @@ function syncDesignDocs(antdDir: string, latestTagByMajor: Map<number, string>) 
     fs.copyFileSync(source, designTarget(major));
     console.log(`  v${major}: synced ${DESIGN_SOURCE} from antd@${tag} → data/design-v${major}.md`);
   }
+}
+
+/**
+ * Sync the root BUG_VERSIONS.json from the latest stable antd checkout.
+ *
+ * This file powers `antd doctor`'s known-bug version check. Keeping it in the
+ * normal sync pipeline preserves the CLI's offline runtime behavior without
+ * letting the bundled bug database drift from upstream.
+ */
+function syncBugVersions(antdDir: string, latestTagByMajor: Map<number, string>) {
+  const latestMajor = Math.max(...latestTagByMajor.keys());
+  const tag = latestTagByMajor.get(latestMajor);
+  if (!tag) {
+    console.log(`  no latest tag, keeping existing data/bug-versions.json`);
+    return;
+  }
+  if (!checkout(antdDir, tag)) {
+    console.log(`  could not check out ${tag}, keeping existing data/bug-versions.json`);
+    return;
+  }
+
+  const source = path.join(antdDir, BUG_VERSIONS_SOURCE);
+  if (!fs.existsSync(source)) {
+    console.log(`  ${BUG_VERSIONS_SOURCE} not found in antd@${tag}, keeping existing data/bug-versions.json`);
+    return;
+  }
+
+  fs.copyFileSync(source, bugVersionsTarget());
+  console.log(`  synced ${BUG_VERSIONS_SOURCE} from antd@${tag} → data/bug-versions.json`);
 }
 
 function main() {
@@ -393,6 +443,10 @@ function main() {
   // Sync per-major design.md files (DESIGN.md) from each major's latest checkout.
   console.log('\n=== Syncing design.md ===');
   syncDesignDocs(antdDir, latestTagByMajor);
+
+  // Sync known-bug version data from latest stable antd.
+  console.log('\n=== Syncing BUG_VERSIONS.json ===');
+  syncBugVersions(antdDir, latestTagByMajor);
 
   // Validate extracted data
   console.log('\n=== Validating extracted data ===');

--- a/spec.md
+++ b/spec.md
@@ -350,7 +350,7 @@ antd doctor --format json
 ```
 
 Checks (in order):
-1. `antd-installed` — verifies antd is installed in the project; severity: error
+1. `antd-installed` — verifies antd is installed in the project and checks the installed version against bundled BUG_VERSIONS data; severity: error. This check is fully offline and does not fetch remote bug metadata or write runtime cache.
 2. `react-compat` — antd version compatibility with React version
 3. `duplicate-install` — detects multiple antd installations
 4. `dayjs-duplicate` — detects multiple dayjs installations in node_modules; severity: error

--- a/src/__tests__/commands/doctor.test.ts
+++ b/src/__tests__/commands/doctor.test.ts
@@ -3,6 +3,7 @@ import { writeFileSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { run, runCLI } from '../helper.js';
+import { cacheStore } from '../../utils/store.js';
 
 async function runDoctorInTempDir(packages: Record<string, object>): Promise<any> {
   const tempDir = mkdtempSync(join(tmpdir(), 'antd-cli-test-'));
@@ -120,6 +121,39 @@ describe('doctor', () => {
     expect(names).toContain('cssinjs-duplicate');
     expect(names).toContain('cssinjs-compat');
     expect(names).toContain('icons-compat');
+  });
+
+  it('should check bundled bug versions without network or cache writes', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network calls not allowed'));
+    const cacheSetSpy = vi.spyOn(cacheStore, 'set').mockImplementation(() => undefined);
+
+    try {
+      const data = await runDoctorInTempDir({
+        antd: { version: '6.4.1', peerDependencies: {} },
+        react: { version: '18.2.0' },
+      });
+
+      const check = data.checks.find((c: { name: string }) => c.name === 'antd-installed');
+      expect(check?.status).toBe('fail');
+      expect(check?.message).toContain('known bugs');
+      expect(check?.suggestion).toContain('https://github.com/ant-design/ant-design/issues/57975');
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(cacheSetSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      cacheSetSpy.mockRestore();
+    }
+  });
+
+  it('should not match bundled bug versions when installed antd version is missing', async () => {
+    const data = await runDoctorInTempDir({
+      antd: { peerDependencies: {} },
+      react: { version: '18.2.0' },
+    });
+
+    const check = data.checks.find((c: { name: string }) => c.name === 'antd-installed');
+    expect(check?.status).toBe('pass');
+    expect(check?.message).toContain('unknown');
   });
 });
 

--- a/src/__tests__/doctor-nobugs.test.ts
+++ b/src/__tests__/doctor-nobugs.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 vi.mock('../utils/bug-versions.js', () => ({
   findBugInfo: () => null,
   getBugVersions: async () => null,
+  loadBundledBugVersions: () => null,
 }));
 
 const { runCLI } = await import('./helper.js');

--- a/src/__tests__/fetch-bug-versions.test.ts
+++ b/src/__tests__/fetch-bug-versions.test.ts
@@ -1,20 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetchWithTimeout, fetchFirstJson } from '../utils/fetch.js';
-import { findBugInfo, getBugVersions } from '../utils/bug-versions.js';
-import { cacheStore } from '../utils/store.js';
-
-// Use an in-memory shim for cacheStore to avoid cross-test on-disk Conf races.
-let memStore: Record<string, unknown> = {};
-beforeEach(() => {
-  memStore = {};
-});
-vi.spyOn(cacheStore, 'get').mockImplementation(((key: string) => memStore[key]) as never);
-vi.spyOn(cacheStore, 'set').mockImplementation(((key: string, value: unknown) => {
-  memStore[key] = value;
-}) as never);
-vi.spyOn(cacheStore, 'delete').mockImplementation(((key: string) => {
-  delete memStore[key];
-}) as never);
+import { findBugInfo } from '../utils/bug-versions.js';
 
 describe('utils/fetch', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
@@ -56,14 +42,6 @@ describe('utils/fetch', () => {
 });
 
 describe('utils/bug-versions', () => {
-  beforeEach(() => {
-    cacheStore.delete('bugVersionsCache');
-  });
-
-  afterEach(() => {
-    cacheStore.delete('bugVersionsCache');
-  });
-
   it('findBugInfo matches a version against a range', () => {
     const map = { '>=5.0.0 <5.10.0': ['https://example/issue'] };
     const result = findBugInfo('5.5.0', map);
@@ -74,47 +52,5 @@ describe('utils/bug-versions', () => {
   it('findBugInfo returns null when no range matches', () => {
     const map = { '>=4.0.0 <5.0.0': ['x'] };
     expect(findBugInfo('5.5.0', map)).toBeNull();
-  });
-
-  it('getBugVersions uses fresh cache', async () => {
-    cacheStore.set('bugVersionsCache', {
-      lastChecked: Date.now(),
-      data: { '>=5.0.0': ['cached'] },
-    });
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
-      async () => new Response('{"unexpected":[]}', { status: 200 }),
-    );
-    const result = await getBugVersions();
-    expect(result?.['>=5.0.0']).toEqual(['cached']);
-    expect(fetchSpy).not.toHaveBeenCalled();
-    fetchSpy.mockRestore();
-  });
-
-  it('getBugVersions fetches when no cache, then caches', async () => {
-    // Use mockImplementation so each parallel fetch gets a fresh Response (body can only be read once)
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
-      async () => new Response('{">=6.0.0":["url"]}', { status: 200 }),
-    );
-    const result = await getBugVersions();
-    expect(result?.['>=6.0.0']).toEqual(['url']);
-    fetchSpy.mockRestore();
-  });
-
-  it('getBugVersions falls back to stale cache on network failure', async () => {
-    cacheStore.set('bugVersionsCache', {
-      lastChecked: Date.now() - 24 * 60 * 60 * 1000, // 24h ago, stale
-      data: { '>=5.0.0': ['stale'] },
-    });
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
-    const result = await getBugVersions();
-    expect(result?.['>=5.0.0']).toEqual(['stale']);
-    fetchSpy.mockRestore();
-  });
-
-  it('getBugVersions returns null when network fails and no cache', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
-    const result = await getBugVersions();
-    expect(result).toBeNull();
-    fetchSpy.mockRestore();
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { formatTable, output } from '../output/formatter.js';
 import { readJson, type PackageJson } from '../utils/json.js';
 import { satisfies } from '../data/version.js';
-import { getBugVersions, findBugInfo } from '../utils/bug-versions.js';
+import { loadBundledBugVersions, findBugInfo } from '../utils/bug-versions.js';
 
 interface DoctorPkgJson extends PackageJson {
   peerDependencies?: Record<string, string>;
@@ -95,7 +95,7 @@ function buildContext(cwd: string): DoctorContext {
   return { cwd, antdPkg, antdMajor, projectPkg, reactPkg, cssinjsPkg, iconsPkg, ecosystemPackages };
 }
 
-async function checkAntdInstalled(ctx: DoctorContext): Promise<CheckResult> {
+function checkAntdInstalled(ctx: DoctorContext): CheckResult {
   if (!ctx.antdPkg) {
     return {
       name: 'antd-installed',
@@ -106,7 +106,7 @@ async function checkAntdInstalled(ctx: DoctorContext): Promise<CheckResult> {
     };
   }
 
-  const bugVersions = await getBugVersions();
+  const bugVersions = ctx.antdPkg.version ? loadBundledBugVersions() : null;
   const hit = bugVersions ? findBugInfo(ctx.antdPkg.version, bugVersions) : null;
 
   if (hit) {
@@ -460,7 +460,7 @@ export function registerDoctorCommand(program: Command): void {
       const ctx = buildContext(process.cwd());
 
       const checks: CheckResult[] = [
-        await checkAntdInstalled(ctx),
+        checkAntdInstalled(ctx),
         checkReactCompat(ctx),
         checkDuplicateInstall(ctx),
         checkDayjsDuplicate(ctx),

--- a/src/utils/bug-versions.ts
+++ b/src/utils/bug-versions.ts
@@ -1,8 +1,10 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { satisfies } from '../data/version.js';
-import { cacheStore } from './store.js';
-import { fetchFirstJson } from './fetch.js';
 
-const BUG_VERSIONS_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export type BugVersionsMap = Record<string, string[]>;
 
@@ -11,11 +13,41 @@ export interface BugMatchResult {
   urls: string[];
 }
 
-const BUG_VERSIONS_SOURCES = [
-  'https://registry.npmmirror.com/antd/latest/files/BUG_VERSIONS.json', // China mirror (fast in CN)
-  'https://unpkg.com/antd/BUG_VERSIONS.json',                           // Unpkg CDN
-  'https://cdn.jsdelivr.net/npm/antd/BUG_VERSIONS.json',                // jsDelivr CDN
-];
+let bundledBugVersions: BugVersionsMap | null | undefined;
+
+function readDataFile(filePath: string): string {
+  const gzPath = filePath + '.gz';
+  /* v8 ignore next 3 -- gz files only present in production builds */
+  if (existsSync(gzPath)) {
+    return gunzipSync(readFileSync(gzPath)).toString('utf-8');
+  }
+  return readFileSync(filePath, 'utf-8');
+}
+
+/** Load bundled BUG_VERSIONS data without network or runtime cache access. */
+export function loadBundledBugVersions(): BugVersionsMap | null {
+  if (bundledBugVersions !== undefined) return bundledBugVersions;
+
+  const candidates = [
+    join(__dirname, '..', 'data', 'bug-versions.json'),       // from dist/
+    join(__dirname, '..', '..', 'data', 'bug-versions.json'), // from src/utils/
+  ];
+
+  for (const filePath of candidates) {
+    try {
+      if (!existsSync(filePath) && !existsSync(filePath + '.gz')) continue;
+      bundledBugVersions = JSON.parse(readDataFile(filePath)) as BugVersionsMap;
+      return bundledBugVersions;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  /* v8 ignore start -- defensive: bundled data/ is always present */
+  bundledBugVersions = null;
+  return bundledBugVersions;
+  /* v8 ignore stop */
+}
 
 /** Find the first bug range that the given antd version matches. */
 export function findBugInfo(version: string, bugVersions: BugVersionsMap): BugMatchResult | null {
@@ -25,28 +57,4 @@ export function findBugInfo(version: string, bugVersions: BugVersionsMap): BugMa
     }
   }
   return null;
-}
-
-/**
- * Get BUG_VERSIONS data using a 6-hour cache.
- * Falls back to stale cache on network failure.
- * Returns null only if never cached and all fetches fail.
- */
-export async function getBugVersions(): Promise<BugVersionsMap | null> {
-  const now = Date.now();
-  const cached = cacheStore.get('bugVersionsCache');
-
-  if (cached && now - cached.lastChecked < BUG_VERSIONS_TTL_MS) {
-    return cached.data;
-  }
-
-  const fetched = await fetchFirstJson<BugVersionsMap>(BUG_VERSIONS_SOURCES, 5000);
-
-  if (fetched) {
-    cacheStore.set('bugVersionsCache', { lastChecked: now, data: fetched });
-    return fetched;
-  }
-
-  // Network failed — degrade gracefully to stale cache data
-  return cached?.data ?? null;
 }

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -29,10 +29,6 @@ export interface AppCache {
     lastChecked: number;
     latestVersion: string;
   };
-  bugVersionsCache?: {
-    lastChecked: number;
-    data: Record<string, string[]>;
-  };
 }
 
 export const cacheStore = new Conf<AppCache>({


### PR DESCRIPTION
## Summary
- bundle Ant Design BUG_VERSIONS data in data/bug-versions.json
- make doctor use bundled bug metadata instead of runtime fetch/cache access
- remove the old remote BUG_VERSIONS fetch/cache helper entirely
- sync data/bug-versions.json from upstream BUG_VERSIONS.json in scripts/sync.ts
- add regression coverage that doctor does not call fetch or write runtime cache for known-bug checks
- document that doctor known-bug checks are offline

## Verification
- npx vitest run src/__tests__/commands/doctor.test.ts src/__tests__/fetch-bug-versions.test.ts
- npm run typecheck
- npm run build
- npx tsx scripts/sync.ts (syntax checked; exits with usage because --antd-dir is required)
- NO_UPDATE_CHECK=1 node dist/index.js doctor --format json (temp fixture with antd 6.4.1)
- rg for remote BUG_VERSIONS URLs / getBugVersions / bugVersionsCache returns no matches

## Note
- `npm run test` in the local worktree currently times out in unrelated env command tests; GitHub CI is the authoritative full-suite run for this PR.

## Source
- BUG_VERSIONS data copied from https://github.com/ant-design/ant-design/blob/master/BUG_VERSIONS.json