### PR TITLE
fix(changelog): preserve emoji entries and ownership

### DIFF
--- a/scripts/extractors/__tests__/changelog.test.ts
+++ b/scripts/extractors/__tests__/changelog.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { extractChangelog } from '../changelog.js';
+
+describe('extractChangelog', () => {
+  it('retains emoji bullets and limits component ownership to indented changes', () => {
+    const antdDir = mkdtempSync(path.join(tmpdir(), 'antd-cli-changelog-'));
+
+    try {
+      writeFileSync(
+        path.join(antdDir, 'CHANGELOG.en-US.md'),
+        `## 6.5.0
+\`2026-07-10\`
+
+- 📦 Internal package maintenance
+- 📖 Documentation refresh
+- ⌨️ Keyboard navigation improvements
+- 🇳🇴 Norwegian locale update
+- Button
+  - 🐞 Fix focus handling
+  - 🆕 Add loading state
+- 🔥 Add Alert hot-path support
+`,
+      );
+
+      expect(extractChangelog(antdDir)).toEqual([
+        {
+          version: '6.5.0',
+          date: '2026-07-10',
+          changes: [
+            { component: 'General', type: 'other', description: '📦 Internal package maintenance' },
+            { component: 'General', type: 'other', description: '📖 Documentation refresh' },
+            { component: 'General', type: 'other', description: '⌨️ Keyboard navigation improvements' },
+            { component: 'General', type: 'other', description: '🇳🇴 Norwegian locale update' },
+            { component: 'Button', type: 'fix', description: '🐞 Fix focus handling' },
+            { component: 'Button', type: 'feature', description: '🆕 Add loading state' },
+            { component: 'Alert', type: 'feature', description: '🔥 Add Alert hot-path support' },
+          ],
+        },
+      ]);
+    } finally {
+      rmSync(antdDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/extractors/changelog.ts
+++ b/scripts/extractors/changelog.ts
@@ -4,7 +4,7 @@ import type { ChangelogEntry } from '../../src/types.js';
 
 /** Map emoji prefixes to change types */
 function classifyChange(line: string): ChangelogEntry['changes'][0]['type'] {
-  if (line.includes('🆕') || line.includes('🛠')) return 'feature';
+  if (line.includes('🆕') || line.includes('🛠') || line.includes('🔥')) return 'feature';
   if (line.includes('🐞')) return 'fix';
   if (line.includes('💄')) return 'style';
   if (line.includes('⚡️') || line.includes('🗑')) return 'deprecation';
@@ -24,7 +24,7 @@ function extractComponent(line: string): string {
 /** Clean a changelog line: remove emojis, PR links, contributor mentions */
 function cleanDescription(line: string): string {
   return line
-    .replace(/^-\s*/, '')
+    .replace(/^\s*-\s*/, '')
     .replace(/\[#\d+\]\([^)]+\)/g, '')
     .replace(/\[@?\w+\]\(https?:\/\/github\.com\/[^)]+\)/g, '')
     .replace(/@\w+/g, '')
@@ -71,11 +71,15 @@ function parseChangelog(content: string): ChangelogEntry[] {
     }
 
     // Change line with emoji
-    const changeMatch = line.match(/^\s*-\s+[🐞🆕💄⚡️🗑💥🌐🛠⌨️🤖♿️]/u);
+    const changeMatch = line.match(
+      /^(\s*)-\s+(?:\p{Extended_Pictographic}|\p{Regional_Indicator}{2})/u,
+    );
     if (changeMatch && currentVersion) {
+      const isIndented = changeMatch[1].length > 0;
+      if (!isIndented) currentComponent = '';
       const type = classifyChange(line);
       const desc = cleanDescription(line);
-      const component = currentComponent || extractComponent(line);
+      const component = isIndented && currentComponent ? currentComponent : extractComponent(line);
 
       if (desc) {
         currentChanges.push({ component, type, description: desc });

--- a/spec.md
+++ b/spec.md
@@ -69,6 +69,7 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 - The extraction script handles `\|` (escaped pipes in markdown table cells) by replacing them with a placeholder before splitting. This ensures multi-value union types like `` `primary` \| `dashed` \| `link` `` are stored correctly as `` `primary` | `dashed` | `link` `` instead of being split across wrong columns.
 - Each version file contains both `en` and `zh` descriptions, keyed by language
 - `semantic` data extracted from `components/*/demo/_semantic.tsx` files
+- Changelog extraction recognizes Unicode emoji prefixes (including country flags); only indented change bullets inherit the preceding component group, while top-level bullets resolve their own component context.
 - Data is auto-extracted from antd source via `scripts/extract.ts`
 - `data/design-v{major}.md` (the design-language document served by `antd design.md`) is **not** extracted but **copied verbatim** from antd's repo-root `DESIGN.md` during sync, since it is hand-curated prose, not derivable data. It is major-grained, so `scripts/sync.ts` checks out each major's latest tag and copies the file to `data/design-v{major}.md` (only `design-v6.md` exists today; antd has not published `DESIGN.md` for v3/v4/v5). If the source `DESIGN.md` is absent for a major, the existing bundled copy is kept rather than deleted.
 - For v5+ design tokens, `scripts/sync.ts` fetches `token-meta.json` from the matching published `antd@{version}` tarball for each extracted tag and replaces any previous checkout copy before extraction, so token data cannot be reused across versions.
@@ -976,7 +977,7 @@ Extraction sources:
 | Demos | `components/*/demo/*.tsx` + `*.md` | File read + bilingual md parsing |
 | Tokens | `components/version/token-meta.json` | Direct JSON read |
 | Semantic | `components/*/demo/_semantic.tsx` | Regex extraction of locales + semantics |
-| Changelog | `CHANGELOG.{en-US,zh-CN}.md` | Markdown heading/emoji parsing |
+| Changelog | `CHANGELOG.{en-US,zh-CN}.md` | Markdown heading, Unicode emoji, and indentation-aware component parsing |
 | FAQ | `index.{en-US,zh-CN}.md` `## FAQ` section | Markdown section extraction |
 
 Extractors are organized as `scripts/extractors/*.ts` modules (components, props, demos, tokens, semantic, changelog, faq).


### PR DESCRIPTION
## Summary

- recognize Unicode emoji-prefixed changelog bullets, including country flags
- inherit component ownership only for indented bullets and resolve top-level entries independently
- classify `🔥` entries as features and remove indentation markers from extracted descriptions
- document the extraction behavior in `spec.md`

## Verification

- `npx vitest run scripts/extractors/__tests__/changelog.test.ts`
- `npm run typecheck`
- `npm run build`
- `npx vitest run --reporter=dot --testTimeout=10000` (50 files, 684 tests)
- `git diff --check`
