### PR TITLE
fix(changelog): stop guessing prop renames

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -303,7 +303,7 @@ antd changelog 4.24.0 5.0.0 Select      # Select-specific changes
 
 Version range uses `<from>..<to>` syntax (inclusive on both ends). Both `from` and `to` must be full semver (e.g. `5.10.0`, not `5.10`). Single version returns only that exact version's entries.
 
-API diff mode (`changelog <v1> <v2>`) output includes: added props, removed props, changed types, renamed props. Cross-major-version diffing (e.g. v4 vs v5) is supported because the components schema is consistent across versions.
+API diff mode (`changelog <v1> <v2>`) output includes added props, removed props, and changed types. It does not infer renames solely from matching prop types. Cross-major-version diffing (e.g. v4 vs v5) is supported because the components schema is consistent across versions.
 
 ### Agent Integration
 
@@ -1071,10 +1071,8 @@ GitHub Releases are created only after npm publish succeeds, so public release n
     {"name": "popupClassName", "type": "string"}
   ],
   "removed": [
-    {"name": "dropdownClassName", "replacement": "popupClassName"}
+    {"name": "dropdownClassName", "type": "string"}
   ],
-  "changed": [
-    {"name": "dropdownMatchSelectWidth", "renamed": "popupMatchSelectWidth"}
-  ]
+  "changed": []
 }
 ```

--- a/src/__tests__/commands/changelog.test.ts
+++ b/src/__tests__/commands/changelog.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { run, runCLI } from '../helper.js';
+import { diffProps } from '../../commands/changelog.js';
 
 describe('changelog', () => {
+  it('does not guess a rename from an unrelated prop with the same type', () => {
+    const result = diffProps(
+      [{ name: 'autoFocus', type: 'boolean', default: '-' }],
+      [{ name: 'disabled', type: 'boolean', default: '-' }],
+    );
+
+    expect(result.removed).toEqual([{ name: 'autoFocus', type: 'boolean' }]);
+  });
+
   it('should show changelog', async () => {
     const out = await run('changelog', '5.21.0');
     expect(out).toContain('5.21.0');

--- a/src/__tests__/commands/changelog.test.ts
+++ b/src/__tests__/commands/changelog.test.ts
@@ -5,11 +5,21 @@ import { diffProps } from '../../commands/changelog.js';
 describe('changelog', () => {
   it('does not guess a rename from an unrelated prop with the same type', () => {
     const result = diffProps(
-      [{ name: 'autoFocus', type: 'boolean', default: '-' }],
-      [{ name: 'disabled', type: 'boolean', default: '-' }],
+      [
+        { name: 'autoFocus', type: 'boolean', default: '-' },
+        { name: 'value', type: 'string', default: '-' },
+      ],
+      [
+        { name: 'disabled', type: 'boolean', default: '-' },
+        { name: 'value', type: 'number', default: '-' },
+      ],
     );
 
-    expect(result.removed).toEqual([{ name: 'autoFocus', type: 'boolean' }]);
+    expect(result).toEqual({
+      added: [{ name: 'disabled', type: 'boolean' }],
+      removed: [{ name: 'autoFocus', type: 'boolean' }],
+      changed: [{ name: 'value', change: 'string → number' }],
+    });
   });
 
   it('should show changelog', async () => {

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -42,7 +42,6 @@ const EMOJI_MAP: Record<string, string> = {
 export interface PropDiff {
   name: string;
   type?: string;
-  replacement?: string;
   change?: string;
 }
 
@@ -65,7 +64,7 @@ export interface DiffResult {
   component?: string;
 }
 
-function diffProps(
+export function diffProps(
   oldProps: PropData[],
   newProps: PropData[],
 ): { added: PropDiff[]; removed: PropDiff[]; changed: PropDiff[] } {
@@ -89,10 +88,7 @@ function diffProps(
 
   for (const [name, prop] of oldMap) {
     if (!newMap.has(name)) {
-      const possibleRename = [...newMap.values()].find(
-        (p) => p.type === prop.type && !oldMap.has(p.name),
-      );
-      removed.push({ name, type: prop.type, replacement: possibleRename?.name });
+      removed.push({ name, type: prop.type });
     }
   }
 
@@ -285,10 +281,7 @@ function printApiDiff(result: DiffResult, format: string, lang: string = 'en'): 
   for (const diff of result.diffs) {
     console.log(`  ${diff.component}:`);
     for (const p of diff.added) console.log(`    + ${p.name}: ${p.type}`);
-    for (const p of diff.removed) {
-      const note = p.replacement ? ` (replaced by ${p.replacement})` : '';
-      console.log(`    - ${p.name}: ${p.type}${note}`);
-    }
+    for (const p of diff.removed) console.log(`    - ${p.name}: ${p.type}`);
     for (const p of diff.changed) console.log(`    ~ ${p.name}: ${p.change}`);
     console.log('');
   }


### PR DESCRIPTION
## Summary

- stop treating any newly added prop with the same type as a rename target
- report independent additions and removals without a fabricated `replacement`
- update the API diff contract and example in `spec.md`

## Verification

- `npx vitest run src/__tests__/commands/changelog.test.ts` (27 tests)
- `npm run typecheck`
- `npm run build`
- `npx vitest run --reporter=dot --testTimeout=10000` (49 files, 684 tests)
- `git diff --check`
