### PR TITLE
fix: authenticate sync release checks

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Check if sync needed
         id: check-version
         run: npx tsx scripts/check-sync-needed.ts
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Baseline test (before data sync)
         if: steps.check-version.outputs.needs_publish == 'true'

--- a/scripts/check-sync-needed.ts
+++ b/scripts/check-sync-needed.ts
@@ -12,7 +12,7 @@
  *   needs_publish — CLI for the synced version hasn't been published yet
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -52,7 +52,7 @@ export function getLatestStableVersion(output: string): string | null {
 
 function getLatestNpmVersion(major: number): string | null {
   try {
-    const output = execSync(`npm view antd@${major} version --json`, { encoding: 'utf8' });
+    const output = execFileSync('npm', ['view', `antd@${major}`, 'version', '--json'], { encoding: 'utf8' });
     return getLatestStableVersion(output);
   } catch (err) {
     if (!isNpmPackageNotFoundError(err)) {
@@ -76,7 +76,7 @@ function getLocalVersion(major: number): string | null {
 
 function isCliVersionPublished(version: string): boolean {
   try {
-    execSync(`npm view "@ant-design/cli@${version}" version`, { stdio: 'pipe' });
+    execFileSync('npm', ['view', `@ant-design/cli@${version}`, 'version'], { stdio: 'pipe' });
     return true;
   } catch (err) {
     if (!isNpmPackageNotFoundError(err)) {
@@ -87,7 +87,7 @@ function isCliVersionPublished(version: string): boolean {
 }
 
 function gitTagExists(version: string): boolean {
-  return execSync(`git ls-remote --tags origin "refs/tags/v${version}"`, { encoding: 'utf8' }).trim().length > 0;
+  return execFileSync('git', ['ls-remote', '--tags', 'origin', `refs/tags/v${version}`], { encoding: 'utf8' }).trim().length > 0;
 }
 
 function isGithubReleaseNotFoundError(err: unknown): boolean {
@@ -99,7 +99,7 @@ function isGithubReleaseNotFoundError(err: unknown): boolean {
 
 function githubReleaseExists(version: string): boolean {
   try {
-    execSync(`gh release view "v${version}"`, { stdio: 'pipe' });
+    execFileSync('gh', ['release', 'view', `v${version}`], { stdio: 'pipe' });
     return true;
   } catch (err) {
     if (!isGithubReleaseNotFoundError(err)) {
@@ -122,10 +122,12 @@ export function resolveSyncStatus(options: SyncStatusOptions) {
   }
 
   const v6Local = options.getLocalVersion(6);
-  const cliPublished = v6Local ? options.isCliVersionPublished(v6Local) : false;
-  const tagExists = v6Local ? options.gitTagExists(v6Local) : false;
-  const releaseExists = v6Local ? options.githubReleaseExists(v6Local) : false;
-  const needsPublish = needsSync || !v6Local || !cliPublished || !tagExists || !releaseExists;
+  const needsPublish =
+    needsSync ||
+    !v6Local ||
+    !options.isCliVersionPublished(v6Local) ||
+    !options.gitTagExists(v6Local) ||
+    !options.githubReleaseExists(v6Local);
 
   return { needsSync, needsPublish, statusLines };
 }

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -4,7 +4,7 @@
  * Handles version check, git operations, and npm publish.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import { join, resolve } from 'node:path';
@@ -25,7 +25,7 @@ function run(cmd: string, options?: { cwd?: string; stdio?: 'pipe' | 'inherit' }
 
 function getNpmVersion(pkgName: string, version: string): string | null {
   try {
-    return run(`npm view "${pkgName}@${version}" version`);
+    return execFileSync('npm', ['view', `${pkgName}@${version}`, 'version'], { encoding: 'utf8' }).trim();
   } catch (err) {
     if (!isNpmPackageNotFoundError(err)) {
       throw err;
@@ -71,7 +71,7 @@ export function getPublishSteps(plan: ReturnType<typeof getPublishPlan>): Publis
 
 function gitTagExists(version: string): boolean {
   try {
-    return run(`git ls-remote --tags origin "refs/tags/v${version}"`).length > 0;
+    return execFileSync('git', ['ls-remote', '--tags', 'origin', `refs/tags/v${version}`], { encoding: 'utf8' }).trim().length > 0;
   } catch {
     return false;
   }
@@ -86,7 +86,7 @@ export function isGithubReleaseNotFoundError(err: unknown): boolean {
 
 function githubReleaseExists(version: string): boolean {
   try {
-    run(`gh release view "v${version}"`);
+    execFileSync('gh', ['release', 'view', `v${version}`], { stdio: 'pipe' });
     return true;
   } catch (err) {
     if (!isGithubReleaseNotFoundError(err)) {

--- a/spec.md
+++ b/spec.md
@@ -971,7 +971,7 @@ GitHub Actions workflow `.github/workflows/sync.yml` runs hourly:
 
 The CLI version is kept in sync with antd — e.g., when antd publishes v6.3.2, the CLI is also published as v6.3.2.
 If sync produces data-only changes while the current CLI version has already been published, the workflow commits and pushes those data changes without attempting to republish the same npm version.
-If the package version was already committed but a previous publish attempt failed, `scripts/publish.ts` recovers missing release artifacts without requiring a new version bump. The sync gate treats a missing npm package, git tag, or GitHub Release for the synced v6 version as `needs_publish=true`.
+If the package version was already committed but a previous publish attempt failed, `scripts/publish.ts` recovers missing release artifacts without requiring a new version bump. The sync gate treats a missing npm package, git tag, or GitHub Release for the synced v6 version as `needs_publish=true`; the check step passes `GH_TOKEN` so GitHub Release lookup can run in Actions.
 Npm registry lookups fail closed: only explicit package/version not-found errors are treated as unpublished; network, registry, or auth failures stop the workflow instead of triggering a false recovery.
 GitHub Releases are created only after npm publish succeeds, so public release notes do not appear before the package is installable.
 

--- a/src/__tests__/scripts/check-sync-needed.test.ts
+++ b/src/__tests__/scripts/check-sync-needed.test.ts
@@ -39,4 +39,24 @@ describe('check-sync-needed', () => {
     expect(status.needsSync).toBe(false);
     expect(status.needsPublish).toBe(true);
   });
+
+  it('short-circuits release artifact checks when data sync is already needed', () => {
+    const status = resolveSyncStatus({
+      majors: [6],
+      getLatestNpmVersion: () => '6.4.5',
+      getLocalVersion: () => '6.4.4',
+      isCliVersionPublished: () => {
+        throw new Error('should not check npm package when sync is needed');
+      },
+      gitTagExists: () => {
+        throw new Error('should not check git tag when sync is needed');
+      },
+      githubReleaseExists: () => {
+        throw new Error('should not check GitHub Release when sync is needed');
+      },
+    });
+
+    expect(status.needsSync).toBe(true);
+    expect(status.needsPublish).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- pass GH_TOKEN to the sync gate so GitHub Release lookup works in Actions
- address PR #179 review feedback by short-circuiting release artifact checks when sync is already needed
- replace shell-interpolated npm/git/gh existence checks with execFileSync argument arrays in sync/publish scripts

## Test Plan

- npm run build
- npm run typecheck
- npx vitest run src/__tests__/scripts/check-sync-needed.test.ts src/__tests__/scripts/publish.test.ts
