### PR TITLE
fix: fail closed on corrupted versions index

### DIFF
--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -175,17 +175,19 @@ function fetchTokenMeta(antdDir: string, tag: string) {
   }
 }
 
-function updateVersionsJson(major: number, minorMap: Map<string, string>) {
-  const file = path.join(DATA_DIR, 'versions.json');
+export function updateVersionsJson(dataDir: string, major: number, minorMap: Map<string, string>) {
+  const file = path.join(dataDir, 'versions.json');
   let index: Record<string, Record<string, string>> = {};
   try {
     if (fs.existsSync(file)) {
-      index = JSON.parse(fs.readFileSync(file, 'utf8'));
+      const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('versions.json must contain an object index');
+      }
+      index = parsed;
     }
   } catch (err) {
-    // If versions.json is corrupted, DON'T overwrite it — that would lose data for
-    // majors not in our loop (e.g. v3). Just update this major's key in an empty object.
-    console.error(`  Warning: Failed to parse versions.json, data for other majors may be lost: ${err instanceof Error ? err.message : err}`);
+    throw new Error(`Failed to parse versions.json; refusing to overwrite existing version index: ${err instanceof Error ? err.message : err}`);
   }
   const majorKey = `v${major}`;
   if (!index[majorKey]) index[majorKey] = {};
@@ -193,7 +195,7 @@ function updateVersionsJson(major: number, minorMap: Map<string, string>) {
     index[majorKey][minorKey] = tag;
   }
   // Atomic write: write to temp file in same directory then rename (avoids EXDEV across filesystems)
-  const tmpFile = path.join(DATA_DIR, `.versions-${Date.now()}.tmp`);
+  const tmpFile = path.join(dataDir, `.versions-${Date.now()}.tmp`);
   try {
     fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2) + '\n');
     fs.renameSync(tmpFile, file);
@@ -434,7 +436,7 @@ function main() {
       extract(antdDir, snapshot);
     }
 
-    updateVersionsJson(major, minorMap);
+    updateVersionsJson(DATA_DIR, major, minorMap);
     console.log(`  Updated versions.json for v${major}`);
   }
 

--- a/spec.md
+++ b/spec.md
@@ -74,6 +74,7 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 - A GitHub Actions workflow (`sync.yml`) runs daily: for each major version it extracts the latest snapshot and any new minor-series snapshots, then updates `versions.json`
 - Sync fails closed if release tags cannot be fetched for any configured major line, instead of publishing partially refreshed data.
 - Stale snapshots (files not referenced by `versions.json`) are cleaned up automatically: when a new patch replaces an old one for the same minor series, the old file is removed inline; a final sweep after sync removes any orphaned snapshot files. `versions.json` is the source of truth — the cleanup scope derives from its contents, not from a hardcoded major-version list
+- If `versions.json` cannot be parsed, sync fails closed instead of overwriting it with a partial index, so stale snapshot cleanup never runs from corrupted version metadata.
 - Historical snapshots can be bootstrapped locally via `scripts/bootstrap-snapshots.ts`
 - CLI version aligns with the latest antd version (e.g., antd 6.3.2 → CLI 6.3.2)
 - The components schema is consistent across major versions to enable cross-version diffing

--- a/src/__tests__/scripts/sync-versions-json.test.ts
+++ b/src/__tests__/scripts/sync-versions-json.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { updateVersionsJson } from '../../../scripts/sync.js';
+
+describe('sync versions.json handling', () => {
+  let workdir: string;
+  let dataDir: string;
+
+  beforeEach(() => {
+    workdir = join(tmpdir(), `antd-cli-sync-versions-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    dataDir = join(workdir, 'data');
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, 'versions.json'), '{broken');
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it('fails closed instead of overwriting a corrupted versions.json', () => {
+    expect(() => updateVersionsJson(dataDir, 6, new Map([['6.4', '6.4.4']]))).toThrow(/versions\.json/);
+    expect(readFileSync(join(dataDir, 'versions.json'), 'utf8')).toBe('{broken');
+  });
+
+  it('fails closed when versions.json parses to a non-object value', () => {
+    writeFileSync(join(dataDir, 'versions.json'), 'null');
+
+    expect(() => updateVersionsJson(dataDir, 6, new Map([['6.4', '6.4.4']]))).toThrow(/versions\.json/);
+    expect(readFileSync(join(dataDir, 'versions.json'), 'utf8')).toBe('null');
+  });
+});


### PR DESCRIPTION
## Summary / 变更摘要

- Fail `versions.json` updates when the existing index cannot be parsed.
- 当现有 `versions.json` 无法解析时，让更新流程直接失败。
- Preserve the corrupted file instead of replacing it with a partial index.
- 保留损坏文件原状，避免用不完整索引覆盖。
- Document the fail-closed cleanup behavior.
- 补充 fail-closed 的快照清理行为说明。

## Tests / 测试

- `npx vitest run src/__tests__/scripts/sync-versions-json.test.ts`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了版本配置文件的校验机制，当数据格式异常时系统将拒绝覆盖，防止已有版本数据被意外损坏。

* **Documentation**
  * 补充了数据同步的安全性说明文档。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->