### PR TITLE
fix: fail sync when release tags are unavailable

### DIFF
--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -52,19 +52,25 @@ function parseArgs(args: string[]): { antdDir: string } {
 }
 
 /** Returns all release tags for a major version, sorted ascending by semver. */
-function fetchTags(major: number): string[] {
+export function fetchTags(major: number): string[] {
   try {
     const out = execSync(
       `git ls-remote --tags --sort=v:refname ${ANTD_REMOTE} "refs/tags/${major}.*"`,
       { encoding: 'utf8' },
     );
-    return out
+    const tags = out
       .split('\n')
       .filter((line) => line && !line.includes('^{}'))
       .map((line) => line.replace(/.*refs\/tags\//, ''));
+    if (tags.length === 0) {
+      throw new Error(`No release tags found for v${major}`);
+    }
+    return tags;
   } catch (err) {
-    console.error(`Error fetching tags for v${major}: ${err instanceof Error ? err.message : err}`);
-    return [];
+    const stderr = err && typeof err === 'object' && 'stderr' in err && err.stderr
+      ? `\n${Buffer.isBuffer(err.stderr) ? err.stderr.toString('utf8') : String(err.stderr)}`
+      : '';
+    throw new Error(`Error fetching tags for v${major}: ${err instanceof Error ? err.message : err}${stderr}`);
   }
 }
 
@@ -370,10 +376,6 @@ function main() {
     console.log(`\n=== Syncing v${major} ===`);
 
     const tags = fetchTags(major);
-    if (tags.length === 0) {
-      console.warn(`No tags fetched for v${major}, skipping`);
-      continue;
-    }
     const minorMap = buildMinorMap(tags); // pre-releases already excluded
     const latestTag = [...minorMap.values()].at(-1);
     if (!latestTag) {
@@ -455,4 +457,6 @@ function main() {
   console.log('\nSync complete.');
 }
 
-main();
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/spec.md
+++ b/spec.md
@@ -72,6 +72,7 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 - Data is auto-extracted from antd source via `scripts/extract.ts`
 - `data/design-v{major}.md` (the design-language document served by `antd design.md`) is **not** extracted but **copied verbatim** from antd's repo-root `DESIGN.md` during sync, since it is hand-curated prose, not derivable data. It is major-grained, so `scripts/sync.ts` checks out each major's latest tag and copies the file to `data/design-v{major}.md` (only `design-v6.md` exists today; antd has not published `DESIGN.md` for v3/v4/v5). If the source `DESIGN.md` is absent for a major, the existing bundled copy is kept rather than deleted.
 - A GitHub Actions workflow (`sync.yml`) runs daily: for each major version it extracts the latest snapshot and any new minor-series snapshots, then updates `versions.json`
+- Sync fails closed if release tags cannot be fetched for any configured major line, instead of publishing partially refreshed data.
 - Stale snapshots (files not referenced by `versions.json`) are cleaned up automatically: when a new patch replaces an old one for the same minor series, the old file is removed inline; a final sweep after sync removes any orphaned snapshot files. `versions.json` is the source of truth — the cleanup scope derives from its contents, not from a hardcoded major-version list
 - Historical snapshots can be bootstrapped locally via `scripts/bootstrap-snapshots.ts`
 - CLI version aligns with the latest antd version (e.g., antd 6.3.2 → CLI 6.3.2)

--- a/src/__tests__/scripts/sync-fetch-tags.test.ts
+++ b/src/__tests__/scripts/sync-fetch-tags.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const execSyncMock = vi.fn(() => {
+  const error = new Error('network failed') as Error & { stderr: Buffer };
+  error.stderr = Buffer.from('fatal: unable to access remote');
+  throw error;
+});
+
+vi.mock('node:child_process', () => ({
+  execSync: execSyncMock,
+  execFileSync: vi.fn(),
+}));
+
+describe('sync tag fetching', () => {
+  it('fails closed when release tags cannot be fetched', async () => {
+    const { fetchTags } = await import('../../../scripts/sync.js');
+
+    expect(() => fetchTags(6)).toThrow(/fatal: unable to access remote/);
+  });
+});


### PR DESCRIPTION
## Summary / 变更摘要

- Fail closed when `git ls-remote` fails or returns no release tags.
- 当 `git ls-remote` 失败或没有返回 release tags 时直接失败。
- Stop the sync job instead of silently skipping a major line.
- 直接中止 sync job，避免静默跳过某个 major 线。
- Document the partial-sync prevention behavior.
- 补充防止半同步数据发布的行为说明。

## Tests / 测试

- `npx vitest run src/__tests__/scripts/sync-fetch-tags.test.ts`
- `npm run typecheck`
