### PR TITLE
docs: align sync schedule spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -72,7 +72,7 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 - Data is auto-extracted from antd source via `scripts/extract.ts`
 - `data/design-v{major}.md` (the design-language document served by `antd design.md`) is **not** extracted but **copied verbatim** from antd's repo-root `DESIGN.md` during sync, since it is hand-curated prose, not derivable data. It is major-grained, so `scripts/sync.ts` checks out each major's latest tag and copies the file to `data/design-v{major}.md` (only `design-v6.md` exists today; antd has not published `DESIGN.md` for v3/v4/v5). If the source `DESIGN.md` is absent for a major, the existing bundled copy is kept rather than deleted.
 - For v5+ design tokens, `scripts/sync.ts` fetches `token-meta.json` from the matching published `antd@{version}` tarball for each extracted tag and replaces any previous checkout copy before extraction, so token data cannot be reused across versions.
-- A GitHub Actions workflow (`sync.yml`) runs daily: for each major version it extracts the latest snapshot and any new minor-series snapshots, then updates `versions.json`
+- A GitHub Actions workflow (`sync.yml`) runs hourly: for each major version it extracts the latest snapshot and any new minor-series snapshots, then updates `versions.json`
 - Sync fails closed if release tags cannot be fetched for any configured major line, instead of publishing partially refreshed data.
 - Stale snapshots (files not referenced by `versions.json`) are cleaned up automatically: when a new patch replaces an old one for the same minor series, the old file is removed inline; a final sweep after sync removes any orphaned snapshot files. `versions.json` is the source of truth — the cleanup scope derives from its contents, not from a hardcoded major-version list
 - If `versions.json` cannot be parsed, sync fails closed instead of overwriting it with a partial index, so stale snapshot cleanup never runs from corrupted version metadata.
@@ -958,7 +958,7 @@ The command reuses the existing `fetchLatestVersion()` (3-mirror race + 24h cach
 
 ### Automated Data Sync
 
-GitHub Actions workflow `.github/workflows/sync.yml` runs daily:
+GitHub Actions workflow `.github/workflows/sync.yml` runs hourly:
 
 1. For each major version (v4, v5, v6), find the latest antd release tag via `git ls-remote`
 2. Before syncing, compare each bundled primary snapshot with the latest stable npm version for that major line


### PR DESCRIPTION
## Summary / 变更摘要

- Update `spec.md` to say the sync workflow runs hourly, matching `.github/workflows/sync.yml`.
- 更新 `spec.md`，说明 sync workflow 是每小时运行，与 `.github/workflows/sync.yml` 保持一致。

## Tests / 测试

- Not run; documentation-only change.
- 未运行；仅文档变更。
