### PR TITLE
fix(lint): skip non-JS asset imports in performance rule (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- `antd lint` no longer flags default/namespace imports of non-JS assets (e.g. `antd/dist/reset.css`, `antd/es/icon.svg`) under the performance rule, since such sources resolve to a bundler asset with only a default export ([#185](https://github.com/ant-design/ant-design-cli/issues/185))
+
+
 ## [6.5.0](https://github.com/ant-design/ant-design-cli/compare/v6.4.5...v6.5.0) (2026-06-27)
 
 - Update antd metadata ([v6@6.5.0](https://github.com/ant-design/ant-design-cli/compare/v6.4.5...v6.5.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- `antd lint` no longer flags default/namespace imports of non-JS assets (e.g. `antd/dist/reset.css`, `antd/es/icon.svg`) under the performance rule, since such sources resolve to a bundler asset with only a default export ([#185](https://github.com/ant-design/ant-design-cli/issues/185))
+- `antd lint` no longer flags default/namespace imports of non-JS assets (e.g. `antd/dist/reset.css`, `antd/es/some-icon.svg`) under the performance rule, since such sources resolve to a bundler asset with only a default export ([#185](https://github.com/ant-design/ant-design-cli/issues/185))
 
 
 ## [6.5.0](https://github.com/ant-design/ant-design-cli/compare/v6.4.5...v6.5.0) (2026-06-27)

--- a/spec.md
+++ b/spec.md
@@ -585,7 +585,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
   - Typography.Text `ellipsis` with `expandable` / `rows` (not supported)
   - Radio `optionType` outside Radio.Group (only valid inside Radio.Group)
   - TreeSelect `multiple={false}` + `treeCheckable` conflict
-- **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern and there is no tree-shaking benefit to be gained.
+- **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern and there is no tree-shaking benefit to be gained. Non-module asset sources (any extension other than `.js/.jsx/.ts/.tsx/.mjs/.cjs`, e.g. `.css/.svg/.ttf/.woff2/.png`) are also excluded, since they resolve to a bundler asset with only a default export and have no named exports.
 
 #### `antd migrate <from> <to>`
 

--- a/spec.md
+++ b/spec.md
@@ -585,7 +585,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
   - Typography.Text `ellipsis` with `expandable` / `rows` (not supported)
   - Radio `optionType` outside Radio.Group (only valid inside Radio.Group)
   - TreeSelect `multiple={false}` + `treeCheckable` conflict
-- **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern and there is no tree-shaking benefit to be gained. Non-module asset sources (any extension other than `.js/.jsx/.ts/.tsx/.mjs/.cjs`, e.g. `.css/.svg/.ttf/.woff2/.png`) are also excluded, since they resolve to a bundler asset with only a default export and have no named exports.
+- **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern and there is no tree-shaking benefit to be gained. Non-module asset sources (any extension other than `.js/.jsx/.ts/.tsx/.mjs/.cjs/.mts/.cts`, e.g. `.css/.svg/.ttf/.woff2/.png`) are also excluded, since they resolve to a bundler asset with only a default export and have no named exports.
 
 #### `antd migrate <from> <to>`
 

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -319,6 +319,28 @@ const App = () => (
     expect(data.issues.some((i: LintIssue) => i.rule === 'performance' && i.message.includes('default'))).toBe(true);
   });
 
+  it('should not flag default/namespace imports of non-JS assets (#185)', async () => {
+    const out = await lintFixture(
+      'asset-import',
+      `import resetStyles from 'antd/dist/reset.css';\nimport iconUrl from 'antd/es/some-icon.svg';\nimport fontUrl from 'antd/fonts/icon.woff2';\nimport * as styles from 'antd/dist/styles.png';\nconst App = () => <div className={resetStyles}>{iconUrl}{fontUrl}{styles}</div>;`,
+      ['--only', 'performance', '--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    expect(data.issues.some((i: LintIssue) => i.rule === 'performance')).toBe(false);
+  });
+
+  it('should still flag bare antd default import alongside asset imports (#185)', async () => {
+    const out = await lintFixture(
+      'asset-and-module-import',
+      `import resetStyles from 'antd/dist/reset.css';\nimport antd from 'antd';\nconst App = () => <antd.Button>{resetStyles}</antd.Button>;`,
+      ['--only', 'performance', '--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    const perfIssues = data.issues.filter((i: LintIssue) => i.rule === 'performance');
+    expect(perfIssues.some((i: LintIssue) => i.message.includes('antd/dist/reset.css'))).toBe(false);
+    expect(perfIssues.some((i: LintIssue) => i.message.includes('default') && i.message.includes("from antd."))).toBe(true);
+  });
+
   it('should warn on Checkbox value outside Checkbox.Group', async () => {
     const out = await lintFixture(
       'checkbox-value',

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -132,7 +132,7 @@ function isLocalePath(source: string, antdAliases: string[]): boolean {
   );
 }
 
-const MODULE_EXTENSIONS = new Set(['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs']);
+const MODULE_EXTENSIONS = new Set(['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs', 'mts', 'cts']);
 
 // A source like `antd/dist/reset.css` resolves to a bundler asset with only a
 // default export, so the default/namespace-import performance rule can't apply.
@@ -219,10 +219,9 @@ function lintFile(
         }
 
         if (!only || only === 'performance') {
-          const skipPerformance = isLocalePath(source, antdAliases) || isNonModuleSource(source);
-          const isNamespace = spec.type === 'ImportNamespaceSpecifier' && !skipPerformance;
-          const isDefault = spec.type === 'ImportDefaultSpecifier' && !skipPerformance;
-          if (isNamespace || isDefault) {
+          const isNamespace = spec.type === 'ImportNamespaceSpecifier';
+          const isDefault = spec.type === 'ImportDefaultSpecifier';
+          if ((isNamespace || isDefault) && !isLocalePath(source, antdAliases) && !isNonModuleSource(source)) {
             const localName = spec.local?.name ?? '';
             pendingPerformanceIssues.push({
               line: lineOf(node), source, localName,

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -132,6 +132,18 @@ function isLocalePath(source: string, antdAliases: string[]): boolean {
   );
 }
 
+const MODULE_EXTENSIONS = new Set(['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs']);
+
+// A source like `antd/dist/reset.css` resolves to a bundler asset with only a
+// default export, so the default/namespace-import performance rule can't apply.
+// Bare specifiers and extensionless subpaths (`antd`, `antd/es/button`) have no
+// extension and are treated as modules.
+function isNonModuleSource(source: string): boolean {
+  const match = /\.([^./]+)$/.exec(source);
+  if (!match) return false;
+  return !MODULE_EXTENSIONS.has(match[1].toLowerCase());
+}
+
 function mayContainAntdAlias(content: string, antdAliases: string[]): boolean {
   return antdAliases.some((antdAlias) => content.includes(antdAlias));
 }
@@ -207,13 +219,14 @@ function lintFile(
         }
 
         if (!only || only === 'performance') {
-          const isNonLocaleNamespace = spec.type === 'ImportNamespaceSpecifier' && !isLocalePath(source, antdAliases);
-          const isNonLocaleDefault = spec.type === 'ImportDefaultSpecifier' && !isLocalePath(source, antdAliases);
-          if (isNonLocaleNamespace || isNonLocaleDefault) {
+          const skipPerformance = isLocalePath(source, antdAliases) || isNonModuleSource(source);
+          const isNamespace = spec.type === 'ImportNamespaceSpecifier' && !skipPerformance;
+          const isDefault = spec.type === 'ImportDefaultSpecifier' && !skipPerformance;
+          if (isNamespace || isDefault) {
             const localName = spec.local?.name ?? '';
             pendingPerformanceIssues.push({
               line: lineOf(node), source, localName,
-              kind: isNonLocaleNamespace ? 'namespace' : 'default',
+              kind: isNamespace ? 'namespace' : 'default',
             });
             namespaceMemberUsage.set(localName, new Set());
           }


### PR DESCRIPTION
## Summary

Fixes #185.

The `lint` performance rule flags default/namespace imports from any antd-recognized source, including non-JS assets:

```tsx
import resetStyles from "antd/dist/reset.css";
import iconUrl from "antd/es/some-icon.svg";
```
```
✗ performance  Avoid default import from antd/dist/reset.css. Use named imports instead
```

These are bundler asset imports that only have a default export, so the "use named imports instead" suggestion is impossible — a false positive.

#104 added the path-based `isLocalePath()` carve-out for `*/locale/*`, but that only covers the locale case. Rather than add another path-based carve-out, this generalizes per the issue discussion: skip any source whose file extension is **not** a JS/TS module extension (`.js/.jsx/.ts/.tsx/.mjs/.cjs`). Non-module sources can't have named exports, so the suggestion is never actionable.

## Changes

- Add `isNonModuleSource()` in `src/commands/lint.ts` and OR it into the performance-rule skip condition alongside `isLocalePath()`. Bare specifiers and extensionless subpaths (`antd`, `antd/es/button`) have no extension and remain treated as modules.
- Regression tests in `src/__tests__/commands/lint.test.ts`: asset imports (`.css/.svg/.woff2/.png`) produce no performance issue, and a bare `antd` default import is still flagged.
- Document the carve-out in `spec.md` and add a `CHANGELOG.md` entry.

## Verification

```
npm run build
npx vitest run src/__tests__/commands/lint.test.ts   # 42 passed
npm run typecheck                                     # clean
```

Manual:
```
$ node dist/index.js lint <dir> --only performance
  ✗ <dir>/a.tsx:3 [performance]
    Avoid default import from antd. Use named imports: `import { Button } from 'antd'`
Summary: 0 deprecated, 0 a11y, 0 usage, 1 performance
```
(asset imports no longer flagged; bare `antd` default import still flagged)

Note: 2 pre-existing `migrate` snapshot failures are unrelated to this change (they also fail on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了 `antd lint` 在 `--only performance` 下对 CSS、SVG、字体与图片等非 JS 资源的默认/命名空间导入产生的误报。
  * 性能分析现在仅聚焦真实的代码模块导入，避免将打包资源误计入分析结果。
* **Tests**
  * 补充了多种资源混合导入及与 `antd` 默认导入并存的场景测试。
* **Documentation**
  * 更新了性能规则说明与变更记录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->