### PR TITLE
fix: commit data-only sync changes

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -5,11 +5,10 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
-import { resolve, join } from 'node:path';
-
-const GH_TOKEN = process.env.GH_TOKEN;
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 function run(cmd: string, options?: { cwd?: string; stdio?: 'pipe' | 'inherit' }): string {
   const result = execSync(cmd, {
@@ -29,6 +28,23 @@ function getNpmVersion(pkgName: string, version: string): string | null {
   }
 }
 
+interface PublishPlanInput {
+  cliVersion: string;
+  oldVersion: string;
+  existingVersion: string | null;
+  changedFiles: Set<string>;
+}
+
+export function getPublishPlan(input: PublishPlanInput) {
+  const hasLocalChanges = input.changedFiles.size > 0 || input.cliVersion !== input.oldVersion;
+  const shouldPublish = !input.existingVersion;
+  return {
+    shouldCommit: hasLocalChanges,
+    shouldPublish,
+    shouldSkip: !hasLocalChanges && !shouldPublish,
+  };
+}
+
 function main() {
   // Get CLI version from v6.json (antd v6 version as CLI version)
   const v6Data = JSON.parse(readFileSync('data/v6.json', 'utf-8'));
@@ -36,10 +52,6 @@ function main() {
 
   // Check if already published
   const existingVersion = getNpmVersion('@ant-design/cli', cliVersion);
-  if (existingVersion) {
-    console.log(`Version ${cliVersion} already published to npm, skipping release`);
-    process.exit(0);
-  }
 
   // Collect version info for changelog — only include versions whose data file actually changed
   const changedFiles = new Set(run('git diff --name-only HEAD -- data/').split(/\r?\n/).filter(Boolean));
@@ -54,6 +66,12 @@ function main() {
   // Get current package.json version
   const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
   const oldVersion = pkg.version;
+  const plan = getPublishPlan({ cliVersion, oldVersion, existingVersion, changedFiles });
+
+  if (plan.shouldSkip) {
+    console.log(`Version ${cliVersion} already published to npm and no local changes were found, skipping release`);
+    process.exit(0);
+  }
 
   // Update package.json version if needed
   if (cliVersion !== oldVersion) {
@@ -70,14 +88,20 @@ function main() {
   run('npx vitest run --update', { stdio: 'inherit' });
 
   // Commit, tag and push only after successful build + test
-  if (cliVersion !== oldVersion) {
+  if (plan.shouldCommit) {
     run('git config user.name "github-actions[bot]"');
     run('git config user.email "github-actions[bot]@users.noreply.github.com"');
     run('git add data/ package.json package-lock.json CHANGELOG.md CHANGELOG.zh-CN.md src/__tests__/snapshots/');
-    run(`git commit -m "data: sync antd metadata (${versionsStr})"`);
-    run(`git tag "v${cliVersion}"`);
-    run('git push origin main --tags');
+    run(`git commit -m "data: sync antd metadata (${versionsStr || cliVersion})"`);
 
+    if (plan.shouldPublish && cliVersion !== oldVersion) {
+      run(`git tag "v${cliVersion}"`);
+    }
+
+    run(plan.shouldPublish && cliVersion !== oldVersion ? 'git push origin main --tags' : 'git push origin main');
+  }
+
+  if (plan.shouldPublish && cliVersion !== oldVersion) {
     // Create GitHub Release
     const releaseNotes = run(`npx tsx scripts/extract-changelog.ts "${cliVersion}"`);
     const releaseNotesPath = join(os.tmpdir(), `release-notes-${Date.now()}.md`);
@@ -86,9 +110,15 @@ function main() {
   }
 
   // Publish to npm (clear NODE_AUTH_TOKEN for OIDC Trusted Publishing)
-  run('NODE_AUTH_TOKEN="" npm publish --provenance --access public', { stdio: 'inherit' });
+  if (plan.shouldPublish) {
+    run('NODE_AUTH_TOKEN="" npm publish --provenance --access public', { stdio: 'inherit' });
 
-  console.log(`Successfully published @ant-design/cli@${cliVersion}`);
+    console.log(`Successfully published @ant-design/cli@${cliVersion}`);
+  } else {
+    console.log(`Version ${cliVersion} already published to npm; committed synced data changes only`);
+  }
 }
 
-main();
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main();
+}

--- a/spec.md
+++ b/spec.md
@@ -969,6 +969,7 @@ GitHub Actions workflow `.github/workflows/sync.yml` runs daily:
 7. Align CLI version with the latest antd version and publish to npm
 
 The CLI version is kept in sync with antd — e.g., when antd publishes v6.3.2, the CLI is also published as v6.3.2.
+If sync produces data-only changes while the current CLI version has already been published, the workflow commits and pushes those data changes without attempting to republish the same npm version.
 
 ## Output Examples
 

--- a/src/__tests__/scripts/publish.test.ts
+++ b/src/__tests__/scripts/publish.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getPublishPlan } from '../../../scripts/publish.js';
+
+describe('publish workflow plan', () => {
+  it('commits synced data changes even when the CLI version is already published', () => {
+    const plan = getPublishPlan({
+      cliVersion: '6.4.4',
+      oldVersion: '6.4.4',
+      existingVersion: '6.4.4',
+      changedFiles: new Set(['data/v5.json']),
+    });
+
+    expect(plan.shouldCommit).toBe(true);
+    expect(plan.shouldPublish).toBe(false);
+    expect(plan.shouldSkip).toBe(false);
+  });
+
+  it('skips when the published CLI version has no local changes', () => {
+    const plan = getPublishPlan({
+      cliVersion: '6.4.4',
+      oldVersion: '6.4.4',
+      existingVersion: '6.4.4',
+      changedFiles: new Set(),
+    });
+
+    expect(plan.shouldCommit).toBe(false);
+    expect(plan.shouldPublish).toBe(false);
+    expect(plan.shouldSkip).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary / 变更摘要

- Add a publish planning helper for already-published versions.
- 增加发布计划判断逻辑，处理当前 CLI 版本已发布的场景。
- Commit and push synced data changes even when the current CLI version already exists on npm.
- 即使当前 CLI 版本已经发布到 npm，也会提交并推送 sync 产生的数据变更。
- Skip duplicate npm publishing for data-only sync updates.
- 对仅数据变更的 sync 更新，跳过重复 npm publish。

## Tests / 测试

- `npx vitest run src/__tests__/scripts/publish.test.ts`
- `npm run typecheck`
