### PR TITLE
fix: fail sync on missing indexed snapshots

### DIFF
--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -109,6 +109,47 @@ function extract(antdDir: string, output: string) {
   });
 }
 
+interface SyncMinorSnapshotOptions {
+  antdDir: string;
+  dataDir: string;
+  minorKey: string;
+  tag: string;
+  checkoutTag?: (antdDir: string, tag: string) => boolean;
+  fetchTokenMetaForTag?: (antdDir: string, tag: string) => void;
+  extractSnapshot?: (antdDir: string, output: string) => void;
+}
+
+export function syncMinorSnapshot(options: SyncMinorSnapshotOptions) {
+  const {
+    antdDir,
+    dataDir,
+    minorKey,
+    tag,
+    checkoutTag = checkout,
+    fetchTokenMetaForTag = fetchTokenMeta,
+    extractSnapshot = extract,
+  } = options;
+  const snapshot = path.join(dataDir, `v${tag}.json`);
+  if (fs.existsSync(snapshot)) {
+    console.log(`  Snapshot v${tag}.json already exists, skipping`);
+    return;
+  }
+
+  console.log(`  Extracting ${minorKey} → ${tag}`);
+  if (!checkoutTag(antdDir, tag)) {
+    throw new Error(`Failed to checkout ${tag}`);
+  }
+  fetchTokenMetaForTag(antdDir, tag);
+  extractSnapshot(antdDir, snapshot);
+
+  const stalePattern = new RegExp(`^v${minorKey.replaceAll('.', '\\.')}\\.\\d+\\.json$`);
+  const staleFiles = fs.readdirSync(dataDir).filter((f) => f !== `v${tag}.json` && stalePattern.test(f));
+  for (const stale of staleFiles) {
+    fs.unlinkSync(path.join(dataDir, stale));
+    console.log(`  Removed stale snapshot: data/${stale}`);
+  }
+}
+
 /**
  * Fetch token-meta.json from the published npm package for the given antd version.
  * This file is a build artifact that doesn't exist in raw git source,
@@ -195,6 +236,12 @@ export function updateVersionsJson(dataDir: string, major: number, minorMap: Map
   if (!index[majorKey]) index[majorKey] = {};
   for (const [minorKey, tag] of minorMap) {
     index[majorKey][minorKey] = tag;
+  }
+  for (const tag of Object.values(index[majorKey])) {
+    const snapshot = path.join(dataDir, `v${tag}.json`);
+    if (!fs.existsSync(snapshot)) {
+      throw new Error(`versions.json would reference missing snapshot data/v${tag}.json`);
+    }
   }
   // Atomic write: write to temp file in same directory then rename (avoids EXDEV across filesystems)
   const tmpFile = path.join(dataDir, `.versions-${Date.now()}.tmp`);
@@ -411,31 +458,12 @@ function main() {
 
     // Extract per-minor snapshots, replacing stale ones whose patch version changed
     for (const [minorKey, tag] of minorMap) {
-      const snapshot = path.join(DATA_DIR, `v${tag}.json`);
-      if (fs.existsSync(snapshot)) {
-        console.log(`  Snapshot v${tag}.json already exists, skipping`);
-        continue;
-      }
-      // Remove stale snapshot for this minor (e.g. v6.4.2.json when tag is now 6.4.3)
-      const stalePattern = new RegExp(`^v${minorKey.replaceAll('.', '\\.')}\\.\\d+\\.json$`);
-      const staleFiles = fs.readdirSync(DATA_DIR).filter((f) => stalePattern.test(f));
-      for (const stale of staleFiles) {
-        fs.unlinkSync(path.join(DATA_DIR, stale));
-        console.log(`  Removed stale snapshot: data/${stale}`);
-      }
-      console.log(`  Extracting ${minorKey} → ${tag}`);
-      if (!checkout(antdDir, tag)) {
-        console.warn(`  Skipping ${minorKey} due to checkout failure`);
-        continue;
-      }
       try {
-        fetchTokenMeta(antdDir, tag);
+        syncMinorSnapshot({ antdDir, dataDir: DATA_DIR, minorKey, tag });
       } catch (err) {
         console.error(`  ERROR: ${err instanceof Error ? err.message : err}`);
-        console.error(`  Skipping ${minorKey} snapshot — cannot proceed without token data`);
-        continue;
+        throw new Error(`Failed to sync ${minorKey} snapshot ${tag}; refusing to update versions.json`);
       }
-      extract(antdDir, snapshot);
     }
 
     updateVersionsJson(DATA_DIR, major, minorMap);

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -233,10 +233,15 @@ export function updateVersionsJson(dataDir: string, major: number, minorMap: Map
   for (const [minorKey, tag] of minorMap) {
     index[majorKey][minorKey] = tag;
   }
-  for (const tag of Object.values(index[majorKey])) {
-    const snapshot = path.join(dataDir, `v${tag}.json`);
-    if (!fs.existsSync(snapshot)) {
-      throw new Error(`versions.json would reference missing snapshot data/v${tag}.json`);
+  for (const minorIndex of Object.values(index)) {
+    if (!minorIndex || typeof minorIndex !== 'object' || Array.isArray(minorIndex)) {
+      throw new Error('versions.json major entries must contain object indexes');
+    }
+    for (const tag of Object.values(minorIndex)) {
+      const snapshot = path.join(dataDir, `v${tag}.json`);
+      if (!fs.existsSync(snapshot)) {
+        throw new Error(`versions.json would reference missing snapshot data/v${tag}.json`);
+      }
     }
   }
   // Atomic write: write to temp file in same directory then rename (avoids EXDEV across filesystems)

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -109,26 +109,22 @@ function extract(antdDir: string, output: string) {
   });
 }
 
-interface SyncMinorSnapshotOptions {
-  antdDir: string;
-  dataDir: string;
-  minorKey: string;
-  tag: string;
+interface SyncMinorSnapshotDeps {
   checkoutTag?: (antdDir: string, tag: string) => boolean;
   fetchTokenMetaForTag?: (antdDir: string, tag: string) => void;
   extractSnapshot?: (antdDir: string, output: string) => void;
 }
 
-export function syncMinorSnapshot(options: SyncMinorSnapshotOptions) {
-  const {
-    antdDir,
-    dataDir,
-    minorKey,
-    tag,
-    checkoutTag = checkout,
-    fetchTokenMetaForTag = fetchTokenMeta,
-    extractSnapshot = extract,
-  } = options;
+export function syncMinorSnapshot(
+  antdDir: string,
+  dataDir: string,
+  minorKey: string,
+  tag: string,
+  deps: SyncMinorSnapshotDeps = {},
+) {
+  const checkoutTag = deps.checkoutTag ?? checkout;
+  const fetchTokenMetaForTag = deps.fetchTokenMetaForTag ?? fetchTokenMeta;
+  const extractSnapshot = deps.extractSnapshot ?? extract;
   const snapshot = path.join(dataDir, `v${tag}.json`);
   if (fs.existsSync(snapshot)) {
     console.log(`  Snapshot v${tag}.json already exists, skipping`);
@@ -459,7 +455,7 @@ function main() {
     // Extract per-minor snapshots, replacing stale ones whose patch version changed
     for (const [minorKey, tag] of minorMap) {
       try {
-        syncMinorSnapshot({ antdDir, dataDir: DATA_DIR, minorKey, tag });
+        syncMinorSnapshot(antdDir, DATA_DIR, minorKey, tag);
       } catch (err) {
         console.error(`  ERROR: ${err instanceof Error ? err.message : err}`);
         throw new Error(`Failed to sync ${minorKey} snapshot ${tag}; refusing to update versions.json`);

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -10,6 +10,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { PropData, MetadataStore } from '../src/types.js';
 
 const DATA_DIR = path.join(import.meta.dirname, '..', 'data');
@@ -102,6 +103,41 @@ function checkEmptyPropsWithApi(files: string[]): SnapshotIssue[] {
   return issues;
 }
 
+export function validateVersionsIndexReferences(dataDir: string): string[] {
+  const versionsPath = path.join(dataDir, 'versions.json');
+  const issues: string[] = [];
+  let index: Record<string, Record<string, string>>;
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(versionsPath, 'utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return ['versions.json must contain an object index'];
+    }
+    index = parsed;
+  } catch (err) {
+    return [`versions.json is not valid JSON: ${err instanceof Error ? err.message : err}`];
+  }
+
+  for (const minorIndex of Object.values(index)) {
+    if (!minorIndex || typeof minorIndex !== 'object' || Array.isArray(minorIndex)) {
+      issues.push('versions.json major entries must contain object indexes');
+      continue;
+    }
+    for (const tag of Object.values(minorIndex)) {
+      if (typeof tag !== 'string') {
+        issues.push('versions.json snapshot tags must be strings');
+        continue;
+      }
+      const snapshot = `data/v${tag}.json`;
+      if (!fs.existsSync(path.join(dataDir, `v${tag}.json`))) {
+        issues.push(`versions.json references missing snapshot ${snapshot}`);
+      }
+    }
+  }
+
+  return issues;
+}
+
 function main() {
   const files = fs.readdirSync(DATA_DIR)
     .filter(f => /^v\d+.*\.json$/.test(f))
@@ -152,6 +188,15 @@ function main() {
     warnCount++;
   }
 
+  const versionsIndexIssues = validateVersionsIndexReferences(DATA_DIR);
+  for (const issue of versionsIndexIssues) {
+    if (!quiet) {
+      console.log(`[ERROR] [versions-index] ${issue}`);
+    }
+    ruleCounts.set('versions-index', (ruleCounts.get('versions-index') || 0) + 1);
+    errorCount++;
+  }
+
   console.log(`\nSummary:`);
   for (const [rule, count] of [...ruleCounts.entries()].sort()) {
     console.log(`  ${rule}: ${count}`);
@@ -168,4 +213,6 @@ function main() {
   }
 }
 
-main();
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/spec.md
+++ b/spec.md
@@ -76,6 +76,7 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 - Sync fails closed if release tags cannot be fetched for any configured major line, instead of publishing partially refreshed data.
 - Stale snapshots (files not referenced by `versions.json`) are cleaned up automatically: when a new patch replaces an old one for the same minor series, the old file is removed inline; a final sweep after sync removes any orphaned snapshot files. `versions.json` is the source of truth — the cleanup scope derives from its contents, not from a hardcoded major-version list
 - If `versions.json` cannot be parsed, sync fails closed instead of overwriting it with a partial index, so stale snapshot cleanup never runs from corrupted version metadata.
+- `versions.json` is only updated when every indexed minor snapshot exists on disk, and `scripts/validate-data.ts --quiet` fails if any index entry points at a missing snapshot.
 - Historical snapshots can be bootstrapped locally via `scripts/bootstrap-snapshots.ts`
 - CLI version aligns with the latest antd version (e.g., antd 6.3.2 → CLI 6.3.2)
 - The components schema is consistent across major versions to enable cross-version diffing

--- a/src/__tests__/scripts/sync-versions-json.test.ts
+++ b/src/__tests__/scripts/sync-versions-json.test.ts
@@ -42,11 +42,7 @@ describe('sync versions.json handling', () => {
     const previousSnapshot = join(dataDir, 'v6.4.2.json');
     writeFileSync(previousSnapshot, '{}');
 
-    expect(() => syncMinorSnapshot({
-      antdDir: workdir,
-      dataDir,
-      minorKey: '6.4',
-      tag: '6.4.4',
+    expect(() => syncMinorSnapshot(workdir, dataDir, '6.4', '6.4.4', {
       checkoutTag: () => true,
       fetchTokenMetaForTag: () => undefined,
       extractSnapshot: () => {

--- a/src/__tests__/scripts/sync-versions-json.test.ts
+++ b/src/__tests__/scripts/sync-versions-json.test.ts
@@ -38,6 +38,20 @@ describe('sync versions.json handling', () => {
     expect(readFileSync(join(dataDir, 'versions.json'), 'utf8')).toBe('{}');
   });
 
+  it('fails closed when any existing major references a missing snapshot', () => {
+    writeFileSync(join(dataDir, 'versions.json'), JSON.stringify({
+      v5: { '5.27': '5.27.6' },
+      v6: {},
+    }));
+    writeFileSync(join(dataDir, 'v6.4.4.json'), '{}');
+
+    expect(() => updateVersionsJson(dataDir, 6, new Map([['6.4', '6.4.4']]))).toThrow(/data\/v5\.27\.6\.json/);
+    expect(JSON.parse(readFileSync(join(dataDir, 'versions.json'), 'utf8'))).toEqual({
+      v5: { '5.27': '5.27.6' },
+      v6: {},
+    });
+  });
+
   it('keeps the previous minor snapshot when the replacement extraction fails', () => {
     const previousSnapshot = join(dataDir, 'v6.4.2.json');
     writeFileSync(previousSnapshot, '{}');

--- a/src/__tests__/scripts/sync-versions-json.test.ts
+++ b/src/__tests__/scripts/sync-versions-json.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { updateVersionsJson } from '../../../scripts/sync.js';
+import { syncMinorSnapshot, updateVersionsJson } from '../../../scripts/sync.js';
 
 describe('sync versions.json handling', () => {
   let workdir: string;
@@ -29,5 +29,31 @@ describe('sync versions.json handling', () => {
 
     expect(() => updateVersionsJson(dataDir, 6, new Map([['6.4', '6.4.4']]))).toThrow(/versions\.json/);
     expect(readFileSync(join(dataDir, 'versions.json'), 'utf8')).toBe('null');
+  });
+
+  it('fails closed when versions.json would reference a missing snapshot', () => {
+    writeFileSync(join(dataDir, 'versions.json'), '{}');
+
+    expect(() => updateVersionsJson(dataDir, 6, new Map([['6.4', '6.4.4']]))).toThrow(/data\/v6\.4\.4\.json/);
+    expect(readFileSync(join(dataDir, 'versions.json'), 'utf8')).toBe('{}');
+  });
+
+  it('keeps the previous minor snapshot when the replacement extraction fails', () => {
+    const previousSnapshot = join(dataDir, 'v6.4.2.json');
+    writeFileSync(previousSnapshot, '{}');
+
+    expect(() => syncMinorSnapshot({
+      antdDir: workdir,
+      dataDir,
+      minorKey: '6.4',
+      tag: '6.4.4',
+      checkoutTag: () => true,
+      fetchTokenMetaForTag: () => undefined,
+      extractSnapshot: () => {
+        throw new Error('extract failed');
+      },
+    })).toThrow(/extract failed/);
+
+    expect(existsSync(previousSnapshot)).toBe(true);
   });
 });

--- a/src/__tests__/scripts/validate-data.test.ts
+++ b/src/__tests__/scripts/validate-data.test.ts
@@ -1,0 +1,33 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { validateVersionsIndexReferences } from '../../../scripts/validate-data.js';
+
+describe('validate data versions index', () => {
+  let workdir: string;
+  let dataDir: string;
+
+  beforeEach(() => {
+    workdir = join(tmpdir(), `antd-cli-validate-data-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    dataDir = join(workdir, 'data');
+    mkdirSync(dataDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it('reports versions.json entries that point to missing snapshots', () => {
+    writeFileSync(join(dataDir, 'versions.json'), JSON.stringify({ v6: { '6.4': '6.4.4' } }));
+    writeFileSync(join(dataDir, 'v6.json'), JSON.stringify({
+      version: '6.4.4',
+      majorVersion: '6',
+      components: [{ name: 'Button', props: [] }],
+    }));
+
+    expect(validateVersionsIndexReferences(dataDir)).toEqual([
+      'versions.json references missing snapshot data/v6.4.4.json',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary / 摘要

- Fail `updateVersionsJson` before writing `versions.json` when an indexed minor snapshot file is missing.
- Make `validate-data` import-safe and add `versions.json` reference validation.
- Document that sync and validation now reject missing indexed snapshots.

- 当索引中的 minor snapshot 文件缺失时，在写入 `versions.json` 前直接失败。
- 让 `validate-data` 可被测试导入，并新增 `versions.json` 引用完整性校验。
- 在 spec 中记录 sync/validate 会拒绝缺失的索引快照。

## Testing / 测试

- `npx vitest run src/__tests__/scripts/sync-versions-json.test.ts src/__tests__/scripts/validate-data.test.ts src/__tests__/scripts/sync-fetch-tags.test.ts src/__tests__/scripts/sync-token-meta.test.ts src/__tests__/scripts/check-sync-needed.test.ts src/__tests__/scripts/publish.test.ts`
- `npx tsx scripts/validate-data.ts --quiet`
- `npm run typecheck`
- `npm run build` passed before full local test run.

## Note / 说明

- Full local `npm run test` is currently affected by machine-local `/tmp` contents and env scan timeouts; focused sync tests and typecheck pass. CI should run in a clean environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 在更新 `versions.json` 前增加一致性校验：只有当所有被索引的 minor 快照文件都存在时才允许写回；发现缺失将终止更新并避免覆盖现有内容。
  * 同步 minor 快照时自动跳过已存在项，并在替换提取失败时防止旧快照被误清理。

* **测试**
  * 补充用例覆盖“写入保护/失败不覆盖”和校验缺失引用的行为。

* **文档**
  * 更新数据层规范，明确 `versions.json` 更新与数据完整性约束。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->