### PR TITLE
feat(lint): 支持 diff 和 staged 模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,10 +381,14 @@ Four rule categories: `deprecated`, `a11y`, `performance`, `best-practice`. Depr
 antd lint ./src
 antd lint ./src --only deprecated
 antd lint ./src --only a11y
+antd lint ./src --diff              # check changed files only
+antd lint --staged                  # check staged files only
 antd lint ./src --only deprecated --format json --antd-alias @shared-components
 ```
 
 Use `--antd-alias <source>` to treat additional package names as aliases of `antd`. Repeat the flag for multiple wrapper packages; `antd` remains enabled by default.
+
+Use `--diff [base]` to lint changed git files only. By default it compares with `origin/main`'s merge-base, falling back to `HEAD`; pass a base ref such as `main` to override it. Use `--staged` to lint only staged files.
 
 ### `antd migrate <from> <to>`
 

--- a/spec.md
+++ b/spec.md
@@ -553,6 +553,9 @@ antd lint --only deprecated         # only check deprecated APIs
 antd lint --only a11y               # only check accessibility
 antd lint --only usage              # only check usage mistakes
 antd lint --only performance        # only check performance
+antd lint --diff                    # only check files changed from origin/main (fallback: HEAD)
+antd lint --diff main               # only check files changed from a specific git base
+antd lint --staged                  # only check staged git files
 antd lint --format json
 antd lint --only deprecated --format json --antd-alias @shared-components
 ```
@@ -560,6 +563,8 @@ antd lint --only deprecated --format json --antd-alias @shared-components
 Options:
 - `--only <category>` — limit checks to `deprecated`, `a11y`, `usage`, or `performance`
 - `--antd-alias <source>` — treat additional package names as aliases of `antd`; repeat the flag for multiple wrapper packages. `antd` remains enabled by default.
