### PR TITLE
feat(lint): 报告跳过文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ antd lint ./src --only deprecated --format json --antd-alias @shared-components
 
 Use `--antd-alias <source>` to treat additional package names as aliases of `antd`. Repeat the flag for multiple wrapper packages; `antd` remains enabled by default.
 
+Files that cannot be read or parsed are reported as skipped instead of being silently ignored. JSON output includes `skippedFiles`, `partial`, and `summary.skipped`; text and markdown output include a skipped-files section.
+
 ### `antd migrate <from> <to>`
 
 v3→v4 covers 15+ migration steps; v4→v5 covers 25+ migration steps; v5→v6 covers 30+. Each step includes component name, breaking flag, search pattern, and before/after code.

--- a/spec.md
+++ b/spec.md
@@ -573,9 +573,19 @@ JSON output:
       "message": "Button `ghost` is deprecated (since 5.12.0). Please use `variant` instead"
     }
   ],
-  "summary": {"total": 1, "deprecated": 1, "a11y": 0, "usage": 0, "performance": 0}
+  "skippedFiles": [
+    {
+      "file": "src/pages/broken.tsx",
+      "reason": "parse-error",
+      "message": "Unexpected token"
+    }
+  ],
+  "partial": true,
+  "summary": {"total": 1, "deprecated": 1, "a11y": 0, "usage": 0, "performance": 0, "skipped": 1}
 }
 ```
+
+When a file cannot be read or parsed, `antd lint` reports it in `skippedFiles` instead of silently dropping it. `partial` is `true` whenever at least one file was skipped. Text and markdown output include a skipped-files section with the reason and parser/read error message.
 
 Note: This is complementary to ESLint. `antd lint` focuses on antd-specific knowledge (deprecated APIs per version, prop combination mistakes, antd accessibility) that generic ESLint rules cannot cover.
 

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -514,6 +514,7 @@ const App = () => (
     );
     expect(out).toContain('## Lint Results');
     expect(out).toContain('### Skipped Files');
+    expect(out).not.toContain('| Rule | Severity | Message | File |');
     expect(out).toContain('parse-error');
     expect(out).toContain('unparseable-markdown.tsx');
   });

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { chmodSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { LintIssue } from '../../commands/lint.js';
 import { run, runCLI } from '../helper.js';
@@ -461,6 +461,49 @@ const App = () => (
     expect(out).toContain('Skipped 1 file');
     expect(out).toContain('[parse-error]');
     expect(out).toContain('unparseable-text.tsx');
+  });
+
+  it('should show skipped files alongside text issues', async () => {
+    const tmpDir = join(__dirname, '__tmp_lint_issue_and_skip__');
+    try {
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(join(tmpDir, 'issue.tsx'), `import { Image } from 'antd';\nconst App = () => <Image src="x.png" />;\n`);
+      writeFileSync(join(tmpDir, 'broken.tsx'), `import { Button } from 'antd';\nconst App = () => { broken( <Button };\n`);
+
+      const result = await runCLI('lint', tmpDir);
+
+      expect(result.stdout).toContain('Found 1 issues');
+      expect(result.stdout).toContain('Skipped files:');
+      expect(result.stdout).toContain('broken.tsx');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should report files that cannot be read as skipped', async () => {
+    const tmpDir = join(__dirname, '__tmp_lint_unreadable__');
+    const fixture = join(tmpDir, 'unreadable.tsx');
+    try {
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(fixture, `import { Button } from 'antd';\nconst App = () => <Button>OK</Button>;\n`);
+      chmodSync(fixture, 0o000);
+
+      const result = await runCLI('lint', fixture, '--format', 'json');
+      const data = JSON.parse(result.stdout);
+
+      expect(data.summary.skipped).toBe(1);
+      expect(data.skippedFiles[0]).toEqual(expect.objectContaining({
+        file: fixture,
+        reason: 'read-error',
+      }));
+    } finally {
+      try {
+        chmodSync(fixture, 0o600);
+      } catch {
+        // File may not exist if setup failed before writeFileSync.
+      }
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('should show skipped files in markdown output', async () => {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -443,8 +443,36 @@ const App = () => (
       ['--format', 'json'],
     );
     const data = JSON.parse(out);
-    // Parser error → file is skipped, 0 issues
     expect(data.issues).toEqual([]);
+    expect(data.summary.skipped).toBe(1);
+    expect(data.skippedFiles).toEqual([
+      expect.objectContaining({
+        reason: 'parse-error',
+        file: expect.stringContaining('unparseable.tsx'),
+      }),
+    ]);
+  });
+
+  it('should show skipped files in text output', async () => {
+    const out = await lintFixture(
+      'unparseable-text',
+      `import { Button } from 'antd';\nconst App = () => { broken( <Button };`,
+    );
+    expect(out).toContain('Skipped 1 file');
+    expect(out).toContain('[parse-error]');
+    expect(out).toContain('unparseable-text.tsx');
+  });
+
+  it('should show skipped files in markdown output', async () => {
+    const out = await lintFixture(
+      'unparseable-markdown',
+      `import { Button } from 'antd';\nconst App = () => { broken( <Button };`,
+      ['--format', 'markdown'],
+    );
+    expect(out).toContain('## Lint Results');
+    expect(out).toContain('### Skipped Files');
+    expect(out).toContain('parse-error');
+    expect(out).toContain('unparseable-markdown.tsx');
   });
 
   it('should output markdown table format', async () => {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -16,6 +16,12 @@ export interface LintIssue {
   message: string;
 }
 
+interface SkippedFile {
+  file: string;
+  reason: 'read-error' | 'parse-error';
+  message: string;
+}
+
 type DeprecatedInfo = { prop: string; since: string; message: string };
 
 function getDeprecatedProps(store: ReturnType<typeof loadMetadataForVersion>): Map<string, DeprecatedInfo[]> {
@@ -157,21 +163,37 @@ function lintFile(
   deprecatedMap: Map<string, DeprecatedInfo[]>,
   antdAliases: string[],
   only?: string,
-): LintIssue[] {
+): { issues: LintIssue[]; skipped?: SkippedFile } {
   let content: string;
   try {
     content = readFileSync(filePath, 'utf-8');
     /* v8 ignore start -- fs read error */
-  } catch {
-    return [];
+  } catch (error) {
+    return {
+      issues: [],
+      skipped: {
+        file: filePath,
+        reason: 'read-error',
+        message: error instanceof Error ? error.message : 'Failed to read file',
+      },
+    };
   }
   /* v8 ignore stop */
 
   // Fast pre-check: skip files that don't reference configured antd aliases
-  if (!mayContainAntdAlias(content, antdAliases)) return [];
+  if (!mayContainAntdAlias(content, antdAliases)) return { issues: [] };
 
   const result = parseSync(filePath, content);
-  if (result.errors.length > 0) return [];
+  if (result.errors.length > 0) {
+    return {
+      issues: [],
+      skipped: {
+        file: filePath,
+        reason: 'parse-error',
+        message: result.errors[0]?.message ?? 'Failed to parse file',
+      },
+    };
+  }
 
   const issues: LintIssue[] = [];
   const importedComponents = new Set<string>();
@@ -395,7 +417,7 @@ function lintFile(
     report('performance', 'error', pending.line, `Avoid ${importKind} import from ${pending.source}. ${suggestion}`);
   }
 
-  return issues;
+  return { issues };
 }
 
 export function registerLintCommand(program: Command): void {
@@ -414,9 +436,12 @@ export function registerLintCommand(program: Command): void {
 
       const files = collectFiles(targetPath);
       const allIssues: LintIssue[] = [];
+      const skippedFiles: SkippedFile[] = [];
 
       for (const file of files) {
-        allIssues.push(...lintFile(file, deprecatedMap, antdAliases, cmdOpts.only));
+        const result = lintFile(file, deprecatedMap, antdAliases, cmdOpts.only);
+        allIssues.push(...result.issues);
+        if (result.skipped) skippedFiles.push(result.skipped);
       }
 
       const summary = {
@@ -425,19 +450,11 @@ export function registerLintCommand(program: Command): void {
         a11y: allIssues.filter((i) => i.rule === 'a11y').length,
         usage: allIssues.filter((i) => i.rule === 'usage').length,
         performance: allIssues.filter((i) => i.rule === 'performance').length,
+        skipped: skippedFiles.length,
       };
 
       if (opts.format === 'json') {
-        output({ issues: allIssues, summary }, 'json');
-        return;
-      }
-
-      if (allIssues.length === 0) {
-        console.log(localize(
-          `Scanned ${files.length} files. No issues found.`,
-          `扫描了 ${files.length} 个文件，未发现问题。`,
-          opts.lang,
-        ));
+        output({ issues: allIssues, skippedFiles, partial: skippedFiles.length > 0, summary }, 'json');
         return;
       }
 
@@ -446,9 +463,10 @@ export function registerLintCommand(program: Command): void {
         localize(`${summary.a11y} a11y`, `${summary.a11y} 无障碍`, opts.lang),
         localize(`${summary.usage} usage`, `${summary.usage} 用法`, opts.lang),
         localize(`${summary.performance} performance`, `${summary.performance} 性能`, opts.lang),
+        localize(`${summary.skipped} skipped`, `${summary.skipped} 已跳过`, opts.lang),
       ].join(', ');
 
-      if (opts.format === 'markdown') {
+      if (opts.format === 'markdown' && (allIssues.length > 0 || skippedFiles.length > 0)) {
         console.log(`## ${localize('Lint Results', 'Lint 结果', opts.lang)}`);
         console.log('');
         console.log(localize(
@@ -465,8 +483,41 @@ export function registerLintCommand(program: Command): void {
         ];
         const rows = allIssues.map((i) => [i.rule, i.severity, i.message, `${i.file}:${i.line}`]);
         console.log(formatTable(headers, rows, 'markdown'));
+        if (skippedFiles.length > 0) {
+          console.log('');
+          console.log(`### ${localize('Skipped Files', '跳过文件', opts.lang)}`);
+          console.log('');
+          console.log(formatTable(
+            [
+              localize('Reason', '原因', opts.lang),
+              localize('Message', '信息', opts.lang),
+              localize('File', '文件', opts.lang),
+            ],
+            skippedFiles.map((file) => [file.reason, file.message, file.file]),
+            'markdown',
+          ));
+        }
         console.log('');
         console.log(`**${localize('Summary:', '摘要：', opts.lang)}** ${summaryParts}`);
+        return;
+      }
+
+      if (allIssues.length === 0) {
+        console.log(localize(
+          `Scanned ${files.length} files. No issues found.`,
+          `扫描了 ${files.length} 个文件，未发现问题。`,
+          opts.lang,
+        ));
+        if (skippedFiles.length > 0) {
+          console.log(localize(
+            `Skipped ${skippedFiles.length} file${skippedFiles.length > 1 ? 's' : ''}:`,
+            `跳过 ${skippedFiles.length} 个文件：`,
+            opts.lang,
+          ));
+          for (const skipped of skippedFiles) {
+            console.log(`  - ${skipped.file} [${skipped.reason}] ${skipped.message}`);
+          }
+        }
         return;
       }
 
@@ -480,6 +531,13 @@ export function registerLintCommand(program: Command): void {
         const icon = issue.severity === 'error' ? '✗' : '⚠';
         console.log(`  ${icon} ${issue.file}:${issue.line} [${issue.rule}]`);
         console.log(`    ${issue.message}`);
+      }
+
+      if (skippedFiles.length > 0) {
+        console.log(`\n${localize('Skipped files:', '跳过文件：', opts.lang)}`);
+        for (const skipped of skippedFiles) {
+          console.log(`  - ${skipped.file} [${skipped.reason}] ${skipped.message}`);
+        }
       }
 
       console.log(`\n${localize('Summary:', '摘要：', opts.lang)} ${summaryParts}`);

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -420,6 +420,12 @@ function lintFile(
   return { issues };
 }
 
+function printSkippedFiles(skippedFiles: SkippedFile[]): void {
+  for (const skipped of skippedFiles) {
+    console.log(`  - ${skipped.file} [${skipped.reason}] ${skipped.message}`);
+  }
+}
+
 export function registerLintCommand(program: Command): void {
   program
     .command('lint [target]')
@@ -475,14 +481,16 @@ export function registerLintCommand(program: Command): void {
           opts.lang,
         ));
         console.log('');
-        const headers = [
-          localize('Rule', '规则', opts.lang),
-          localize('Severity', '级别', opts.lang),
-          localize('Message', '信息', opts.lang),
-          localize('File', '文件', opts.lang),
-        ];
-        const rows = allIssues.map((i) => [i.rule, i.severity, i.message, `${i.file}:${i.line}`]);
-        console.log(formatTable(headers, rows, 'markdown'));
+        if (allIssues.length > 0) {
+          const headers = [
+            localize('Rule', '规则', opts.lang),
+            localize('Severity', '级别', opts.lang),
+            localize('Message', '信息', opts.lang),
+            localize('File', '文件', opts.lang),
+          ];
+          const rows = allIssues.map((i) => [i.rule, i.severity, i.message, `${i.file}:${i.line}`]);
+          console.log(formatTable(headers, rows, 'markdown'));
+        }
         if (skippedFiles.length > 0) {
           console.log('');
           console.log(`### ${localize('Skipped Files', '跳过文件', opts.lang)}`);
@@ -514,9 +522,7 @@ export function registerLintCommand(program: Command): void {
             `跳过 ${skippedFiles.length} 个文件：`,
             opts.lang,
           ));
-          for (const skipped of skippedFiles) {
-            console.log(`  - ${skipped.file} [${skipped.reason}] ${skipped.message}`);
-          }
+          printSkippedFiles(skippedFiles);
         }
         return;
       }
@@ -535,9 +541,7 @@ export function registerLintCommand(program: Command): void {
 
       if (skippedFiles.length > 0) {
         console.log(`\n${localize('Skipped files:', '跳过文件：', opts.lang)}`);
-        for (const skipped of skippedFiles) {
-          console.log(`  - ${skipped.file} [${skipped.reason}] ${skipped.message}`);
-        }
+        printSkippedFiles(skippedFiles);
       }
 
       console.log(`\n${localize('Summary:', '摘要：', opts.lang)} ${summaryParts}`);


### PR DESCRIPTION
## 变更

- `antd lint` 不再静默忽略读文件或解析失败的文件
- JSON 输出新增 `skippedFiles`、`partial` 和 `summary.skipped`
- text / markdown 输出增加 skipped files 区块
- 更新 README 和 `spec.md` 的输出说明

## 验证

- `npx vitest run src/__tests__/commands/lint.test.ts`
- `npm run typecheck`
- `npm run build`
- 构建后手动验证 parse-error JSON 输出

## 备注

本地全量 `npm run test` 在改动前的基线就失败：worktree 初始未构建 `dist/index.js`，且当前机器 `/tmp` 下已有旧临时项目会污染 migrate snapshot。已按本 PR 影响面完成 focused 验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * `lint` 输出新增“跳过的文件”展示：包含原因与对应文件名，不再静默忽略。

* **改进**
  * 当存在无法读取/解析的文件时，结果将标记为“部分完成”，并在汇总中计入跳过数量。
  * JSON、文本与 Markdown 输出均增加跳过相关字段/分区；Markdown 会在规则表之外单独呈现“Skipped Files”。

* **测试**
  * 扩展跳过场景用例，覆盖不同输出格式及混合结果呈现。

* **文档**
  * 更新说明与输出示例，反映跳过文件的格式与行为约定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->