### PR TITLE
fix: harden sync publish recovery

### DIFF
--- a/scripts/check-sync-needed.ts
+++ b/scripts/check-sync-needed.ts
@@ -17,6 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import semver from 'semver';
+import { isNpmPackageNotFoundError } from './utils/npm-errors.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.join(__dirname, '..', 'data');
@@ -51,7 +52,10 @@ function getLatestNpmVersion(major: number): string | null {
   try {
     const output = execSync(`npm view antd@${major} version --json`, { encoding: 'utf8' });
     return getLatestStableVersion(output);
-  } catch {
+  } catch (err) {
+    if (!isNpmPackageNotFoundError(err)) {
+      throw err;
+    }
     return null;
   }
 }
@@ -72,7 +76,10 @@ function isCliVersionPublished(version: string): boolean {
   try {
     execSync(`npm view "@ant-design/cli@${version}" version`, { stdio: 'pipe' });
     return true;
-  } catch {
+  } catch (err) {
+    if (!isNpmPackageNotFoundError(err)) {
+      throw err;
+    }
     return false;
   }
 }

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -9,6 +9,9 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getErrorText, isNpmPackageNotFoundError } from './utils/npm-errors.js';
+
+export { isNpmPackageNotFoundError } from './utils/npm-errors.js';
 
 function run(cmd: string, options?: { cwd?: string; stdio?: 'pipe' | 'inherit' }): string {
   const result = execSync(cmd, {
@@ -22,8 +25,11 @@ function run(cmd: string, options?: { cwd?: string; stdio?: 'pipe' | 'inherit' }
 
 function getNpmVersion(pkgName: string, version: string): string | null {
   try {
-    return run(`npm view "${pkgName}@${version}" version 2>/dev/null || true`);
-  } catch {
+    return run(`npm view "${pkgName}@${version}" version`);
+  } catch (err) {
+    if (!isNpmPackageNotFoundError(err)) {
+      throw err;
+    }
     return null;
   }
 }
@@ -51,6 +57,18 @@ export function getPublishPlan(input: PublishPlanInput) {
   };
 }
 
+type PublishStep = 'commit' | 'tag' | 'push' | 'publish' | 'release';
+
+export function getPublishSteps(plan: ReturnType<typeof getPublishPlan>): PublishStep[] {
+  const steps: PublishStep[] = [];
+  if (plan.shouldCommit) steps.push('commit');
+  if (plan.shouldTag) steps.push('tag');
+  if (plan.shouldCommit || plan.shouldTag) steps.push('push');
+  if (plan.shouldPublish) steps.push('publish');
+  if (plan.shouldRelease) steps.push('release');
+  return steps;
+}
+
 function gitTagExists(version: string): boolean {
   try {
     return run(`git ls-remote --tags origin "refs/tags/v${version}"`).length > 0;
@@ -60,19 +78,10 @@ function gitTagExists(version: string): boolean {
 }
 
 export function isGithubReleaseNotFoundError(err: unknown): boolean {
-  const parts: string[] = [];
-
-  if (err instanceof Error) {
-    parts.push(err.message);
-  }
-
-  if (err && typeof err === 'object' && 'stderr' in err) {
-    const stderr = err.stderr;
-    parts.push(Buffer.isBuffer(stderr) ? stderr.toString('utf8') : String(stderr ?? ''));
-  }
-
-  const errorText = parts.join('\n').toLowerCase();
-  return errorText.includes('not found') || errorText.includes('could not resolve to a release');
+  const errorText = getErrorText(err);
+  return errorText.includes('release not found')
+    || errorText.includes('http 404')
+    || errorText.includes('could not resolve to a release');
 }
 
 function githubReleaseExists(version: string): boolean {
@@ -131,37 +140,32 @@ function main() {
   run('npm run build', { stdio: 'inherit' });
   run('npx vitest run --update', { stdio: 'inherit' });
 
-  // Commit, tag and push only after successful build + test
-  if (plan.shouldCommit) {
-    run('git config user.name "github-actions[bot]"');
-    run('git config user.email "github-actions[bot]@users.noreply.github.com"');
-    run('git add data/ package.json package-lock.json CHANGELOG.md CHANGELOG.zh-CN.md src/__tests__/snapshots/');
-    run(`git commit -m "data: sync antd metadata (${versionsStr || cliVersion})"`);
-
-    if (plan.shouldTag) {
+  for (const step of getPublishSteps(plan)) {
+    if (step === 'commit') {
+      run('git config user.name "github-actions[bot]"');
+      run('git config user.email "github-actions[bot]@users.noreply.github.com"');
+      run('git add data/ package.json package-lock.json CHANGELOG.md CHANGELOG.zh-CN.md src/__tests__/snapshots/');
+      run(`git commit -m "data: sync antd metadata (${versionsStr || cliVersion})"`);
+    } else if (step === 'tag') {
       run(`git tag "v${cliVersion}"`);
+    } else if (step === 'push') {
+      if (plan.shouldCommit) {
+        run(plan.shouldTag ? 'git push origin main --tags' : 'git push origin main');
+      } else {
+        run(`git push origin "v${cliVersion}"`);
+      }
+    } else if (step === 'publish') {
+      run('NODE_AUTH_TOKEN="" npm publish --provenance --access public', { stdio: 'inherit' });
+      console.log(`Successfully published @ant-design/cli@${cliVersion}`);
+    } else if (step === 'release') {
+      const releaseNotes = run(`npx tsx scripts/extract-changelog.ts "${cliVersion}"`);
+      const releaseNotesPath = join(os.tmpdir(), `release-notes-${Date.now()}.md`);
+      writeFileSync(releaseNotesPath, releaseNotes);
+      run(`gh release create "v${cliVersion}" --title "v${cliVersion}" --notes-file "${releaseNotesPath}"`, { stdio: 'inherit' });
     }
-
-    run(plan.shouldTag ? 'git push origin main --tags' : 'git push origin main');
-  } else if (plan.shouldTag) {
-    run(`git tag "v${cliVersion}"`);
-    run(`git push origin "v${cliVersion}"`);
   }
 
-  if (plan.shouldRelease) {
-    // Create GitHub Release
-    const releaseNotes = run(`npx tsx scripts/extract-changelog.ts "${cliVersion}"`);
-    const releaseNotesPath = join(os.tmpdir(), `release-notes-${Date.now()}.md`);
-    writeFileSync(releaseNotesPath, releaseNotes);
-    run(`gh release create "v${cliVersion}" --title "v${cliVersion}" --notes-file "${releaseNotesPath}"`, { stdio: 'inherit' });
-  }
-
-  // Publish to npm (clear NODE_AUTH_TOKEN for OIDC Trusted Publishing)
-  if (plan.shouldPublish) {
-    run('NODE_AUTH_TOKEN="" npm publish --provenance --access public', { stdio: 'inherit' });
-
-    console.log(`Successfully published @ant-design/cli@${cliVersion}`);
-  } else {
+  if (!plan.shouldPublish) {
     console.log(`Version ${cliVersion} already published to npm; committed synced data changes only`);
   }
 }

--- a/scripts/utils/npm-errors.ts
+++ b/scripts/utils/npm-errors.ts
@@ -1,0 +1,22 @@
+export function getErrorText(err: unknown): string {
+  const parts: string[] = [];
+
+  if (err instanceof Error) {
+    parts.push(err.message);
+  }
+
+  if (err && typeof err === 'object' && 'stderr' in err) {
+    const stderr = err.stderr;
+    parts.push(Buffer.isBuffer(stderr) ? stderr.toString('utf8') : String(stderr ?? ''));
+  }
+
+  return parts.join('\n').toLowerCase();
+}
+
+export function isNpmPackageNotFoundError(err: unknown): boolean {
+  const errorText = getErrorText(err);
+  return errorText.includes('e404')
+    || errorText.includes('404 not found')
+    || errorText.includes('not in this registry')
+    || errorText.includes('no match found for version');
+}

--- a/spec.md
+++ b/spec.md
@@ -971,7 +971,9 @@ GitHub Actions workflow `.github/workflows/sync.yml` runs hourly:
 
 The CLI version is kept in sync with antd — e.g., when antd publishes v6.3.2, the CLI is also published as v6.3.2.
 If sync produces data-only changes while the current CLI version has already been published, the workflow commits and pushes those data changes without attempting to republish the same npm version.
-If the package version was already committed but a previous publish attempt failed, `scripts/publish.ts` recovers the missing git tag, GitHub Release, and npm publish without requiring a new version bump.
+If the package version was already committed but a previous publish attempt failed, `scripts/publish.ts` recovers the missing git tag, npm publish, and GitHub Release without requiring a new version bump.
+Npm registry lookups fail closed: only explicit package/version not-found errors are treated as unpublished; network, registry, or auth failures stop the workflow instead of triggering a false recovery.
+GitHub Releases are created only after npm publish succeeds, so public release notes do not appear before the package is installable.
 
 ## Output Examples
 

--- a/src/__tests__/scripts/publish.test.ts
+++ b/src/__tests__/scripts/publish.test.ts
@@ -95,4 +95,16 @@ describe('publish workflow plan', () => {
 
     expect(steps.indexOf('publish')).toBeLessThan(steps.indexOf('release'));
   });
+
+  it('keeps publish before release during recovery without a commit', () => {
+    const steps = getPublishSteps({
+      shouldCommit: false,
+      shouldPublish: true,
+      shouldTag: false,
+      shouldRelease: true,
+      shouldSkip: false,
+    });
+
+    expect(steps).toEqual(['publish', 'release']);
+  });
 });

--- a/src/__tests__/scripts/publish.test.ts
+++ b/src/__tests__/scripts/publish.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { getPublishPlan, isGithubReleaseNotFoundError } from '../../../scripts/publish.js';
+import {
+  getPublishPlan,
+  getPublishSteps,
+  isGithubReleaseNotFoundError,
+  isNpmPackageNotFoundError,
+} from '../../../scripts/publish.js';
 
 describe('publish workflow plan', () => {
   it('commits synced data changes even when the CLI version is already published', () => {
@@ -69,5 +74,25 @@ describe('publish workflow plan', () => {
     expect(isGithubReleaseNotFoundError(new Error('release not found'))).toBe(true);
     expect(isGithubReleaseNotFoundError({ stderr: Buffer.from('HTTP 404: Not Found') })).toBe(true);
     expect(isGithubReleaseNotFoundError(new Error('HTTP 401: Bad credentials'))).toBe(false);
+    expect(isGithubReleaseNotFoundError({ stderr: Buffer.from('sh: gh: command not found') })).toBe(false);
+  });
+
+  it('only classifies npm not-found errors as unpublished packages', () => {
+    expect(isNpmPackageNotFoundError({ stderr: Buffer.from('npm ERR! code E404\nnpm ERR! 404 Not Found') })).toBe(true);
+    expect(isNpmPackageNotFoundError(new Error('No match found for version 6.4.4'))).toBe(true);
+    expect(isNpmPackageNotFoundError(new Error('network timeout'))).toBe(false);
+    expect(isNpmPackageNotFoundError(new Error('npm ERR! code E401'))).toBe(false);
+  });
+
+  it('publishes to npm before creating a GitHub Release', () => {
+    const steps = getPublishSteps({
+      shouldCommit: true,
+      shouldPublish: true,
+      shouldTag: true,
+      shouldRelease: true,
+      shouldSkip: false,
+    });
+
+    expect(steps.indexOf('publish')).toBeLessThan(steps.indexOf('release'));
   });
 });


### PR DESCRIPTION
## Summary

- Fail closed on npm registry lookup errors during sync publish checks.
- Treat only explicit npm package/version not-found responses as unpublished.
- Create GitHub Releases only after npm publish succeeds.

## 摘要

- sync publish 检查遇到 npm registry 查询异常时 fail closed。
- 只有明确的 npm 包/版本不存在响应才视为未发布。
- 只有 npm publish 成功后才创建 GitHub Release。

## Verification

- `npx vitest run src/__tests__/scripts/check-sync-needed.test.ts src/__tests__/scripts/publish.test.ts src/__tests__/scripts/sync-versions-json.test.ts src/__tests__/scripts/validate-data.test.ts`
- `npm run typecheck`
- `npx tsx scripts/validate-data.ts --quiet`
- `npm run build`

## 验证

- `npx vitest run src/__tests__/scripts/check-sync-needed.test.ts src/__tests__/scripts/publish.test.ts src/__tests__/scripts/sync-versions-json.test.ts src/__tests__/scripts/validate-data.test.ts`
- `npm run typecheck`
- `npx tsx scripts/validate-data.ts --quiet`
- `npm run build`

## Notes

`npm run test` still fails locally because the existing migrate snapshot tests scan this machine's `/tmp` directory and pick up unrelated local projects. The focused tests covering this change pass.

## 说明

`npm run test` 在本机仍会失败，因为现有 migrate snapshot 测试会扫描这台机器的 `/tmp` 目录，并读到无关的本地项目。本次改动相关的 focused tests 已通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **改进与优化**
  * 改进了发布流程的错误处理机制，优化了包未找到场景的识别和恢复能力
  * 调整GitHub Release创建时机，改为在npm包发布成功后执行

* **文档**
  * 更新发布流程文档，明确错误处理策略和发布时序

<!-- end of auto-generated comment: release notes by coderabbit.ai -->