### PR TITLE
docs: expand v6.4.5 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,55 @@
 
 ## [6.4.5](https://github.com/ant-design/ant-design-cli/compare/v6.4.4...v6.4.5) (2026-06-22)
 
+### Features
+
+- New `antd setup` command for initializing Ant Design projects and configuration ([#165](https://github.com/ant-design/ant-design-cli/pull/165))
+- `antd migrate` can now scan a directory and generate targeted migration prompts from actual usage ([#159](https://github.com/ant-design/ant-design-cli/pull/159))
+
+### Bug Fixes
+
+- Fix sync release authentication and recovery paths so missing or failed publish artifacts are detected and repaired reliably ([#180](https://github.com/ant-design/ant-design-cli/pull/180), [#179](https://github.com/ant-design/ant-design-cli/pull/179), [#178](https://github.com/ant-design/ant-design-cli/pull/178), [#177](https://github.com/ant-design/ant-design-cli/pull/177), [#176](https://github.com/ant-design/ant-design-cli/pull/176))
+- Harden the sync workflow against missing release tags, corrupted version indexes, stale token metadata, and data-only sync changes ([#174](https://github.com/ant-design/ant-design-cli/pull/174), [#173](https://github.com/ant-design/ant-design-cli/pull/173), [#172](https://github.com/ant-design/ant-design-cli/pull/172), [#171](https://github.com/ant-design/ant-design-cli/pull/171), [#170](https://github.com/ant-design/ant-design-cli/pull/170), [#169](https://github.com/ant-design/ant-design-cli/pull/169), [#168](https://github.com/ant-design/ant-design-cli/pull/168))
+- Keep doctor bug checks offline so tests and normal runs do not make network calls ([#164](https://github.com/ant-design/ant-design-cli/pull/164))
+- Count `antd` subpath default imports in usage analysis ([#163](https://github.com/ant-design/ant-design-cli/pull/163))
+- Avoid stack traces for invalid global options ([#162](https://github.com/ant-design/ant-design-cli/pull/162))
+
+### Security
+
+- Resolve Dependabot security alerts ([#167](https://github.com/ant-design/ant-design-cli/pull/167))
+
+### Other Changes
+
+- Bump dependencies ([#175](https://github.com/ant-design/ant-design-cli/pull/175), [#160](https://github.com/ant-design/ant-design-cli/pull/160), [#157](https://github.com/ant-design/ant-design-cli/pull/157))
+- Keep update-check cache tests safely mocked ([#161](https://github.com/ant-design/ant-design-cli/pull/161))
+- Add Chinese release notes for v6.4.4 ([#158](https://github.com/ant-design/ant-design-cli/pull/158))
 - Update antd metadata ([v6@6.4.5](https://github.com/ant-design/ant-design-cli/compare/v6.4.4...v6.4.5#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+
+---
+
+### 新功能
+
+- 新增 `antd setup` 命令，用于初始化 Ant Design 项目和相关配置 ([#165](https://github.com/ant-design/ant-design-cli/pull/165))
+- `antd migrate` 现在可以扫描目录，并基于实际使用情况生成更有针对性的迁移提示词 ([#159](https://github.com/ant-design/ant-design-cli/pull/159))
+
+### Bug 修复
+
+- 修复同步发布流程的鉴权与恢复路径，确保缺失或失败的发布产物能被可靠检测和修复 ([#180](https://github.com/ant-design/ant-design-cli/pull/180), [#179](https://github.com/ant-design/ant-design-cli/pull/179), [#178](https://github.com/ant-design/ant-design-cli/pull/178), [#177](https://github.com/ant-design/ant-design-cli/pull/177), [#176](https://github.com/ant-design/ant-design-cli/pull/176))
+- 增强同步流程，覆盖 release tag 缺失、版本索引损坏、Token 元数据过期和纯数据同步变更等场景 ([#174](https://github.com/ant-design/ant-design-cli/pull/174), [#173](https://github.com/ant-design/ant-design-cli/pull/173), [#172](https://github.com/ant-design/ant-design-cli/pull/172), [#171](https://github.com/ant-design/ant-design-cli/pull/171), [#170](https://github.com/ant-design/ant-design-cli/pull/170), [#169](https://github.com/ant-design/ant-design-cli/pull/169), [#168](https://github.com/ant-design/ant-design-cli/pull/168))
+- 保持 doctor bug 检查离线执行，避免测试和普通运行触发网络请求 ([#164](https://github.com/ant-design/ant-design-cli/pull/164))
+- `usage` 分析现在会统计 `antd` 子路径的默认导入 ([#163](https://github.com/ant-design/ant-design-cli/pull/163))
+- 传入无效全局选项时不再输出堆栈信息 ([#162](https://github.com/ant-design/ant-design-cli/pull/162))
+
+### 安全
+
+- 修复 Dependabot 安全告警 ([#167](https://github.com/ant-design/ant-design-cli/pull/167))
+
+### 其他变更
+
+- 升级依赖 ([#175](https://github.com/ant-design/ant-design-cli/pull/175), [#160](https://github.com/ant-design/ant-design-cli/pull/160), [#157](https://github.com/ant-design/ant-design-cli/pull/157))
+- 保持升级检查缓存相关测试使用安全 mock ([#161](https://github.com/ant-design/ant-design-cli/pull/161))
+- 为 v6.4.4 补充中文发布说明 ([#158](https://github.com/ant-design/ant-design-cli/pull/158))
+- 同步 antd 元数据 ([v6@6.4.5](https://github.com/ant-design/ant-design-cli/compare/v6.4.4...v6.4.5#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.4.4](https://github.com/ant-design/ant-design-cli/compare/v6.4.3...v6.4.4) (2026-06-12)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,28 @@
 
 ## [6.4.5](https://github.com/ant-design/ant-design-cli/compare/v6.4.4...v6.4.5) (2026-06-22)
 
+### 新功能
+
+- 新增 `antd setup` 命令，用于初始化 Ant Design 项目和相关配置 ([#165](https://github.com/ant-design/ant-design-cli/pull/165))
+- `antd migrate` 现在可以扫描目录，并基于实际使用情况生成更有针对性的迁移提示词 ([#159](https://github.com/ant-design/ant-design-cli/pull/159))
+
+### Bug 修复
+
+- 修复同步发布流程的鉴权与恢复路径，确保缺失或失败的发布产物能被可靠检测和修复 ([#180](https://github.com/ant-design/ant-design-cli/pull/180), [#179](https://github.com/ant-design/ant-design-cli/pull/179), [#178](https://github.com/ant-design/ant-design-cli/pull/178), [#177](https://github.com/ant-design/ant-design-cli/pull/177), [#176](https://github.com/ant-design/ant-design-cli/pull/176))
+- 增强同步流程，覆盖 release tag 缺失、版本索引损坏、Token 元数据过期和纯数据同步变更等场景 ([#174](https://github.com/ant-design/ant-design-cli/pull/174), [#173](https://github.com/ant-design/ant-design-cli/pull/173), [#172](https://github.com/ant-design/ant-design-cli/pull/172), [#171](https://github.com/ant-design/ant-design-cli/pull/171), [#170](https://github.com/ant-design/ant-design-cli/pull/170), [#169](https://github.com/ant-design/ant-design-cli/pull/169), [#168](https://github.com/ant-design/ant-design-cli/pull/168))
+- 保持 doctor bug 检查离线执行，避免测试和普通运行触发网络请求 ([#164](https://github.com/ant-design/ant-design-cli/pull/164))
+- `usage` 分析现在会统计 `antd` 子路径的默认导入 ([#163](https://github.com/ant-design/ant-design-cli/pull/163))
+- 传入无效全局选项时不再输出堆栈信息 ([#162](https://github.com/ant-design/ant-design-cli/pull/162))
+
+### 安全
+
+- 修复 Dependabot 安全告警 ([#167](https://github.com/ant-design/ant-design-cli/pull/167))
+
+### 其他变更
+
+- 升级依赖 ([#175](https://github.com/ant-design/ant-design-cli/pull/175), [#160](https://github.com/ant-design/ant-design-cli/pull/160), [#157](https://github.com/ant-design/ant-design-cli/pull/157))
+- 保持升级检查缓存相关测试使用安全 mock ([#161](https://github.com/ant-design/ant-design-cli/pull/161))
+- 为 v6.4.4 补充中文发布说明 ([#158](https://github.com/ant-design/ant-design-cli/pull/158))
 - 同步 antd 元数据 ([v6@6.4.5](https://github.com/ant-design/ant-design-cli/compare/v6.4.4...v6.4.5#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 


### PR DESCRIPTION
## Summary

- Expand the v6.4.5 changelog entry with grouped English and Chinese release notes
- Add the same expanded Chinese entry to `CHANGELOG.zh-CN.md`
- Keep the existing v6.4.5 metadata sync link

## Verification

- `git diff --check`
- `gh release view v6.4.5 --repo ant-design/ant-design-cli --json body` matched the generated multiline release notes body

## Notes

- `npm run test` was attempted, but the existing migrate snapshot tests failed because they scan the real `/tmp` directory and detected unrelated local files instead of an empty temp directory. No test snapshots were updated for this docs-only PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 完善v6.4.5版本的发布说明，采用结构化分类呈现变更详情，包括新增功能、Bug修复、安全改进和其他更新，帮助用户快速了解各类变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->