### PR TITLE
fix: recover missing publish release artifacts

### DIFF
--- a/scripts/check-sync-needed.ts
+++ b/scripts/check-sync-needed.ts
@@ -17,7 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import semver from 'semver';
-import { isNpmPackageNotFoundError } from './utils/npm-errors.js';
+import { getErrorText, isNpmPackageNotFoundError } from './utils/npm-errors.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.join(__dirname, '..', 'data');
@@ -29,6 +29,8 @@ interface SyncStatusOptions {
   getLatestNpmVersion: (major: number) => string | null;
   getLocalVersion: (major: number) => string | null;
   isCliVersionPublished: (version: string) => boolean;
+  gitTagExists: (version: string) => boolean;
+  githubReleaseExists: (version: string) => boolean;
 }
 
 export function getLatestStableVersion(output: string): string | null {
@@ -84,6 +86,29 @@ function isCliVersionPublished(version: string): boolean {
   }
 }
 
+function gitTagExists(version: string): boolean {
+  return execSync(`git ls-remote --tags origin "refs/tags/v${version}"`, { encoding: 'utf8' }).trim().length > 0;
+}
+
+function isGithubReleaseNotFoundError(err: unknown): boolean {
+  const errorText = getErrorText(err);
+  return errorText.includes('release not found')
+    || errorText.includes('http 404')
+    || errorText.includes('could not resolve to a release');
+}
+
+function githubReleaseExists(version: string): boolean {
+  try {
+    execSync(`gh release view "v${version}"`, { stdio: 'pipe' });
+    return true;
+  } catch (err) {
+    if (!isGithubReleaseNotFoundError(err)) {
+      throw err;
+    }
+    return false;
+  }
+}
+
 export function resolveSyncStatus(options: SyncStatusOptions) {
   let needsSync = false;
   const statusLines: string[] = [];
@@ -97,7 +122,10 @@ export function resolveSyncStatus(options: SyncStatusOptions) {
   }
 
   const v6Local = options.getLocalVersion(6);
-  const needsPublish = needsSync || !v6Local || !options.isCliVersionPublished(v6Local);
+  const cliPublished = v6Local ? options.isCliVersionPublished(v6Local) : false;
+  const tagExists = v6Local ? options.gitTagExists(v6Local) : false;
+  const releaseExists = v6Local ? options.githubReleaseExists(v6Local) : false;
+  const needsPublish = needsSync || !v6Local || !cliPublished || !tagExists || !releaseExists;
 
   return { needsSync, needsPublish, statusLines };
 }
@@ -108,6 +136,8 @@ function main() {
     getLatestNpmVersion,
     getLocalVersion,
     isCliVersionPublished,
+    gitTagExists,
+    githubReleaseExists,
   });
 
   console.log('Version check:');

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -46,8 +46,8 @@ interface PublishPlanInput {
 export function getPublishPlan(input: PublishPlanInput) {
   const hasLocalChanges = input.changedFiles.size > 0 || input.cliVersion !== input.oldVersion;
   const shouldPublish = !input.existingVersion;
-  const shouldTag = shouldPublish && input.existingGitTag !== true;
-  const shouldRelease = shouldPublish && input.existingGithubRelease !== true;
+  const shouldTag = input.existingGitTag !== true;
+  const shouldRelease = input.existingGithubRelease !== true;
   return {
     shouldCommit: hasLocalChanges,
     shouldPublish,
@@ -166,7 +166,7 @@ function main() {
   }
 
   if (!plan.shouldPublish) {
-    console.log(`Version ${cliVersion} already published to npm; committed synced data changes only`);
+    console.log(`Version ${cliVersion} already published to npm; recovered pending release artifacts and/or committed synced data changes`);
   }
 }
 

--- a/spec.md
+++ b/spec.md
@@ -971,7 +971,7 @@ GitHub Actions workflow `.github/workflows/sync.yml` runs hourly:
 
 The CLI version is kept in sync with antd — e.g., when antd publishes v6.3.2, the CLI is also published as v6.3.2.
 If sync produces data-only changes while the current CLI version has already been published, the workflow commits and pushes those data changes without attempting to republish the same npm version.
-If the package version was already committed but a previous publish attempt failed, `scripts/publish.ts` recovers the missing git tag, npm publish, and GitHub Release without requiring a new version bump.
+If the package version was already committed but a previous publish attempt failed, `scripts/publish.ts` recovers missing release artifacts without requiring a new version bump. The sync gate treats a missing npm package, git tag, or GitHub Release for the synced v6 version as `needs_publish=true`.
 Npm registry lookups fail closed: only explicit package/version not-found errors are treated as unpublished; network, registry, or auth failures stop the workflow instead of triggering a false recovery.
 GitHub Releases are created only after npm publish succeeds, so public release notes do not appear before the package is installable.
 

--- a/src/__tests__/scripts/check-sync-needed.test.ts
+++ b/src/__tests__/scripts/check-sync-needed.test.ts
@@ -18,9 +18,25 @@ describe('check-sync-needed', () => {
       getLatestNpmVersion: () => '6.4.4',
       getLocalVersion: () => '6.4.4',
       isCliVersionPublished: () => true,
+      gitTagExists: () => true,
+      githubReleaseExists: () => true,
     });
 
     expect(status.needsSync).toBe(false);
     expect(status.needsPublish).toBe(false);
+  });
+
+  it('requests publish recovery when npm is published but tag or release is missing', () => {
+    const status = resolveSyncStatus({
+      majors: [6],
+      getLatestNpmVersion: () => '6.4.4',
+      getLocalVersion: () => '6.4.4',
+      isCliVersionPublished: () => true,
+      gitTagExists: () => false,
+      githubReleaseExists: () => false,
+    });
+
+    expect(status.needsSync).toBe(false);
+    expect(status.needsPublish).toBe(true);
   });
 });

