### PR TITLE
feat(lint): add v5 usage rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,16 +375,19 @@ antd usage -f Button                # filter to one component
 
 ### `antd lint [target]`
 
-Four rule categories: `deprecated`, `a11y`, `performance`, `best-practice`. Deprecation rules are derived from metadata at runtime, so they're always version-accurate.
+Four rule categories: `deprecated`, `a11y`, `usage`, `performance`. Deprecation rules are derived from metadata at runtime, so they're always version-accurate.
 
 ```bash
 antd lint ./src
 antd lint ./src --only deprecated
 antd lint ./src --only a11y
+antd lint ./src --only usage
 antd lint ./src --diff              # check changed files only
 antd lint --staged                  # check staged files only
 antd lint ./src --only deprecated --format json --antd-alias @shared-components
 ```
+
+`usage` checks include antd-specific prop/API mistakes such as Form.Item conflicts, Upload controlled value conflicts, static feedback APIs that should use `App.useApp()` in v5+, and v5+ Select children APIs that should use `options`.
 
 Use `--antd-alias <source>` to treat additional package names as aliases of `antd`. Repeat the flag for multiple wrapper packages; `antd` remains enabled by default.
 

--- a/spec.md
+++ b/spec.md
@@ -644,6 +644,9 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
   - Typography.Text `ellipsis` with `expandable` / `rows` (not supported)
   - Radio `optionType` outside Radio.Group (only valid inside Radio.Group)
   - TreeSelect `multiple={false}` + `treeCheckable` conflict
+  - antd v5+ static feedback APIs (`message.*`, `notification.*`, `Modal.confirm` / `Modal.info` / `Modal.success` / `Modal.error` / `Modal.warning`) that cannot consume `ConfigProvider` context; use `App.useApp()` instead
+  - antd v5+ Upload controlled/uncontrolled conflicts: using both `fileList` and `defaultFileList`, or using controlled `fileList` without `onChange`
+  - antd v5+ Select children APIs (`Select.Option`, `Select.OptGroup`); use the `options` prop instead
 - **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern and there is no tree-shaking benefit to be gained. Non-module asset sources (any extension other than `.js/.jsx/.ts/.tsx/.mjs/.cjs/.mts/.cts`, e.g. `.css/.svg/.ttf/.woff2/.png`) are also excluded, since they resolve to a bundler asset with only a default export and have no named exports.
 
 #### `antd migrate <from> <to>`

--- a/spec.md
+++ b/spec.md
@@ -644,7 +644,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
   - Typography.Text `ellipsis` with `expandable` / `rows` (not supported)
   - Radio `optionType` outside Radio.Group (only valid inside Radio.Group)
   - TreeSelect `multiple={false}` + `treeCheckable` conflict
-  - antd v5+ static feedback APIs (`message.*`, `notification.*`, `Modal.confirm` / `Modal.info` / `Modal.success` / `Modal.error` / `Modal.warning`) that cannot consume `ConfigProvider` context; use `App.useApp()` instead
+  - antd v5+ static feedback APIs (`message.*`, `notification.*`, `Modal.confirm` / `Modal.info` / `Modal.success` / `Modal.error` / `Modal.warning` / `Modal.warn`) that cannot consume `ConfigProvider` context; use `App.useApp()` instead
   - antd v5+ Upload controlled/uncontrolled conflicts: using both `fileList` and `defaultFileList`, or using controlled `fileList` without `onChange`
   - antd v5+ Select children APIs (`Select.Option`, `Select.OptGroup`); use the `options` prop instead
 - **performance** — Wildcard imports (`import * as`) from `antd`, configured `--antd-alias` packages, or their subpaths; default imports; disabling virtual scroll on Select. Locale paths (`antd/locale/*`, `antd/es/locale/*`, `antd/lib/locale/*`) are excluded since their default import is the documented pattern and there is no tree-shaking benefit to be gained. Non-module asset sources (any extension other than `.js/.jsx/.ts/.tsx/.mjs/.cjs/.mts/.cts`, e.g. `.css/.svg/.ttf/.woff2/.png`) are also excluded, since they resolve to a bundler asset with only a default export and have no named exports.

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -13,13 +13,13 @@ describe('lint', () => {
   });
 
   /** Create a temp fixture, run lint, and clean up. */
