### PR TITLE
fix(version): preserve prerelease ordering

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -63,6 +63,8 @@ When `--version 4.3.5` is requested, `loadMetadataForVersion("4.3.5")` resolves 
 2. **Nearest earlier minor** — if `"4.3"` is absent, find the largest available minor ≤ 4.3 (e.g. `"4.1"`) → load that snapshot
 3. **Fallback** — load `data/v4.json` (latest)
 
+Version ordering uses semver precedence, including prerelease identifiers. For example, `6.0.0-beta.1 < 6.0.0-beta.2 < 6.0.0`.
+
 ### Data Layer Notes
 
 - On load, component props are deduplicated by name (first entry wins).

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -180,6 +180,12 @@ describe('data/version', () => {
     it('returns 0 when equal', () => {
       expect(compare('5.0.0', '5.0.0')).toBe(0);
     });
+    it('orders prerelease identifiers', () => {
+      expect(compare('5.0.0-beta.1', '5.0.0-beta.2')).toBeLessThan(0);
+    });
+    it('orders a prerelease before its final release', () => {
+      expect(compare('5.0.0-beta.2', '5.0.0')).toBeLessThan(0);
+    });
     it('returns null when unparseable', () => {
       expect(compare('not-a-version', 'also-not')).toBeNull();
     });

--- a/src/data/version.ts
+++ b/src/data/version.ts
@@ -149,8 +149,8 @@ function toMajor(version: string): string {
 
 /** Semver comparison using the `semver` package. Returns -1, 0, or 1, or null if either version is unparseable. */
 export function compare(a: string, b: string): number | null {
-  const sa = semver.coerce(a);
-  const sb = semver.coerce(b);
+  const sa = semver.parse(a) ?? semver.coerce(a, { includePrerelease: true });
+  const sb = semver.parse(b) ?? semver.coerce(b, { includePrerelease: true });
   if (!sa || !sb) return null;
   return semver.compare(sa, sb);
 }


### PR DESCRIPTION
## Summary

- preserve prerelease identifiers when comparing valid semver versions
- order prerelease identifiers correctly and keep prereleases before final releases
- retain coercion as a fallback for partial or prefixed version inputs
- document prerelease ordering in `spec.md`

## Verification

- `npx vitest run src/__tests__/version-loader.test.ts` (71 tests)
- `npm run typecheck`
- `npm run build`
- `npx vitest run --reporter=dot --testTimeout=10000` (49 files, 685 tests)
- `git diff --check`
