### PR TITLE
fix: recover failed sync publish releases

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -60,10 +60,19 @@ function gitTagExists(version: string): boolean {
 }
 
 export function isGithubReleaseNotFoundError(err: unknown): boolean {
-  const error = err as { message?: unknown; stderr?: unknown };
-  const stderr = Buffer.isBuffer(error?.stderr) ? error.stderr.toString('utf8') : String(error?.stderr ?? '');
-  const message = `${String(error?.message ?? '')}\n${stderr}`.toLowerCase();
-  return message.includes('not found') || message.includes('could not resolve to a release');
+  const parts: string[] = [];
+
+  if (err instanceof Error) {
+    parts.push(err.message);
+  }
+
+  if (err && typeof err === 'object' && 'stderr' in err) {
+    const stderr = err.stderr;
+    parts.push(Buffer.isBuffer(stderr) ? stderr.toString('utf8') : String(stderr ?? ''));
+  }
+
+  const errorText = parts.join('\n').toLowerCase();
+  return errorText.includes('not found') || errorText.includes('could not resolve to a release');
 }
 
 function githubReleaseExists(version: string): boolean {

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -32,17 +32,50 @@ interface PublishPlanInput {
   cliVersion: string;
   oldVersion: string;
   existingVersion: string | null;
+  existingGitTag?: boolean;
+  existingGithubRelease?: boolean;
   changedFiles: Set<string>;
 }
 
 export function getPublishPlan(input: PublishPlanInput) {
   const hasLocalChanges = input.changedFiles.size > 0 || input.cliVersion !== input.oldVersion;
   const shouldPublish = !input.existingVersion;
+  const shouldTag = shouldPublish && input.existingGitTag !== true;
+  const shouldRelease = shouldPublish && input.existingGithubRelease !== true;
   return {
     shouldCommit: hasLocalChanges,
     shouldPublish,
-    shouldSkip: !hasLocalChanges && !shouldPublish,
+    shouldTag,
+    shouldRelease,
+    shouldSkip: !hasLocalChanges && !shouldPublish && !shouldTag && !shouldRelease,
   };
+}
+
+function gitTagExists(version: string): boolean {
+  try {
+    return run(`git ls-remote --tags origin "refs/tags/v${version}"`).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function isGithubReleaseNotFoundError(err: unknown): boolean {
+  const error = err as { message?: unknown; stderr?: unknown };
+  const stderr = Buffer.isBuffer(error?.stderr) ? error.stderr.toString('utf8') : String(error?.stderr ?? '');
+  const message = `${String(error?.message ?? '')}\n${stderr}`.toLowerCase();
+  return message.includes('not found') || message.includes('could not resolve to a release');
+}
+
+function githubReleaseExists(version: string): boolean {
+  try {
+    run(`gh release view "v${version}"`);
+    return true;
+  } catch (err) {
+    if (!isGithubReleaseNotFoundError(err)) {
+      throw err;
+    }
+    return false;
+  }
 }
 
 function main() {
@@ -52,6 +85,8 @@ function main() {
 
   // Check if already published
   const existingVersion = getNpmVersion('@ant-design/cli', cliVersion);
+  const existingGitTag = gitTagExists(cliVersion);
+  const existingGithubRelease = githubReleaseExists(cliVersion);
 
   // Collect version info for changelog — only include versions whose data file actually changed
   const changedFiles = new Set(run('git diff --name-only HEAD -- data/').split(/\r?\n/).filter(Boolean));
@@ -66,7 +101,7 @@ function main() {
   // Get current package.json version
   const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
   const oldVersion = pkg.version;
-  const plan = getPublishPlan({ cliVersion, oldVersion, existingVersion, changedFiles });
+  const plan = getPublishPlan({ cliVersion, oldVersion, existingVersion, existingGitTag, existingGithubRelease, changedFiles });
 
   if (plan.shouldSkip) {
     console.log(`Version ${cliVersion} already published to npm and no local changes were found, skipping release`);
@@ -94,14 +129,17 @@ function main() {
     run('git add data/ package.json package-lock.json CHANGELOG.md CHANGELOG.zh-CN.md src/__tests__/snapshots/');
     run(`git commit -m "data: sync antd metadata (${versionsStr || cliVersion})"`);
 
-    if (plan.shouldPublish && cliVersion !== oldVersion) {
+    if (plan.shouldTag) {
       run(`git tag "v${cliVersion}"`);
     }
 
-    run(plan.shouldPublish && cliVersion !== oldVersion ? 'git push origin main --tags' : 'git push origin main');
+    run(plan.shouldTag ? 'git push origin main --tags' : 'git push origin main');
+  } else if (plan.shouldTag) {
+    run(`git tag "v${cliVersion}"`);
+    run(`git push origin "v${cliVersion}"`);
   }
 
-  if (plan.shouldPublish && cliVersion !== oldVersion) {
+  if (plan.shouldRelease) {
     // Create GitHub Release
     const releaseNotes = run(`npx tsx scripts/extract-changelog.ts "${cliVersion}"`);
     const releaseNotesPath = join(os.tmpdir(), `release-notes-${Date.now()}.md`);

--- a/spec.md
+++ b/spec.md
@@ -970,6 +970,7 @@ GitHub Actions workflow `.github/workflows/sync.yml` runs hourly:
 
 The CLI version is kept in sync with antd — e.g., when antd publishes v6.3.2, the CLI is also published as v6.3.2.
 If sync produces data-only changes while the current CLI version has already been published, the workflow commits and pushes those data changes without attempting to republish the same npm version.
+If the package version was already committed but a previous publish attempt failed, `scripts/publish.ts` recovers the missing git tag, GitHub Release, and npm publish without requiring a new version bump.
 
 ## Output Examples
 

--- a/src/__tests__/scripts/publish.test.ts
+++ b/src/__tests__/scripts/publish.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getPublishPlan } from '../../../scripts/publish.js';
+import { getPublishPlan, isGithubReleaseNotFoundError } from '../../../scripts/publish.js';
 
 describe('publish workflow plan', () => {
   it('commits synced data changes even when the CLI version is already published', () => {
@@ -7,11 +7,15 @@ describe('publish workflow plan', () => {
       cliVersion: '6.4.4',
       oldVersion: '6.4.4',
       existingVersion: '6.4.4',
+      existingGitTag: true,
+      existingGithubRelease: true,
       changedFiles: new Set(['data/v5.json']),
     });
 
     expect(plan.shouldCommit).toBe(true);
     expect(plan.shouldPublish).toBe(false);
+    expect(plan.shouldTag).toBe(false);
+    expect(plan.shouldRelease).toBe(false);
     expect(plan.shouldSkip).toBe(false);
   });
 
@@ -20,11 +24,50 @@ describe('publish workflow plan', () => {
       cliVersion: '6.4.4',
       oldVersion: '6.4.4',
       existingVersion: '6.4.4',
+      existingGitTag: true,
+      existingGithubRelease: true,
       changedFiles: new Set(),
     });
 
     expect(plan.shouldCommit).toBe(false);
     expect(plan.shouldPublish).toBe(false);
+    expect(plan.shouldTag).toBe(false);
+    expect(plan.shouldRelease).toBe(false);
     expect(plan.shouldSkip).toBe(true);
+  });
+
+  it('recovers tag, release, and npm publish when package version already changed but publish failed', () => {
+    const plan = getPublishPlan({
+      cliVersion: '6.4.4',
+      oldVersion: '6.4.4',
+      existingVersion: null,
+      existingGitTag: false,
+      existingGithubRelease: false,
+      changedFiles: new Set(),
+    });
+
+    expect(plan.shouldCommit).toBe(false);
+    expect(plan.shouldPublish).toBe(true);
+    expect(plan.shouldTag).toBe(true);
+    expect(plan.shouldRelease).toBe(true);
+    expect(plan.shouldSkip).toBe(false);
+  });
+
+  it('defaults omitted tag and release state to recovery when publish is needed', () => {
+    const plan = getPublishPlan({
+      cliVersion: '6.4.4',
+      oldVersion: '6.4.4',
+      existingVersion: null,
+      changedFiles: new Set(),
+    });
+
+    expect(plan.shouldTag).toBe(true);
+    expect(plan.shouldRelease).toBe(true);
+  });
+
+  it('only classifies missing GitHub releases as recoverable lookup misses', () => {
+    expect(isGithubReleaseNotFoundError(new Error('release not found'))).toBe(true);
+    expect(isGithubReleaseNotFoundError({ stderr: Buffer.from('HTTP 404: Not Found') })).toBe(true);
+    expect(isGithubReleaseNotFoundError(new Error('HTTP 401: Bad credentials'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary / 摘要

- Add publish-plan decisions for missing git tags and GitHub Releases.
- Recover tag, release, and npm publish when the package version is already committed but a previous publish attempt failed.
- Document the publish recovery behavior in the sync spec.

- 为缺失的 git tag 和 GitHub Release 增加发布计划判断。
- 当 package version 已经提交但之前发布失败时，补齐 tag、release 和 npm publish。
- 在 sync spec 中记录发布恢复行为。

## Testing / 测试

- `npx vitest run src/__tests__/scripts/publish.test.ts src/__tests__/scripts/check-sync-needed.test.ts src/__tests__/scripts/sync-versions-json.test.ts`
- `npx tsx scripts/validate-data.ts --quiet`
- `npm run typecheck`
- `npm run build` passed before full local test run.

## Note / 说明

- Full local `npm run test` is currently affected by machine-local `/tmp` contents and env scan timeouts; focused publish/sync tests and typecheck pass. CI should run in a clean environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 增强发布流程，现可检测并恢复因前次失败而缺失的版本标签、发行版本和包发布，无需重新更新版本号。

* **Documentation**
  * 更新发布流程文档，说明失败恢复机制。

* **Tests**
  * 扩充发布计划测试用例，覆盖新增的恢复场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->