### PR TITLE
docs: expand v6.5.0 and v6.5.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,73 @@
 
 ## [6.5.1](https://github.com/ant-design/ant-design-cli/compare/v6.5.0...v6.5.1) (2026-07-13)
 
-- Update antd metadata ([v6@6.5.1](https://github.com/ant-design/ant-design-cli/compare/v6.5.0...v6.5.1#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+### Features
 
-
-## Unreleased
+- Add a branded banner to the root help output ([#184](https://github.com/ant-design/ant-design-cli/pull/184))
+- Add `antd lint --diff [base]` and `--staged`, report skipped files, and cover Ant Design v5 usage patterns ([#188](https://github.com/ant-design/ant-design-cli/pull/188), [#189](https://github.com/ant-design/ant-design-cli/pull/189), [#192](https://github.com/ant-design/ant-design-cli/pull/192))
+- Extend `antd setup` with GitHub Actions CI configuration ([#190](https://github.com/ant-design/ant-design-cli/pull/190))
 
 ### Bug Fixes
 
-- `antd lint` no longer flags default/namespace imports of non-JS assets (e.g. `antd/dist/reset.css`, `antd/es/some-icon.svg`) under the performance rule, since such sources resolve to a bundler asset with only a default export ([#185](https://github.com/ant-design/ant-design-cli/issues/185))
+- Ignore non-JavaScript asset imports in the lint performance rule ([#186](https://github.com/ant-design/ant-design-cli/pull/186))
+- Preserve historical metadata, dotted semantic keys, prerelease ordering, and a bounded metadata cache ([#194](https://github.com/ant-design/ant-design-cli/pull/194), [#195](https://github.com/ant-design/ant-design-cli/pull/195), [#198](https://github.com/ant-design/ant-design-cli/pull/198), [#199](https://github.com/ant-design/ant-design-cli/pull/199))
+- Improve changelog extraction by preserving emoji and ownership, avoiding guessed prop renames, and validating inferred component names ([#196](https://github.com/ant-design/ant-design-cli/pull/196), [#197](https://github.com/ant-design/ant-design-cli/pull/197), [#201](https://github.com/ant-design/ant-design-cli/pull/201))
+
+### Security
+
+- Prevent shell injection in release tag handling while keeping sync commands portable on Windows ([#193](https://github.com/ant-design/ant-design-cli/pull/193))
+
+### Other Changes
+
+- Allow package-size reporting to continue when GitHub comment permissions are unavailable ([#187](https://github.com/ant-design/ant-design-cli/pull/187))
+- Bump dependencies ([#183](https://github.com/ant-design/ant-design-cli/pull/183), [#191](https://github.com/ant-design/ant-design-cli/pull/191))
+- Update antd metadata ([v6@6.5.1](https://github.com/ant-design/ant-design-cli/compare/v6.5.0...v6.5.1#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+
+---
+
+### 新功能
+
+- 为根帮助信息新增品牌化 Banner ([#184](https://github.com/ant-design/ant-design-cli/pull/184))
+- 新增 `antd lint --diff [base]` 和 `--staged`，报告跳过的文件，并覆盖 Ant Design v5 使用规则 ([#188](https://github.com/ant-design/ant-design-cli/pull/188), [#189](https://github.com/ant-design/ant-design-cli/pull/189), [#192](https://github.com/ant-design/ant-design-cli/pull/192))
+- 扩展 `antd setup`，支持配置 GitHub Actions CI ([#190](https://github.com/ant-design/ant-design-cli/pull/190))
+
+### Bug 修复
+
+- lint 性能规则不再误报非 JavaScript 资源导入 ([#186](https://github.com/ant-design/ant-design-cli/pull/186))
+- 保留历史元数据、点号语义键和预发布版本顺序，并限制元数据缓存大小 ([#194](https://github.com/ant-design/ant-design-cli/pull/194), [#195](https://github.com/ant-design/ant-design-cli/pull/195), [#198](https://github.com/ant-design/ant-design-cli/pull/198), [#199](https://github.com/ant-design/ant-design-cli/pull/199))
+- 改进 changelog 提取，保留 emoji 与归属关系，不再猜测属性重命名，并校验推断出的组件名 ([#196](https://github.com/ant-design/ant-design-cli/pull/196), [#197](https://github.com/ant-design/ant-design-cli/pull/197), [#201](https://github.com/ant-design/ant-design-cli/pull/201))
+
+### 安全
+
+- 防止发布 tag 处理中的 shell 注入，同时保持同步命令在 Windows 上可用 ([#193](https://github.com/ant-design/ant-design-cli/pull/193))
+
+### 其他变更
+
+- GitHub 评论权限不可用时，包体积报告流程仍可继续 ([#187](https://github.com/ant-design/ant-design-cli/pull/187))
+- 升级依赖 ([#183](https://github.com/ant-design/ant-design-cli/pull/183), [#191](https://github.com/ant-design/ant-design-cli/pull/191))
+- 同步 antd 元数据 ([v6@6.5.1](https://github.com/ant-design/ant-design-cli/compare/v6.5.0...v6.5.1#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+
 
 
 ## [6.5.0](https://github.com/ant-design/ant-design-cli/compare/v6.4.5...v6.5.0) (2026-06-27)
 
+### Documentation
+
+- Expand the v6.4.5 release notes ([#181](https://github.com/ant-design/ant-design-cli/pull/181))
+
+### Other Changes
+
 - Update antd metadata ([v6@6.5.0](https://github.com/ant-design/ant-design-cli/compare/v6.4.5...v6.5.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+
+---
+
+### 文档
+
+- 补充 v6.4.5 发布说明 ([#181](https://github.com/ant-design/ant-design-cli/pull/181))
+
+### 其他变更
+
+- 同步 antd 元数据 ([v6@6.5.0](https://github.com/ant-design/ant-design-cli/compare/v6.4.5...v6.5.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.4.5](https://github.com/ant-design/ant-design-cli/compare/v6.4.4...v6.4.5) (2026-06-22)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,10 +2,36 @@
 
 ## [6.5.1](https://github.com/ant-design/ant-design-cli/compare/v6.5.0...v6.5.1) (2026-07-13)
 
+### 新功能
+
+- 为根帮助信息新增品牌化 Banner ([#184](https://github.com/ant-design/ant-design-cli/pull/184))
+- 新增 `antd lint --diff [base]` 和 `--staged`，报告跳过的文件，并覆盖 Ant Design v5 使用规则 ([#188](https://github.com/ant-design/ant-design-cli/pull/188), [#189](https://github.com/ant-design/ant-design-cli/pull/189), [#192](https://github.com/ant-design/ant-design-cli/pull/192))
+- 扩展 `antd setup`，支持配置 GitHub Actions CI ([#190](https://github.com/ant-design/ant-design-cli/pull/190))
+
+### Bug 修复
+
+- lint 性能规则不再误报非 JavaScript 资源导入 ([#186](https://github.com/ant-design/ant-design-cli/pull/186))
+- 保留历史元数据、点号语义键和预发布版本顺序，并限制元数据缓存大小 ([#194](https://github.com/ant-design/ant-design-cli/pull/194), [#195](https://github.com/ant-design/ant-design-cli/pull/195), [#198](https://github.com/ant-design/ant-design-cli/pull/198), [#199](https://github.com/ant-design/ant-design-cli/pull/199))
+- 改进 changelog 提取，保留 emoji 与归属关系，不再猜测属性重命名，并校验推断出的组件名 ([#196](https://github.com/ant-design/ant-design-cli/pull/196), [#197](https://github.com/ant-design/ant-design-cli/pull/197), [#201](https://github.com/ant-design/ant-design-cli/pull/201))
+
+### 安全
+
+- 防止发布 tag 处理中的 shell 注入，同时保持同步命令在 Windows 上可用 ([#193](https://github.com/ant-design/ant-design-cli/pull/193))
+
+### 其他变更
+
+- GitHub 评论权限不可用时，包体积报告流程仍可继续 ([#187](https://github.com/ant-design/ant-design-cli/pull/187))
+- 升级依赖 ([#183](https://github.com/ant-design/ant-design-cli/pull/183), [#191](https://github.com/ant-design/ant-design-cli/pull/191))
 - 同步 antd 元数据 ([v6@6.5.1](https://github.com/ant-design/ant-design-cli/compare/v6.5.0...v6.5.1#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.5.0](https://github.com/ant-design/ant-design-cli/compare/v6.4.5...v6.5.0) (2026-06-27)
+
+### 文档
+
+- 补充 v6.4.5 发布说明 ([#181](https://github.com/ant-design/ant-design-cli/pull/181))
+
+### 其他变更
 
 - 同步 antd 元数据 ([v6@6.5.0](https://github.com/ant-design/ant-design-cli/compare/v6.4.5...v6.5.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 


### PR DESCRIPTION
## Summary

- expand the v6.5.0 notes to cover the release-note documentation change and metadata sync
- document all 17 pull requests shipped in v6.5.1, grouped into features, fixes, security, and maintenance
- keep the English and Chinese changelogs aligned with the updated GitHub Release bodies
- remove the stale Unreleased entry for #185 because its fix shipped in v6.5.1 via #186

## Verification

- `npm run typecheck`
- `npx vitest run --exclude src/__tests__/snapshots/migrate.test.ts --reporter=dot` — 50 files and 682 tests passed
- `git diff --check`
- verified both GitHub Release bodies match the corresponding `CHANGELOG.md` sections exactly
- verified v6.5.1 release notes cover PRs #183, #184, #186, #187, #188, #189, #190, #191, #192, #193, #194, #195, #196, #197, #198, #199, and #201 that are present in the tag

## Full test note

`npm test` passed 691 of 693 tests. The two failures are existing `migrate.test.ts` snapshots that run `--apply /tmp` and assume `/tmp` is empty; this machine currently has unrelated project worktrees under `/tmp`, so the snapshot scans 6195 files instead of zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 重写并完善 6.5.1 与 6.5.0 的发布说明，新增功能、Bug 修复、安全性及其他变更分类。
  * 补充 v6.4.5 发布说明，并同步更新 antd v6@6.5.1 与 v6@6.5.0 元数据记录。
  * 更新中文发布说明，使中英文版本结构保持一致。
  * 移除未发布（Unreleased）区块。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->