--- a/src/__tests__/scripts/publish.test.ts
+++ b/src/__tests__/scripts/publish.test.ts
@@ -41,6 +41,23 @@ describe('publish workflow plan', () => {
     expect(plan.shouldSkip).toBe(true);
   });
 
+  it('recovers a missing git tag and GitHub Release even when npm is already published', () => {
+    const plan = getPublishPlan({
+      cliVersion: '6.4.4',
+      oldVersion: '6.4.4',
+      existingVersion: '6.4.4',
+      existingGitTag: false,
+      existingGithubRelease: false,
+      changedFiles: new Set(),
+    });
+
+    expect(plan.shouldCommit).toBe(false);
+    expect(plan.shouldPublish).toBe(false);
+    expect(plan.shouldTag).toBe(true);
+    expect(plan.shouldRelease).toBe(true);
+    expect(plan.shouldSkip).toBe(false);
+  });
+
   it('recovers tag, release, and npm publish when package version already changed but publish failed', () => {
     const plan = getPublishPlan({
       cliVersion: '6.4.4',
@@ -106,5 +123,17 @@ describe('publish workflow plan', () => {
     });
 
     expect(steps).toEqual(['publish', 'release']);
+  });
+
+  it('pushes a recovered tag before creating a missing release when npm is already published', () => {
+    const steps = getPublishSteps({
+      shouldCommit: false,
+      shouldPublish: false,
+      shouldTag: true,
+      shouldRelease: true,
+      shouldSkip: false,
+    });
+
+    expect(steps).toEqual(['tag', 'push', 'release']);
   });
 });


### PR DESCRIPTION
## Summary

- recover missing git tags and GitHub Releases even when the npm package is already published
- make the sync gate request publish recovery when the synced v6 npm package, git tag, or GitHub Release is missing
- document the release artifact recovery behavior in the spec

## Test Plan

- npm run build
- npm run typecheck
- npm audit --omit=dev --audit-level=critical
- npx vitest run src/__tests__/scripts/publish.test.ts src/__tests__/scripts/check-sync-needed.test.ts
- all test files except src/__tests__/snapshots/migrate.test.ts: 47 passed, 635 tests passed

Note: full npm run test still has the pre-existing environment-dependent snapshot mismatch in src/__tests__/snapshots/migrate.test.ts because it scans the real /tmp directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 增强发布状态检查，现支持验证 Git 标签和 GitHub Release 是否存在
  * 支持发布恢复机制：即使 npm 已发布，仍可补全缺失的标签和发布记录

* **Documentation**
  * 更新自动同步文档，说明发布恢复逻辑

<!-- end of auto-generated comment: release notes by coderabbit.ai -->