### PR TITLE
feat: add Ant Design CLI help banner

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -83,6 +83,8 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 
 ## Commands
 
+Running `antd`, `antd -h`, or `antd --help` prints root help with the Ant Design CLI banner logo and includes the current CLI version. Running `antd -v`, `antd -V`, `antd --cli-version`, or bare `antd --version` prints only the CLI version.
+
 ### Knowledge Query
 
 #### `antd list`
@@ -835,9 +837,10 @@ Successfully upgraded to v6.4.4
 | Flag | Description | Default |
 |---|---|---|
 | `--format json\|text\|markdown` | Output format. `json` includes all data with no decoration. | `text` |
-| `--version <v>` | Target antd version (full semver, e.g. `5.20.0`) | auto-detect from project |
+| `--version [v]` | Target antd version when a value is provided (full semver, e.g. `5.20.0`); bare `--version` prints the CLI version. | auto-detect from project |
 | `--lang en\|zh` | Output language | `en` |
 | `--detail` | Full information output (more fields in response) | `false` |
+| `-v`, `-V`, `--cli-version` | Print the CLI version number. | — |
 
 Note: `--quiet` removed. `--format json` already provides clean structured output for agents. `--format text` is for human-readable output and always includes formatting.
 

--- a/spec.md
+++ b/spec.md
@@ -83,7 +83,7 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 
 ## Commands
 
-Running `antd`, `antd -h`, or `antd --help` prints root help with the Ant Design CLI banner logo and includes the current CLI version. Running `antd -v`, `antd -V`, `antd --cli-version`, or bare `antd --version` prints only the CLI version.
+Running `antd`, `antd -h`, or `antd --help` prints root help with the Ant Design CLI banner logo and includes the current CLI version. Running `antd -V` or `antd --cli-version` prints only the CLI version.
 
 ### Knowledge Query
 
@@ -837,10 +837,10 @@ Successfully upgraded to v6.4.4
 | Flag | Description | Default |
 |---|---|---|
 | `--format json\|text\|markdown` | Output format. `json` includes all data with no decoration. | `text` |
-| `--version [v]` | Target antd version when a value is provided (full semver, e.g. `5.20.0`); bare `--version` prints the CLI version. | auto-detect from project |
+| `--version [v]` | Target antd version when a value is provided (full semver, e.g. `5.20.0`). | auto-detect from project |
 | `--lang en\|zh` | Output language | `en` |
 | `--detail` | Full information output (more fields in response) | `false` |
