### PR TITLE
fix: parse latest antd version for sync check

### DIFF
--- a/scripts/check-sync-needed.ts
+++ b/scripts/check-sync-needed.ts
@@ -16,15 +16,41 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import semver from 'semver';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.join(__dirname, '..', 'data');
 
 const MAJORS = [4, 5, 6];
 
+interface SyncStatusOptions {
+  majors: number[];
+  getLatestNpmVersion: (major: number) => string | null;
+  getLocalVersion: (major: number) => string | null;
+  isCliVersionPublished: (version: string) => boolean;
+}
+
+export function getLatestStableVersion(output: string): string | null {
+  let versions: unknown;
+  try {
+    versions = JSON.parse(output);
+  } catch {
+    versions = output
+      .split(/\r?\n/)
+      .map((line) => line.match(/'([^']+)'/)?.[1] ?? line.trim());
+  }
+
+  const list = (Array.isArray(versions) ? versions : [versions])
+    .filter((version): version is string => typeof version === 'string')
+    .filter((version) => semver.valid(version) && !semver.prerelease(version));
+
+  return list.sort(semver.compare).at(-1) ?? null;
+}
+
 function getLatestNpmVersion(major: number): string | null {
   try {
-    return execSync(`npm view antd@${major} version`, { encoding: 'utf8' }).trim();
+    const output = execSync(`npm view antd@${major} version --json`, { encoding: 'utf8' });
+    return getLatestStableVersion(output);
   } catch {
     return null;
   }
@@ -42,40 +68,57 @@ function getLocalVersion(major: number): string | null {
   return null;
 }
 
-let needsSync = false;
-const statusLines: string[] = [];
-
-for (const major of MAJORS) {
-  const latest = getLatestNpmVersion(major);
-  const local = getLocalVersion(major);
-  const outdated = latest !== null && latest !== local;
-  if (outdated) needsSync = true;
-  statusLines.push(`  v${major}: npm=${latest ?? 'unavailable'}, local=${local ?? 'missing'}${outdated ? ' (outdated)' : ''}`);
-}
-
-console.log('Version check:');
-console.log(statusLines.join('\n'));
-
-// Check if CLI package has been published for the current v6 version
-const v6Local = getLocalVersion(6);
-const needsPublish = needsSync || (() => {
-  if (!v6Local) return true;
+function isCliVersionPublished(version: string): boolean {
   try {
-    execSync(`npm view "@ant-design/cli@${v6Local}" version`, { stdio: 'pipe' });
-    return false;
-  } catch {
+    execSync(`npm view "@ant-design/cli@${version}" version`, { stdio: 'pipe' });
     return true;
+  } catch {
+    return false;
   }
-})();
-
-const outputFile = process.env.GITHUB_OUTPUT;
-if (outputFile) {
-  fs.appendFileSync(outputFile, `needs_sync=${needsSync}\n`);
-  fs.appendFileSync(outputFile, `needs_publish=${needsPublish}\n`);
 }
 
-if (!needsSync && !needsPublish) {
-  console.log('Data up to date and CLI published, nothing to do');
+export function resolveSyncStatus(options: SyncStatusOptions) {
+  let needsSync = false;
+  const statusLines: string[] = [];
+
+  for (const major of options.majors) {
+    const latest = options.getLatestNpmVersion(major);
+    const local = options.getLocalVersion(major);
+    const outdated = latest !== null && latest !== local;
+    if (outdated) needsSync = true;
+    statusLines.push(`  v${major}: npm=${latest ?? 'unavailable'}, local=${local ?? 'missing'}${outdated ? ' (outdated)' : ''}`);
+  }
+
+  const v6Local = options.getLocalVersion(6);
+  const needsPublish = needsSync || !v6Local || !options.isCliVersionPublished(v6Local);
+
+  return { needsSync, needsPublish, statusLines };
 }
 
-console.log(`needs_sync=${needsSync}, needs_publish=${needsPublish}`);
+function main() {
+  const { needsSync, needsPublish, statusLines } = resolveSyncStatus({
+    majors: MAJORS,
+    getLatestNpmVersion,
+    getLocalVersion,
+    isCliVersionPublished,
+  });
+
+  console.log('Version check:');
+  console.log(statusLines.join('\n'));
+
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    fs.appendFileSync(outputFile, `needs_sync=${needsSync}\n`);
+    fs.appendFileSync(outputFile, `needs_publish=${needsPublish}\n`);
+  }
+
+  if (!needsSync && !needsPublish) {
+    console.log('Data up to date and CLI published, nothing to do');
+  }
+
+  console.log(`needs_sync=${needsSync}, needs_publish=${needsPublish}`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/spec.md
+++ b/spec.md
@@ -961,10 +961,11 @@ The command reuses the existing `fetchLatestVersion()` (3-mirror race + 24h cach
 GitHub Actions workflow `.github/workflows/sync.yml` runs daily:
 
 1. For each major version (v4, v5, v6), find the latest antd release tag via `git ls-remote`
-2. Checkout antd source at that tag
-3. Run `scripts/extract.ts` to generate new data
-4. If data changed, commit and push
-5. Align CLI version with the latest antd version and publish to npm
+2. Before syncing, compare each bundled primary snapshot with the latest stable npm version for that major line
+3. Checkout antd source at that tag
+4. Run `scripts/extract.ts` to generate new data
+5. If data changed, commit and push
+6. Align CLI version with the latest antd version and publish to npm
 
 The CLI version is kept in sync with antd — e.g., when antd publishes v6.3.2, the CLI is also published as v6.3.2.
 

--- a/src/__tests__/scripts/check-sync-needed.test.ts
+++ b/src/__tests__/scripts/check-sync-needed.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getLatestStableVersion, resolveSyncStatus } from '../../../scripts/check-sync-needed.js';
+
+describe('check-sync-needed', () => {
+  it('picks the latest stable version from npm view version output', () => {
+    const output = [
+      "antd@6.0.0 '6.0.0'",
+      "antd@6.4.3 '6.4.3'",
+      "antd@6.4.4 '6.4.4'",
+    ].join('\n');
+
+    expect(getLatestStableVersion(output)).toBe('6.4.4');
+  });
+
+  it('does not request sync when npm output includes all versions and local data is current', () => {
+    const status = resolveSyncStatus({
+      majors: [6],
+      getLatestNpmVersion: () => '6.4.4',
+      getLocalVersion: () => '6.4.4',
+      isCliVersionPublished: () => true,
+    });
+
+    expect(status.needsSync).toBe(false);
+    expect(status.needsPublish).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary / 变更摘要

- Parse npm version-list output and resolve the latest stable antd version for each major line.
- 解析 npm 返回的版本列表，并为每个 antd major 线取最新 stable 版本。
- Make `check-sync-needed` importable and cover the regression with focused tests.
- 让 `check-sync-needed` 可被测试导入，并用聚焦测试覆盖该回归。
- Document the sync pre-check behavior.
- 补充 sync 前置检测行为说明。

## Tests / 测试

- `npx vitest run src/__tests__/scripts/check-sync-needed.test.ts`
- `npm run typecheck`