+- `--diff [base]` — limit checks to changed git files. Without `base`, compares against the merge-base of `origin/main` and `HEAD`; if `origin/main` is unavailable, falls back to `HEAD`. When `base` is provided, compares against the merge-base of that ref and `HEAD`, falling back to the provided ref if no merge-base can be computed. Includes staged and unstaged working tree changes relative to the base.
+- `--staged` — limit checks to staged git files. Cannot be combined with `--diff`.
 
 JSON output:
 ```json

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -524,6 +524,16 @@ const App = () => (
     expect(data.issues.some((i: LintIssue) => i.rule === 'performance' && i.message.includes('default'))).toBe(true);
   });
 
+  it('should use generic named import suggestion when default import members are unknown', async () => {
+    const out = await lintFixture(
+      'default-import-unused',
+      `import antd from 'antd';\nconst App = () => <div>{String(Boolean(antd))}</div>;`,
+      ['--only', 'performance', '--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    expect(data.issues.some((i: LintIssue) => i.rule === 'performance' && i.message.includes('Use named imports instead'))).toBe(true);
+  });
+
   it('should not flag default/namespace imports of non-JS assets (#185)', async () => {
     const out = await lintFixture(
       'asset-import',

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -34,6 +34,7 @@ describe('lint', () => {
       execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
       execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
       execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
       writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { antd: '6.3.1' } }));
       return dir;
     } catch (error) {
@@ -214,6 +215,32 @@ const App = () => (
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Lint target not found');
     expect(result.stderr).not.toContain('at ');
+  });
+
+  it('should not skip changed files when the repo parent path includes a skipped directory name', async () => {
+    const parent = join(__dirname, '__tmp_lint_git_parent__', 'build');
+    const dir = join(parent, 'repo');
+    rmSync(join(__dirname, '__tmp_lint_git_parent__'), { recursive: true, force: true });
+    try {
+      mkdirSync(dir, { recursive: true });
+      execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { antd: '6.3.1' } }));
+      writeFileSync(join(dir, 'changed.tsx'), `import { Button } from 'antd';\nconst App = () => <Button>OK</Button>;\n`);
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+      writeFileSync(join(dir, 'changed.tsx'), `import { Button } from 'antd';\nconst App = () => <Button ghost type="link" />;\n`);
+
+      const result = await runCLI('lint', dir, '--diff', 'HEAD', '--format', 'json');
+      const data = JSON.parse(result.stdout);
+      expect(data.summary.total).toBe(1);
+      expect(data.issues[0].file).toBe(join(dir, 'changed.tsx'));
+    } finally {
+      rmSync(join(__dirname, '__tmp_lint_git_parent__'), { recursive: true, force: true });
+    }
   });
 
   it('should detect namespace import performance issues', async () => {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -29,12 +29,17 @@ describe('lint', () => {
   function gitFixture(name: string): string {
     const dir = join(__dirname, `__tmp_lint_git_${name}__`);
     rmSync(dir, { recursive: true, force: true });
-    mkdirSync(dir, { recursive: true });
-    execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
-    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
-    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
-    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { antd: '6.3.1' } }));
-    return dir;
+    try {
+      mkdirSync(dir, { recursive: true });
+      execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { antd: '6.3.1' } }));
+      return dir;
+    } catch (error) {
+      rmSync(dir, { recursive: true, force: true });
+      throw error;
+    }
   }
 
   it('lint deprecated message includes replacement hint from description', async () => {
@@ -190,6 +195,25 @@ const App = () => (
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it('should reject --diff and --staged without duplicating the error prefix', async () => {
+    const result = await runCLI('lint', '--diff', 'HEAD', '--staged');
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--diff and --staged cannot be used together');
+    expect(result.stderr).not.toContain('Error: Error:');
+  });
+
+  it('should report missing git lint targets without an internal stack trace', async () => {
+    const missing = join(__dirname, '__tmp_lint_git_missing__');
+    rmSync(missing, { recursive: true, force: true });
+
+    const result = await runCLI('lint', missing, '--diff', 'HEAD');
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Lint target not found');
+    expect(result.stderr).not.toContain('at ');
   });
 
   it('should detect namespace import performance issues', async () => {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -26,8 +26,8 @@ describe('lint', () => {
     }
   }
 
-  function gitFixture(name: string): string {
-    const dir = join(__dirname, `__tmp_lint_git_${name}__`);
+  function gitFixture(name: string, fixtureDir?: string): string {
+    const dir = fixtureDir ?? join(__dirname, `__tmp_lint_git_${name}__`);
     rmSync(dir, { recursive: true, force: true });
     try {
       mkdirSync(dir, { recursive: true });
@@ -338,12 +338,7 @@ const App = () => (
     const dir = join(parent, 'repo');
     rmSync(join(__dirname, '__tmp_lint_git_parent__'), { recursive: true, force: true });
     try {
-      mkdirSync(dir, { recursive: true });
-      execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
-      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
-      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
-      execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
-      writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { antd: '6.3.1' } }));
+      gitFixture('parent-skip', dir);
       writeFileSync(join(dir, 'changed.tsx'), `import { Button } from 'antd';\nconst App = () => <Button>OK</Button>;\n`);
       execFileSync('git', ['add', '.'], { cwd: dir });
       execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -276,6 +276,22 @@ const App = () => (
     }
   });
 
+  it('should fall back to git process error messages when stderr is unavailable', async () => {
+    const dir = gitFixture('diff-git-missing');
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = '';
+      const result = await runCLI('lint', dir, '--diff', 'HEAD');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('git');
+      expect(result.stderr).not.toContain('git command failed');
+    } finally {
+      process.env.PATH = originalPath;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('should lint only staged files with --staged', async () => {
     const dir = gitFixture('staged');
     try {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -176,6 +176,81 @@ const App = () => (
     }
   });
 
+  it('should default --diff to HEAD when origin/main is unavailable', async () => {
+    const dir = gitFixture('diff-default');
+    try {
+      writeFileSync(join(dir, 'changed.tsx'), `import { Button } from 'antd';\nconst App = () => <Button>OK</Button>;\n`);
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+      writeFileSync(join(dir, 'changed.tsx'), `import { Button } from 'antd';\nconst App = () => <Button ghost type="link" />;\n`);
+
+      const result = await runCLI('lint', dir, '--diff', '--format', 'json');
+      const data = JSON.parse(result.stdout);
+
+      expect(data.summary.total).toBe(1);
+      expect(data.issues[0].file).toBe(join(dir, 'changed.tsx'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should support --diff when the lint target is a file', async () => {
+    const dir = gitFixture('diff-file-target');
+    try {
+      const changedFile = join(dir, 'changed.tsx');
+      writeFileSync(changedFile, `import { Button } from 'antd';\nconst App = () => <Button>OK</Button>;\n`);
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+      writeFileSync(changedFile, `import { Button } from 'antd';\nconst App = () => <Button ghost type="link" />;\n`);
+
+      const result = await runCLI('lint', changedFile, '--diff', 'HEAD', '--format', 'json');
+      const data = JSON.parse(result.stdout);
+
+      expect(data.summary.total).toBe(1);
+      expect(data.issues[0].file).toBe(changedFile);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should ignore non-source files selected by --diff', async () => {
+    const dir = gitFixture('diff-non-source');
+    try {
+      writeFileSync(join(dir, 'notes.md'), '# notes\n');
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+      writeFileSync(join(dir, 'notes.md'), '# changed notes\n');
+
+      const result = await runCLI('lint', dir, '--diff', 'HEAD', '--format', 'json');
+      const data = JSON.parse(result.stdout);
+
+      expect(data.summary.total).toBe(0);
+      expect(data.issues).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should include git stderr when --diff uses an invalid ref', async () => {
+    const dir = gitFixture('diff-invalid-ref');
+    try {
+      writeFileSync(join(dir, 'changed.tsx'), `import { Button } from 'antd';\nconst App = () => <Button ghost type="link" />;\n`);
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+      const result = await runCLI('lint', dir, '--diff', 'not-a-real-ref');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('not-a-real-ref');
+      expect(result.stderr).not.toContain('Command failed');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('should lint only staged files with --staged', async () => {
     const dir = gitFixture('staged');
     try {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
 import type { LintIssue } from '../../commands/lint.js';
 import { run, runCLI } from '../helper.js';
 
@@ -23,6 +24,17 @@ describe('lint', () => {
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }
+  }
+
+  function gitFixture(name: string): string {
+    const dir = join(__dirname, `__tmp_lint_git_${name}__`);
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+    execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { antd: '6.3.1' } }));
+    return dir;
   }
 
   it('lint deprecated message includes replacement hint from description', async () => {
@@ -136,6 +148,48 @@ const App = () => (
     );
     const data = JSON.parse(out);
     expect(data.issues.some((i: LintIssue) => i.rule === 'usage')).toBe(true);
+  });
+
+  it('should lint only files changed from the diff base with --diff', async () => {
+    const dir = gitFixture('diff');
+    try {
+      writeFileSync(join(dir, 'changed.tsx'), `import { Button } from 'antd';\nconst App = () => <Button>OK</Button>;\n`);
+      writeFileSync(join(dir, 'unchanged.tsx'), `import { Image } from 'antd';\nconst App = () => <Image src="x.png" />;\n`);
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+      writeFileSync(join(dir, 'changed.tsx'), `import { Button } from 'antd';\nconst App = () => <Button ghost type="link" />;\n`);
+
+      const result = await runCLI('lint', dir, '--diff', 'HEAD', '--format', 'json');
+      const data = JSON.parse(result.stdout);
+
+      expect(data.summary.total).toBe(1);
+      expect(data.issues[0].file).toBe(join(dir, 'changed.tsx'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should lint only staged files with --staged', async () => {
+    const dir = gitFixture('staged');
+    try {
+      writeFileSync(join(dir, 'staged.tsx'), `import { Button } from 'antd';\nconst App = () => <Button>OK</Button>;\n`);
+      writeFileSync(join(dir, 'unstaged.tsx'), `import { Image } from 'antd';\nconst App = () => <Image src="x.png" />;\n`);
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+      writeFileSync(join(dir, 'staged.tsx'), `import { Button } from 'antd';\nconst App = () => <Button ghost type="link" />;\n`);
+      writeFileSync(join(dir, 'unstaged.tsx'), `import { Image } from 'antd';\nconst App = () => <Image src="x.png" />;\n`);
+      execFileSync('git', ['add', 'staged.tsx'], { cwd: dir });
+
+      const result = await runCLI('lint', dir, '--staged', '--format', 'json');
+      const data = JSON.parse(result.stdout);
+
+      expect(data.summary.total).toBe(1);
+      expect(data.issues[0].file).toBe(join(dir, 'staged.tsx'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('should detect namespace import performance issues', async () => {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { writeFileSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import type { LintIssue } from '../../commands/lint.js';
@@ -223,6 +223,31 @@ const App = () => (
       execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
 
       writeFileSync(join(dir, 'notes.md'), '# changed notes\n');
+
+      const result = await runCLI('lint', dir, '--diff', 'HEAD', '--format', 'json');
+      const data = JSON.parse(result.stdout);
+
+      expect(data.summary.total).toBe(0);
+      expect(data.issues).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === 'win32')('should ignore changed git symlinks that do not resolve to files', async () => {
+    const dir = gitFixture('diff-symlink-filters');
+    try {
+      mkdirSync(join(dir, 'target-a'));
+      mkdirSync(join(dir, 'target-b'));
+      symlinkSync('target-a', join(dir, 'linked-dir.tsx'), 'dir');
+      symlinkSync('missing-a', join(dir, 'missing-link.tsx'));
+      execFileSync('git', ['add', '.'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir, stdio: 'ignore' });
+
+      rmSync(join(dir, 'linked-dir.tsx'), { force: true });
+      rmSync(join(dir, 'missing-link.tsx'), { force: true });
+      symlinkSync('target-b', join(dir, 'linked-dir.tsx'), 'dir');
+      symlinkSync('missing-b', join(dir, 'missing-link.tsx'));
 
       const result = await runCLI('lint', dir, '--diff', 'HEAD', '--format', 'json');
       const data = JSON.parse(result.stdout);

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander';
 import type { GlobalOptions } from '../types.js';
 import { localize } from '../types.js';
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from 'node:child_process';
 import { dirname, extname, join, relative, resolve } from 'node:path';
 import { parseSync, Visitor } from 'oxc-parser';
 import { loadMetadataForVersion } from '../data/loader.js';
@@ -156,11 +156,22 @@ function collectAntdAlias(source: string, previous: string[]): string[] {
 }
 
 function execGit(cwd: string, args: string[]): string {
-  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  const options: ExecFileSyncOptionsWithStringEncoding = { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] };
+  try {
+    return execFileSync('git', args, options);
+  } catch (error) {
+    const stderr = typeof (error as { stderr?: unknown }).stderr === 'string'
+      ? (error as { stderr: string }).stderr.trim()
+      : '';
+    throw new Error(stderr || (error instanceof Error ? error.message : 'git command failed'));
+  }
 }
 
 function getGitRoot(targetPath: string): string {
   const absoluteTarget = resolve(targetPath);
+  if (!existsSync(absoluteTarget)) {
+    throw new Error(`Lint target not found: ${targetPath}`);
+  }
   const gitCwd = existsSync(absoluteTarget) && statSync(absoluteTarget).isFile()
     ? dirname(absoluteTarget)
     : absoluteTarget;
@@ -473,7 +484,7 @@ export function registerLintCommand(program: Command): void {
       const opts = program.opts<GlobalOptions>();
       const targetPath = target || '.';
       if (cmdOpts.diff && cmdOpts.staged) {
-        program.error('Error: --diff and --staged cannot be used together');
+        program.error('--diff and --staged cannot be used together');
       }
       const versionInfo = detectVersion(opts.version);
       const store = loadMetadataForVersion(versionInfo.version);
@@ -488,7 +499,7 @@ export function registerLintCommand(program: Command): void {
             ? collectGitFiles(targetPath, 'diff', cmdOpts.diff)
             : collectFiles(targetPath);
       } catch (error) {
-        program.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        program.error(error instanceof Error ? error.message : String(error));
       }
       const allIssues: LintIssue[] = [];
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -177,9 +177,11 @@ function getGitRoot(targetPath: string): string {
     if (statSync(absoluteTarget).isFile()) {
       gitCwd = dirname(absoluteTarget);
     }
+  /* v8 ignore start -- defensive: the path may change between existsSync and statSync */
   } catch {
     gitCwd = absoluteTarget;
   }
+  /* v8 ignore stop */
   return execGit(gitCwd, ['rev-parse', '--show-toplevel']).trim();
 }
 
@@ -192,9 +194,11 @@ function isLintableSource(filePath: string, gitPath = filePath): boolean {
   if (!existsSync(filePath)) return false;
   try {
     if (!statSync(filePath).isFile()) return false;
+  /* v8 ignore start -- defensive: the file may change between existsSync and statSync */
   } catch {
     return false;
   }
+  /* v8 ignore stop */
   if (!SCAN_EXTENSIONS.has(extname(filePath))) return false;
   return !gitPath.split(/[\\/]/).some((segment) => SKIP_DIRS.has(segment) || segment.startsWith('.umi'));
 }

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,12 +1,14 @@
 import type { Command } from 'commander';
 import type { GlobalOptions } from '../types.js';
 import { localize } from '../types.js';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, extname, join, relative, resolve } from 'node:path';
 import { parseSync, Visitor } from 'oxc-parser';
 import { loadMetadataForVersion } from '../data/loader.js';
 import { detectVersion } from '../data/version.js';
 import { formatTable, output } from '../output/formatter.js';
-import { collectFiles, getJSXElementName } from '../utils/scan.js';
+import { collectFiles, getJSXElementName, SCAN_EXTENSIONS, SKIP_DIRS } from '../utils/scan.js';
 
 export interface LintIssue {
   file: string;
@@ -17,6 +19,7 @@ export interface LintIssue {
 }
 
 type DeprecatedInfo = { prop: string; since: string; message: string };
+type LintCommandOptions = { only?: string; antdAlias?: string[]; diff?: boolean | string; staged?: boolean };
 
 function getDeprecatedProps(store: ReturnType<typeof loadMetadataForVersion>): Map<string, DeprecatedInfo[]> {
   const result = new Map<string, DeprecatedInfo[]>();
@@ -150,6 +153,66 @@ function mayContainAntdAlias(content: string, antdAliases: string[]): boolean {
 
 function collectAntdAlias(source: string, previous: string[]): string[] {
   return [...previous, source];
+}
+
+function execGit(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function getGitRoot(targetPath: string): string {
+  const absoluteTarget = resolve(targetPath);
+  const gitCwd = existsSync(absoluteTarget) && statSync(absoluteTarget).isFile()
+    ? dirname(absoluteTarget)
+    : absoluteTarget;
+  return execGit(gitCwd, ['rev-parse', '--show-toplevel']).trim();
+}
+
+function getPathspec(repoRoot: string, targetPath: string): string {
+  const rel = relative(repoRoot, resolve(targetPath));
+  return rel === '' ? '.' : rel;
+}
+
+function isLintableSource(filePath: string): boolean {
+  if (!existsSync(filePath)) return false;
+  try {
+    if (!statSync(filePath).isFile()) return false;
+  } catch {
+    return false;
+  }
+  if (!SCAN_EXTENSIONS.has(extname(filePath))) return false;
+  return !filePath.split(/[\\/]/).some((segment) => SKIP_DIRS.has(segment) || segment.startsWith('.umi'));
+}
+
+function resolveDiffBase(repoRoot: string, diff: boolean | string | undefined): string {
+  if (typeof diff === 'string' && diff.trim()) {
+    const requested = diff.trim();
+    try {
+      return execGit(repoRoot, ['merge-base', requested, 'HEAD']).trim() || requested;
+    } catch {
+      return requested;
+    }
+  }
+
+  try {
+    return execGit(repoRoot, ['merge-base', 'origin/main', 'HEAD']).trim();
+  } catch {
+    return 'HEAD';
+  }
+}
+
+function collectGitFiles(targetPath: string, mode: 'diff' | 'staged', diff?: boolean | string): string[] {
+  const repoRoot = getGitRoot(targetPath);
+  const pathspec = getPathspec(repoRoot, targetPath);
+  const args = mode === 'staged'
+    ? ['diff', '--name-only', '--cached', '--diff-filter=ACMR', '--', pathspec]
+    : ['diff', '--name-only', '--diff-filter=ACMR', resolveDiffBase(repoRoot, diff), '--', pathspec];
+
+  return execGit(repoRoot, args)
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean)
+    .map((file) => join(repoRoot, file))
+    .filter(isLintableSource);
 }
 
 function lintFile(
@@ -404,15 +467,29 @@ export function registerLintCommand(program: Command): void {
     .description('Check antd usage against best practices')
     .option('--only <category>', 'Only check specific category (deprecated, a11y, usage, performance)')
     .option('--antd-alias <source>', 'Treat additional package names as aliases of antd imports', collectAntdAlias, [])
-    .action((target: string | undefined, cmdOpts: { only?: string; antdAlias?: string[] }) => {
+    .option('--diff [base]', 'Only lint files changed from a git diff base (default: origin/main, fallback: HEAD)')
+    .option('--staged', 'Only lint staged git files')
+    .action((target: string | undefined, cmdOpts: LintCommandOptions) => {
       const opts = program.opts<GlobalOptions>();
       const targetPath = target || '.';
+      if (cmdOpts.diff && cmdOpts.staged) {
+        program.error('Error: --diff and --staged cannot be used together');
+      }
       const versionInfo = detectVersion(opts.version);
       const store = loadMetadataForVersion(versionInfo.version);
       const deprecatedMap = getDeprecatedProps(store);
       const antdAliases = normalizeAntdAliases(cmdOpts.antdAlias);
 
-      const files = collectFiles(targetPath);
+      let files: string[];
+      try {
+        files = cmdOpts.staged
+          ? collectGitFiles(targetPath, 'staged')
+          : cmdOpts.diff
+            ? collectGitFiles(targetPath, 'diff', cmdOpts.diff)
+            : collectFiles(targetPath);
+      } catch (error) {
+        program.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      }
       const allIssues: LintIssue[] = [];
 
       for (const file of files) {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -172,18 +172,23 @@ function getGitRoot(targetPath: string): string {
   if (!existsSync(absoluteTarget)) {
     throw new Error(`Lint target not found: ${targetPath}`);
   }
-  const gitCwd = existsSync(absoluteTarget) && statSync(absoluteTarget).isFile()
-    ? dirname(absoluteTarget)
-    : absoluteTarget;
+  let gitCwd = absoluteTarget;
+  try {
+    if (statSync(absoluteTarget).isFile()) {
+      gitCwd = dirname(absoluteTarget);
+    }
+  } catch {
+    gitCwd = absoluteTarget;
+  }
   return execGit(gitCwd, ['rev-parse', '--show-toplevel']).trim();
 }
 
 function getPathspec(repoRoot: string, targetPath: string): string {
   const rel = relative(repoRoot, resolve(targetPath));
-  return rel === '' ? '.' : rel;
+  return rel === '' ? '.' : rel.replace(/\\/g, '/');
 }
 
-function isLintableSource(filePath: string): boolean {
+function isLintableSource(filePath: string, gitPath = filePath): boolean {
   if (!existsSync(filePath)) return false;
   try {
     if (!statSync(filePath).isFile()) return false;
@@ -191,7 +196,7 @@ function isLintableSource(filePath: string): boolean {
     return false;
   }
   if (!SCAN_EXTENSIONS.has(extname(filePath))) return false;
-  return !filePath.split(/[\\/]/).some((segment) => SKIP_DIRS.has(segment) || segment.startsWith('.umi'));
+  return !gitPath.split(/[\\/]/).some((segment) => SKIP_DIRS.has(segment) || segment.startsWith('.umi'));
 }
 
 function resolveDiffBase(repoRoot: string, diff: boolean | string | undefined): string {
@@ -222,8 +227,8 @@ function collectGitFiles(targetPath: string, mode: 'diff' | 'staged', diff?: boo
     .split('\n')
     .map((file) => file.trim())
     .filter(Boolean)
-    .map((file) => join(repoRoot, file))
-    .filter(isLintableSource);
+    .filter((file) => isLintableSource(join(repoRoot, file), file))
+    .map((file) => join(repoRoot, file));
 }
 
 function lintFile(


### PR DESCRIPTION
## 变更

- 为 `antd lint` 增加 `--diff [base]`，只检查相对 git base 变更的源码文件
- 增加 `--staged`，只检查已暂存的源码文件
- 更新 README 和 `spec.md`，说明新参数行为

## 验证

- `npx vitest run src/__tests__/commands/lint.test.ts`
- `npx vitest run src/__tests__/commands/lint.test.ts src/__tests__/cli.test.ts src/__tests__/snapshots/help.test.ts`
- `npm run typecheck`
- `npm run build`
- `node dist/index.js lint --diff origin/main --format json`
- `node dist/index.js lint --staged --format json`

## 备注

本地全量 `npm run test` 在改动前的基线就失败：worktree 初始未构建 `dist/index.js`，且当前机器 `/tmp` 下已有旧临时项目会污染 migrate snapshot。已按本 PR 影响面完成 focused 验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * `lint` 新增互斥选项 `--diff [base]` 与 `--staged`：基于变更基准仅检查差异文件，或仅检查暂存区文件。
  * `--format json` 可用于相关输出的按需格式化。
* **文档**
  * 更新 README 与规范文档：补充 `--diff` / `--staged` 示例、参数说明与默认对比逻辑。
* **测试**
  * 扩展 Git 相关集成测试，覆盖基准回退、单文件差异、忽略非源码、异常/边界场景及暂存区扫描行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->