-| `-v`, `-V`, `--cli-version` | Print the CLI version number. | — |
+| `-V`, `--cli-version` | Print the CLI version number. | — |
 
 Note: `--quiet` removed. `--format json` already provides clean structured output for agents. `--format text` is for human-readable output and always includes formatting.
 

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -8,6 +8,7 @@ const { version: cliVersion } = JSON.parse(readFileSync('package.json', 'utf-8')
 describe('CLI', () => {
   it('should show help', async () => {
     const out = await run('--help');
+    expect(out).toContain('Ant Design CLI');
     expect(out).toContain(`antd ${cliVersion}`);
     expect(out).toContain('antd');
     expect(out).toContain('list');

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -9,6 +9,7 @@ describe('CLI', () => {
   it('should show help', async () => {
     const out = await run('--help');
     expect(out).toContain('Ant Design CLI');
+    expect(out).toContain('/ ___ |');
     expect(out).toContain(`antd ${cliVersion}`);
     expect(out).toContain('antd');
     expect(out).toContain('list');

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -34,14 +34,16 @@ describe('CLI', () => {
     expect(out).toMatch(/^\d+\.\d+\.\d+[-\w.]*$/);
   });
 
-  it('should show CLI version with -v', async () => {
-    const out = await run('-v');
-    expect(out).toBe(cliVersion);
+  it('should reject -v because CLI version uses -V', async () => {
+    const result = await runCLI('-v');
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain("unknown option '-v'");
   });
 
-  it('should show CLI version with bare --version', async () => {
+  it('should not treat bare --version as a CLI version alias', async () => {
     const out = await run('--version');
-    expect(out).toBe(cliVersion);
+    expect(out).not.toBe(cliVersion);
   });
 
   it('should output error as JSON to stderr', async () => {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,19 +1,45 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { run, runCLI } from './helper.js';
+
+const { version: cliVersion } = JSON.parse(readFileSync('package.json', 'utf-8')) as { version: string };
 
 describe('CLI', () => {
   it('should show help', async () => {
     const out = await run('--help');
+    expect(out).toContain(`antd ${cliVersion}`);
     expect(out).toContain('antd');
     expect(out).toContain('list');
     expect(out).toContain('info');
     expect(out).toContain('demo');
   });
 
+  it('should show help with version when no command is provided', async () => {
+    const out = await run();
+    expect(out).toContain(`antd ${cliVersion}`);
+    expect(out).toContain('Usage: antd [options] [command]');
+  });
+
+  it('should show help with version with -h', async () => {
+    const out = await run('-h');
+    expect(out).toContain(`antd ${cliVersion}`);
+    expect(out).toContain('Usage: antd [options] [command]');
+  });
+
   it('should show CLI version with -V', async () => {
     const out = await run('-V');
     expect(out).toMatch(/^\d+\.\d+\.\d+[-\w.]*$/);
+  });
+
+  it('should show CLI version with -v', async () => {
+    const out = await run('-v');
+    expect(out).toBe(cliVersion);
+  });
+
+  it('should show CLI version with bare --version', async () => {
+    const out = await run('--version');
+    expect(out).toBe(cliVersion);
   });
 
   it('should output error as JSON to stderr', async () => {

--- a/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
@@ -1,7 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`help > --help 1`] = `
-"antd 6.5.0
+"/\\          Ant Design CLI
+/  \\        antd 6.5.0
+/ /\\ \\       Component intelligence for agents
+/_/  \\_\\     Query, diagnose, and migrate antd projects
 
 
 Usage: antd [options] [command]

--- a/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
@@ -1,10 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`help > --help 1`] = `
-"/\\          Ant Design CLI
-/  \\        antd 6.5.0
-/ /\\ \\       Component intelligence for agents
-/_/  \\_\\     Query, diagnose, and migrate antd projects
+"___          _     ____
+   /   |  ____  (_)___/ / /
+  / /| | / __ \\/ / __  / /
+ / ___ |/ / / / / /_/ /_/
+/_/  |_/_/ /_/_/\\__,_(_)
+
+antd 6.5.0  |  Ant Design CLI
+Component intelligence for React agents
 
 
 Usage: antd [options] [command]

--- a/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
@@ -1,17 +1,22 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`help > --help 1`] = `
-"Usage: antd [options] [command]
+"antd 6.5.0
+
+
+Usage: antd [options] [command]
 
 CLI tool for querying antd knowledge and analyzing antd usage
 
 Options:
   --format <format>                Output format: json, text, or markdown
                                    (default: "text")
-  --version <version>              Target antd version (e.g. 5.20.0)
+  --version [version]              Target antd version (e.g. 5.20.0); omit value
+                                   to output CLI version
   --lang <lang>                    Output language: en or zh (default: "en")
   --detail                         Full information output (default: false)
   -V, --cli-version                Output the CLI version number
+  -v                               Output the CLI version number
   -h, --help                       display help for command
 
 Commands:

--- a/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
@@ -18,12 +18,10 @@ CLI tool for querying antd knowledge and analyzing antd usage
 Options:
   --format <format>                Output format: json, text, or markdown
                                    (default: "text")
-  --version [version]              Target antd version (e.g. 5.20.0); omit value
-                                   to output CLI version
+  --version [version]              Target antd version (e.g. 5.20.0)
   --lang <lang>                    Output language: en or zh (default: "en")
   --detail                         Full information output (default: false)
   -V, --cli-version                Output the CLI version number
-  -v                               Output the CLI version number
   -h, --help                       display help for command
 
 Commands:

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,14 @@ import { checkForUpdate } from './utils/update-check.js';
 import type { GlobalOptions } from './types.js';
 declare const __CLI_VERSION__: string;
 const CLI_VERSION = __CLI_VERSION__;
+type RootOptions = Omit<GlobalOptions, 'version'> & { version?: string | boolean };
+
+function getCommandArgs(argv: readonly string[] | undefined, options: Parameters<Command['parseAsync']>[1]): readonly string[] {
+  if (options?.from === 'user') {
+    return argv ?? [];
+  }
+  return (argv ?? process.argv).slice(2);
+}
 
 export function createProgram(): Command {
   const program = new Command();
@@ -28,15 +36,23 @@ export function createProgram(): Command {
     .name('antd')
     .description('CLI tool for querying antd knowledge and analyzing antd usage')
     .option('--format <format>', 'Output format: json, text, or markdown', 'text')
-    .option('--version <version>', 'Target antd version (e.g. 5.20.0)')
+    .option('--version [version]', 'Target antd version (e.g. 5.20.0); omit value to output CLI version')
     .option('--lang <lang>', 'Output language: en or zh', 'en')
     .option('--detail', 'Full information output', false);
 
-  // -V for CLI version (--version is used for antd version targeting)
+  program.addHelpText('before', `antd ${CLI_VERSION}\n\n`);
+
+  // -V remains for compatibility; -v and bare --version print CLI version.
   program.addOption(new Option('-V, --cli-version', 'Output the CLI version number'));
+  program.addOption(new Option('-v', 'Output the CLI version number'));
 
   // Handle -V/--cli-version via Commander event (fires before subcommand dispatch)
   program.on('option:cli-version', () => {
+    // eslint-disable-next-line no-console
+    console.log(CLI_VERSION);
+    process.exit(0);
+  });
+  program.on('option:v', () => {
     // eslint-disable-next-line no-console
     console.log(CLI_VERSION);
     process.exit(0);
@@ -72,7 +88,12 @@ export function createProgram(): Command {
 
   // Validate global options before any command runs
   program.hook('preAction', () => {
-    const opts = program.opts<GlobalOptions>();
+    const opts = program.opts<RootOptions>();
+    if (opts.version === true) {
+      // eslint-disable-next-line no-console
+      console.log(CLI_VERSION);
+      process.exit(0);
+    }
     const validFormats = ['json', 'text', 'markdown'];
     const validLangs = ['en', 'zh'];
     if (opts.format && !validFormats.includes(opts.format)) {
@@ -86,6 +107,21 @@ export function createProgram(): Command {
   program.hook('postAction', async () => {
     await checkForUpdate();
   });
+
+  const parseAsync = program.parseAsync.bind(program);
+  program.parseAsync = async (argv, options) => {
+    const args = getCommandArgs(argv, options);
+    if (args.length === 0) {
+      program.outputHelp();
+      return program;
+    }
+    if (args.length === 1 && args[0] === '--version') {
+      // eslint-disable-next-line no-console
+      console.log(CLI_VERSION);
+      return program;
+    }
+    return parseAsync(argv, options);
+  };
 
   return program;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,16 @@ declare const __CLI_VERSION__: string;
 const CLI_VERSION = __CLI_VERSION__;
 type RootOptions = Omit<GlobalOptions, 'version'> & { version?: string | boolean };
 
+function getHelpBanner(version: string): string {
+  return [
+    '/\\          Ant Design CLI',
+    `/  \\        antd ${version}`,
+    '/ /\\ \\       Component intelligence for agents',
+    '/_/  \\_\\     Query, diagnose, and migrate antd projects',
+    '',
+  ].join('\n');
+}
+
 function getCommandArgs(argv: readonly string[] | undefined, options: Parameters<Command['parseAsync']>[1]): readonly string[] {
   if (options?.from === 'user') {
     return argv ?? [];
@@ -40,7 +50,7 @@ export function createProgram(): Command {
     .option('--lang <lang>', 'Output language: en or zh', 'en')
     .option('--detail', 'Full information output', false);
 
-  program.addHelpText('before', `antd ${CLI_VERSION}\n\n`);
+  program.addHelpText('before', `${getHelpBanner(CLI_VERSION)}\n`);
 
   // -V remains for compatibility; -v and bare --version print CLI version.
   program.addOption(new Option('-V, --cli-version', 'Output the CLI version number'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,10 +24,14 @@ type RootOptions = Omit<GlobalOptions, 'version'> & { version?: string | boolean
 
 function getHelpBanner(version: string): string {
   return [
-    '/\\          Ant Design CLI',
-    `/  \\        antd ${version}`,
-    '/ /\\ \\       Component intelligence for agents',
-    '/_/  \\_\\     Query, diagnose, and migrate antd projects',
+    '    ___          _     ____',
+    '   /   |  ____  (_)___/ / /',
+    '  / /| | / __ \\/ / __  / /',
+    ' / ___ |/ / / / / /_/ /_/',
+    '/_/  |_/_/ /_/_/\\__,_(_)',
+    '',
+    `antd ${version}  |  Ant Design CLI`,
+    'Component intelligence for React agents',
     '',
   ].join('\n');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ import { checkForUpdate } from './utils/update-check.js';
 import type { GlobalOptions } from './types.js';
 declare const __CLI_VERSION__: string;
 const CLI_VERSION = __CLI_VERSION__;
-type RootOptions = Omit<GlobalOptions, 'version'> & { version?: string | boolean };
 
 function getHelpBanner(version: string): string {
   return [
@@ -50,23 +49,16 @@ export function createProgram(): Command {
     .name('antd')
     .description('CLI tool for querying antd knowledge and analyzing antd usage')
     .option('--format <format>', 'Output format: json, text, or markdown', 'text')
-    .option('--version [version]', 'Target antd version (e.g. 5.20.0); omit value to output CLI version')
+    .option('--version [version]', 'Target antd version (e.g. 5.20.0)')
     .option('--lang <lang>', 'Output language: en or zh', 'en')
     .option('--detail', 'Full information output', false);
 
   program.addHelpText('before', `${getHelpBanner(CLI_VERSION)}\n`);
 
-  // -V remains for compatibility; -v and bare --version print CLI version.
   program.addOption(new Option('-V, --cli-version', 'Output the CLI version number'));
-  program.addOption(new Option('-v', 'Output the CLI version number'));
 
   // Handle -V/--cli-version via Commander event (fires before subcommand dispatch)
   program.on('option:cli-version', () => {
-    // eslint-disable-next-line no-console
-    console.log(CLI_VERSION);
-    process.exit(0);
-  });
-  program.on('option:v', () => {
     // eslint-disable-next-line no-console
     console.log(CLI_VERSION);
     process.exit(0);
@@ -102,12 +94,7 @@ export function createProgram(): Command {
 
   // Validate global options before any command runs
   program.hook('preAction', () => {
-    const opts = program.opts<RootOptions>();
-    if (opts.version === true) {
-      // eslint-disable-next-line no-console
-      console.log(CLI_VERSION);
-      process.exit(0);
-    }
+    const opts = program.opts<GlobalOptions>();
     const validFormats = ['json', 'text', 'markdown'];
     const validLangs = ['en', 'zh'];
     if (opts.format && !validFormats.includes(opts.format)) {
@@ -127,11 +114,6 @@ export function createProgram(): Command {
     const args = getCommandArgs(argv, options);
     if (args.length === 0) {
       program.outputHelp();
-      return program;
-    }
-    if (args.length === 1 && args[0] === '--version') {
-      // eslint-disable-next-line no-console
-      console.log(CLI_VERSION);
       return program;
     }
     return parseAsync(argv, options);


### PR DESCRIPTION
## Summary

- Add a larger ASCII Ant Design CLI wordmark to root help output for `antd`, `antd -h`, and `antd --help`.
- Keep CLI version output scoped to `-V` / `--cli-version`; `-v` is not supported and `--version` remains reserved for selecting the target antd version.
- Cover the banner and version-flag behavior with CLI assertions and the root help snapshot.

## Verification

- `npx vitest run src/__tests__/cli.test.ts` (confirmed RED before the rollback)
- `npx vitest run src/__tests__/snapshots/help.test.ts -u`
- `npx vitest run src/__tests__/cli.test.ts src/__tests__/snapshots/help.test.ts`
- `npm run build`
- `npm run typecheck`
- `git diff --check`
- `node dist/index.js -V`
- `node dist/index.js -v`
- `node dist/index.js --version`

## Notes

- `npm run test` was attempted earlier, but existing migrate tests failed because `migrate --apply /tmp` scans this machine's real `/tmp` and picked up unrelated local worktrees instead of the empty-directory snapshot fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 更新了 CLI 根命令与帮助输出：`antd` / `antd -h` / `antd --help` 会显示带 Ant Design CLI 横幅及当前 CLI 版本的帮助内容。
  * `--version` 现在支持可选参数：不带参数时输出当前 CLI 版本；带参数时可指定目标 antd 版本（full semver），未提供则继续按环境自动探测。
* **Bug 修复**
  * `-V` / `--cli-version` 仅输出 CLI 版本；`-v` 不再作为版本别名，改为报错退出。
* **文档**
  * 更新了相关说明文档以反映新的帮助与版本行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->