-  async function lintFixture(name: string, content: string, extraArgs: string[] = []): Promise<string> {
+  async function lintFixture(name: string, content: string, extraArgs: string[] = [], version = '6.3.1'): Promise<string> {
     const tmpDir = join(__dirname, `__tmp_lint_${name}__`);
     const fixture = join(tmpDir, `${name}.tsx`);
     try {
       mkdirSync(tmpDir, { recursive: true });
       writeFileSync(fixture, content);
-      const result = await runCLI('lint', fixture, '--version', '6.3.1', ...extraArgs);
+      const result = await runCLI('lint', fixture, '--version', version, ...extraArgs);
       return result.stdout;
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
@@ -551,6 +551,45 @@ class Demo {
     );
     const data = JSON.parse(out);
     expect(data.issues.filter((i: LintIssue) => i.rule === 'usage' && i.message.includes('feedback API'))).toHaveLength(0);
+  });
+
+  it('should not warn on App.useApp feedback instances shadowing static imports', async () => {
+    const out = await lintFixture(
+      'static-feedback-shadowed',
+      `import { App, message, notification, Modal } from 'antd';
+function Demo({ message: propMessage }) {
+  const { message, notification, modal: Modal } = App.useApp();
+  message.success('Saved');
+  notification.open({ message: 'Saved' });
+  Modal.confirm({ title: 'Confirm' });
+  propMessage.success('Saved');
+}
+`,
+      ['--only', 'usage', '--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    expect(data.issues.filter((i: LintIssue) => i.rule === 'usage' && i.message.includes('feedback API'))).toHaveLength(0);
+  });
+
+  it('should not run v5 usage rules for antd v4', async () => {
+    const out = await lintFixture(
+      'v4-usage-rules',
+      `import { message, notification, Modal, Select, Upload } from 'antd';
+message.success('Saved');
+notification.open({ message: 'Saved' });
+Modal.confirm({ title: 'Confirm' });
+const App = () => (
+  <>
+    <Upload fileList={[]} defaultFileList={[]} />
+    <Select><Select.Option value="a">A</Select.Option></Select>
+  </>
+);
+`,
+      ['--only', 'usage', '--format', 'json'],
+      '4.24.16',
+    );
+    const data = JSON.parse(out);
+    expect(data.issues).toHaveLength(0);
   });
 
   it('should warn on Upload controlled value conflicts', async () => {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -515,6 +515,59 @@ const App = () => (
     expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('shouldUpdate'))).toBe(true);
   });
 
+  it('should warn on static feedback APIs in antd v5+', async () => {
+    const out = await lintFixture(
+      'static-feedback',
+      `import { message, notification, Modal } from 'antd';
+message.success('Saved');
+notification.open({ message: 'Saved' });
+Modal.confirm({ title: 'Confirm' });
+`,
+      ['--only', 'usage', '--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('message.success'))).toBe(true);
+    expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('notification.open'))).toBe(true);
+    expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('Modal.confirm'))).toBe(true);
+  });
+
+  it('should warn on Upload controlled value conflicts', async () => {
+    const out = await lintFixture(
+      'upload-control',
+      `import { Upload } from 'antd';
+const App = () => (
+  <>
+    <Upload fileList={[]} defaultFileList={[]} />
+    <Upload fileList={[]} />
+  </>
+);
+`,
+      ['--only', 'usage', '--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    expect(data.issues.filter((i: LintIssue) => i.rule === 'usage' && i.message.includes('Upload'))).toHaveLength(2);
+  });
+
+  it('should warn on Select.Option children in antd v5+', async () => {
+    const out = await lintFixture(
+      'select-option-children',
+      `import { Select } from 'antd';
+const App = () => (
+  <Select>
+    <Select.Option value="a">A</Select.Option>
+    <Select.OptGroup label="Group">
+      <Select.Option value="b">B</Select.Option>
+    </Select.OptGroup>
+  </Select>
+);
+`,
+      ['--only', 'usage', '--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('Select.Option'))).toBe(true);
+    expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('Select.OptGroup'))).toBe(true);
+  });
+
   it('should warn on icon onClick without aria-label', async () => {
     const out = await lintFixture(
       'icon-aria',

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -531,6 +531,27 @@ Modal.confirm({ title: 'Confirm' });
     expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('Modal.confirm'))).toBe(true);
   });
 
+  it('should not warn on dynamic or non-imported feedback member calls', async () => {
+    const out = await lintFixture(
+      'static-feedback-false-positives',
+      `import { message } from 'antd';
+const method = 'success';
+message[method]('Saved');
+const [api] = message.useMessage();
+api.success('Saved');
+getFeedback().message.success('Saved');
+class Demo {
+  run() {
+    this.message.success('Saved');
+  }
+}
+`,
+      ['--only', 'usage', '--format', 'json'],
+    );
+    const data = JSON.parse(out);
+    expect(data.issues.filter((i: LintIssue) => i.rule === 'usage' && i.message.includes('feedback API'))).toHaveLength(0);
+  });
+
   it('should warn on Upload controlled value conflicts', async () => {
     const out = await lintFixture(
       'upload-control',
@@ -539,13 +560,15 @@ const App = () => (
   <>
     <Upload fileList={[]} defaultFileList={[]} />
     <Upload fileList={[]} />
+    <Upload.Dragger fileList={[]} defaultFileList={[]} />
+    <Upload.Dragger fileList={[]} />
   </>
 );
 `,
       ['--only', 'usage', '--format', 'json'],
     );
     const data = JSON.parse(out);
-    expect(data.issues.filter((i: LintIssue) => i.rule === 'usage' && i.message.includes('Upload'))).toHaveLength(2);
+    expect(data.issues.filter((i: LintIssue) => i.rule === 'usage' && i.message.includes('Upload'))).toHaveLength(4);
   });
 
   it('should warn on Select.Option children in antd v5+', async () => {

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -520,13 +520,14 @@ const App = () => (
       'static-feedback',
       `import { message, notification, Modal } from 'antd';
 message.success('Saved');
+message['success']('Saved');
 notification.open({ message: 'Saved' });
 Modal.confirm({ title: 'Confirm' });
 `,
       ['--only', 'usage', '--format', 'json'],
     );
     const data = JSON.parse(out);
-    expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('message.success'))).toBe(true);
+    expect(data.issues.filter((i: LintIssue) => i.rule === 'usage' && i.message.includes('message.success'))).toHaveLength(2);
     expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('notification.open'))).toBe(true);
     expect(data.issues.some((i: LintIssue) => i.rule === 'usage' && i.message.includes('Modal.confirm'))).toBe(true);
   });

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -107,16 +107,23 @@ function getMemberPath(node: any): string[] {
   if (node.type === 'ChainExpression') return getMemberPath(node.expression);
   if (node.type === 'MemberExpression' || node.type === 'OptionalMemberExpression') {
     const objectPath = getMemberPath(node.object);
+    if (objectPath.length === 0) return [];
     let propertyName: string | undefined;
-    if (node.property?.type === 'Identifier') {
+    if (node.property?.type === 'Identifier' && !node.computed) {
       propertyName = node.property.name;
     } else if (node.property?.type === 'Literal' && typeof node.property.value === 'string') {
       propertyName = node.property.value;
     }
-    return propertyName ? [...objectPath, propertyName] : objectPath;
+    return propertyName ? [...objectPath, propertyName] : [];
   }
   return [];
 }
+
+const STATIC_FEEDBACK_METHODS: Record<string, string[]> = {
+  message: ['open', 'success', 'error', 'info', 'warning', 'warn', 'loading'],
+  notification: ['open', 'success', 'error', 'info', 'warning', 'warn'],
+  Modal: ['confirm', 'info', 'success', 'error', 'warning', 'warn'],
+};
 
 /** Create a stateful offset-to-line converter that exploits monotonically increasing offsets. */
 function createLineMapper(source: string): (offset: number) => number {
@@ -371,24 +378,7 @@ function lintFile(
       const callName = path.join('.');
       const line = lineOf(node);
 
-      if (
-        importedName === 'message' &&
-        ['open', 'success', 'error', 'info', 'warning', 'warn', 'loading'].includes(method)
-      ) {
-        report('usage', 'warning', line, `Static antd feedback API \`${callName}\` cannot consume ConfigProvider context. Use App.useApp() instead.`);
-      }
-
-      if (
-        importedName === 'notification' &&
-        ['open', 'success', 'error', 'info', 'warning', 'warn'].includes(method)
-      ) {
-        report('usage', 'warning', line, `Static antd feedback API \`${callName}\` cannot consume ConfigProvider context. Use App.useApp() instead.`);
-      }
-
-      if (
-        importedName === 'Modal' &&
-        ['confirm', 'info', 'success', 'error', 'warning', 'warn'].includes(method)
-      ) {
+      if (importedName && STATIC_FEEDBACK_METHODS[importedName]?.includes(method)) {
         report('usage', 'warning', line, `Static antd feedback API \`${callName}\` cannot consume ConfigProvider context. Use App.useApp() instead.`);
       }
     },
@@ -530,7 +520,7 @@ function lintFile(
           }
         }
 
-        if (enableV5UsageRules && compName === 'Upload' && importedComponents.has('Upload')) {
+        if (enableV5UsageRules && (compName === 'Upload' || compName === 'Upload.Dragger') && importedComponents.has('Upload')) {
           if (hasAttr(attrs, 'fileList') && hasAttr(attrs, 'defaultFileList')) {
             report('usage', 'warning', line, 'Upload should not use both controlled `fileList` and uncontrolled `defaultFileList`');
           } else if (hasAttr(attrs, 'fileList') && !hasAttr(attrs, 'onChange')) {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -119,6 +119,32 @@ function getMemberPath(node: any): string[] {
   return [];
 }
 
+function collectPatternNames(pattern: any, names: string[] = []): string[] {
+  if (!pattern) return names;
+  if (pattern.type === 'Identifier') {
+    names.push(pattern.name);
+  /* v8 ignore start -- defensive support for uncommon binding patterns */
+  } else if (pattern.type === 'AssignmentPattern') {
+    collectPatternNames(pattern.left, names);
+  } else if (pattern.type === 'RestElement') {
+    collectPatternNames(pattern.argument, names);
+  } else if (pattern.type === 'ArrayPattern') {
+    for (const element of pattern.elements ?? []) collectPatternNames(element, names);
+  } else if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties ?? []) {
+      if (property.type === 'Property') {
+        collectPatternNames(property.value, names);
+      } else if (property.type === 'RestElement') {
+        collectPatternNames(property.argument, names);
+      }
+    }
+  } else if (pattern.pattern) {
+    collectPatternNames(pattern.pattern, names);
+  }
+  /* v8 ignore stop */
+  return names;
+}
+
 const STATIC_FEEDBACK_METHODS: Record<string, string[]> = {
   message: ['open', 'success', 'error', 'info', 'warning', 'warn', 'loading'],
   notification: ['open', 'success', 'error', 'info', 'warning', 'warn'],
@@ -326,9 +352,52 @@ function lintFile(
   // Track namespace/default import usage for performance rule suggestions
   const pendingPerformanceIssues: { line: number; source: string; localName: string; kind: 'namespace' | 'default' }[] = [];
   const namespaceMemberUsage = new Map<string, Set<string>>();
+  const scopeStack: Set<string>[] = [new Set()];
+
+  const declarePattern = (pattern: any) => {
+    const currentScope = scopeStack[scopeStack.length - 1];
+    for (const name of collectPatternNames(pattern)) {
+      currentScope.add(name);
+    }
+  };
+
+  const isShadowed = (name: string): boolean => scopeStack.some((scope) => scope.has(name));
+
+  const pushFunctionScope = (node: any) => {
+    scopeStack.push(new Set());
+    for (const param of node.params ?? []) declarePattern(param);
+  };
 
   // Single pass: collect imports and check all rules
   const visitor = new Visitor({
+    BlockStatement() {
+      scopeStack.push(new Set());
+    },
+    'BlockStatement:exit'() {
+      scopeStack.pop();
+    },
+    FunctionDeclaration: pushFunctionScope,
+    'FunctionDeclaration:exit'() {
+      scopeStack.pop();
+    },
+    FunctionExpression: pushFunctionScope,
+    'FunctionExpression:exit'() {
+      scopeStack.pop();
+    },
+    ArrowFunctionExpression: pushFunctionScope,
+    'ArrowFunctionExpression:exit'() {
+      scopeStack.pop();
+    },
+    CatchClause(node: any) {
+      scopeStack.push(new Set());
+      if (node.param) declarePattern(node.param);
+    },
+    'CatchClause:exit'() {
+      scopeStack.pop();
+    },
+    VariableDeclarator(node: any) {
+      declarePattern(node.id);
+    },
     JSXElement(node: any) {
       const elName = getJSXElementName(node.openingElement?.name);
       jsxAncestorStack.push(elName);
@@ -378,7 +447,7 @@ function lintFile(
       const callName = path.join('.');
       const line = lineOf(node);
 
-      if (importedName && STATIC_FEEDBACK_METHODS[importedName]?.includes(method)) {
+      if (importedName && !isShadowed(path[0]) && STATIC_FEEDBACK_METHODS[importedName]?.includes(method)) {
         report('usage', 'warning', line, `Static antd feedback API \`${callName}\` cannot consume ConfigProvider context. Use App.useApp() instead.`);
       }
     },

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -101,6 +101,23 @@ function getObjectExpressionKeys(attrs: any[], name: string): string[] {
 }
 /* v8 ignore stop */
 
+function getMemberPath(node: any): string[] {
+  if (!node) return [];
+  if (node.type === 'Identifier') return [node.name];
+  if (node.type === 'ChainExpression') return getMemberPath(node.expression);
+  if (node.type === 'MemberExpression' || node.type === 'OptionalMemberExpression') {
+    const objectPath = getMemberPath(node.object);
+    let propertyName: string | undefined;
+    if (node.property?.type === 'Identifier') {
+      propertyName = node.property.name;
+    } else if (node.property?.type === 'Literal' && typeof node.property.value === 'string') {
+      propertyName = node.property.value;
+    }
+    return propertyName ? [...objectPath, propertyName] : objectPath;
+  }
+  return [];
+}
+
 /** Create a stateful offset-to-line converter that exploits monotonically increasing offsets. */
 function createLineMapper(source: string): (offset: number) => number {
   let lastOffset = 0;
@@ -245,6 +262,7 @@ function lintFile(
   filePath: string,
   deprecatedMap: Map<string, DeprecatedInfo[]>,
   antdAliases: string[],
+  antdMajor: number,
   only?: string,
 ): { issues: LintIssue[]; skipped?: SkippedFile } {
   let content: string;
@@ -280,7 +298,9 @@ function lintFile(
 
   const issues: LintIssue[] = [];
   const importedComponents = new Set<string>();
+  const antdImportLocals = new Map<string, string>();
   const offsetToLine = createLineMapper(content);
+  const enableV5UsageRules = antdMajor >= 5;
 
   const lineOf = (node: any): number => {
     if (typeof node.start === 'number') return offsetToLine(node.start);
@@ -320,7 +340,9 @@ function lintFile(
         if (spec.type === 'ImportSpecifier') {
           if (spec.importKind === 'type') continue;
           const name = spec.imported?.name || spec.local?.name;
+          const localName = spec.local?.name || name;
           if (name) importedComponents.add(name);
+          if (name && localName) antdImportLocals.set(localName, name);
         }
 
         if (!only || only === 'performance') {
@@ -335,6 +357,39 @@ function lintFile(
             namespaceMemberUsage.set(localName, new Set());
           }
         }
+      }
+    },
+
+    CallExpression(node: any) {
+      if (only && only !== 'usage') return;
+      if (!enableV5UsageRules) return;
+
+      const path = getMemberPath(node.callee);
+      if (path.length < 2) return;
+      const importedName = antdImportLocals.get(path[0]);
+      const method = path[1];
+      const callName = path.join('.');
+      const line = lineOf(node);
+
+      if (
+        importedName === 'message' &&
+        ['open', 'success', 'error', 'info', 'warning', 'warn', 'loading'].includes(method)
+      ) {
+        report('usage', 'warning', line, `Static antd feedback API \`${callName}\` cannot consume ConfigProvider context. Use App.useApp() instead.`);
+      }
+
+      if (
+        importedName === 'notification' &&
+        ['open', 'success', 'error', 'info', 'warning', 'warn'].includes(method)
+      ) {
+        report('usage', 'warning', line, `Static antd feedback API \`${callName}\` cannot consume ConfigProvider context. Use App.useApp() instead.`);
+      }
+
+      if (
+        importedName === 'Modal' &&
+        ['confirm', 'info', 'success', 'error', 'warning', 'warn'].includes(method)
+      ) {
+        report('usage', 'warning', line, `Static antd feedback API \`${callName}\` cannot consume ConfigProvider context. Use App.useApp() instead.`);
       }
     },
 
@@ -474,6 +529,23 @@ function lintFile(
             report('usage', 'warning', line, 'TreeSelect `multiple={false}` is ignored when `treeCheckable` is true');
           }
         }
+
+        if (enableV5UsageRules && compName === 'Upload' && importedComponents.has('Upload')) {
+          if (hasAttr(attrs, 'fileList') && hasAttr(attrs, 'defaultFileList')) {
+            report('usage', 'warning', line, 'Upload should not use both controlled `fileList` and uncontrolled `defaultFileList`');
+          } else if (hasAttr(attrs, 'fileList') && !hasAttr(attrs, 'onChange')) {
+            report('usage', 'warning', line, 'Upload with controlled `fileList` should provide `onChange`');
+          }
+        }
+
+        if (enableV5UsageRules && importedComponents.has('Select')) {
+          if (compName === 'Select.Option') {
+            report('usage', 'warning', line, 'Select.Option children are not recommended in antd v5+. Use the `options` prop instead.');
+          }
+          if (compName === 'Select.OptGroup') {
+            report('usage', 'warning', line, 'Select.OptGroup children are not recommended in antd v5+. Use grouped `options` instead.');
+          }
+        }
       }
 
       // --- Performance checks ---
@@ -542,7 +614,7 @@ export function registerLintCommand(program: Command): void {
       const skippedFiles: SkippedFile[] = [];
 
       for (const file of files) {
-        const result = lintFile(file, deprecatedMap, antdAliases, cmdOpts.only);
+        const result = lintFile(file, deprecatedMap, antdAliases, parseInt(versionInfo.majorVersion.slice(1), 10), cmdOpts.only);
         allIssues.push(...result.issues);
         if (result.skipped) skippedFiles.push(result.skipped);
       }


### PR DESCRIPTION
## 背景

补充 `antd lint --only usage` 的低误报规则，覆盖 antd v5+ 下更常见的 API / 组件使用问题。

## 变更

- 新增静态反馈 API 检查：`message.*`、`notification.*`、`Modal.confirm/info/success/error/warning`，提示使用 `App.useApp()` 获取上下文能力。
- 新增 Upload 受控用法检查：同时使用 `fileList` / `defaultFileList`，或受控 `fileList` 缺少 `onChange`。
- 新增 Select children API 检查：v5+ 下提示将 `Select.Option` / `Select.OptGroup` 迁移到 `options`。
- 更新 `spec.md` 和 README 中的 lint 规则说明。

## 验证

- `npx vitest run src/__tests__/commands/lint.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

备注：本地 `npm run test` 目前会在 migrate 的 `/tmp` 快照用例失败，因为机器上的 `/tmp` 有其他 antd 项目残留，导致扫描结果不是快照期望的空目录；与本次 lint 改动无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * `lint` 新增/扩展 `usage` 规则分类，支持 `--only usage`（含 `--format json`），对 antd v5+ 的静态反馈 API、Upload 受控/非受控冲突、以及 Select 子组件用法给出告警提示。
* **文档**
  * 更新 README 与规范：调整 `antd lint` 规则类别说明，并补充 `usage` 覆盖的典型问题类型与示例。
* **测试**
  * 增加 `lint --only usage` 相关断言用例，覆盖上述告警触发与不触发场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->