### PR TITLE
fix: clarify stale CLI installs in update notice

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1001,11 +1001,12 @@ After each command completes, the CLI silently checks whether a newer version is
 **Notice format (stderr only):**
 
 ```
-╭────────────────────────────────────────╮
-│  Update available: 0.1.1 → 0.2.0       │
-│  Run: antd upgrade                      │
-│  Or:  npm i -g @ant-design/cli          │
-╰────────────────────────────────────────╯
+╭─────────────────────────────────────────────╮
+│  Update available: 0.1.1 → 0.2.0            │
+│  Running: /path/to/antd                      │
+│  Run: antd upgrade                           │
+│  Or: npm install -g @ant-design/cli@latest  │
+╰─────────────────────────────────────────────╯
 ```
 
 **Behavior details:**
@@ -1014,7 +1015,8 @@ After each command completes, the CLI silently checks whether a newer version is
 - Bug-reporting suggestions in SKILL.md and MCP prompts are skipped when `ANTD_NO_AUTO_REPORT=1` is set
 - Uses `registry.npmjs.org` with a 3 s timeout; failures are silent
 - Output goes to **stderr**, so `--format json` stdout is never polluted
-- No new production dependencies — uses only built-in Node modules (`node:https`, `node:fs`, `node:os`, `node:path`)
+- The notice shows the active `antd` binary path when it can be resolved and derives the manual install command from that path, making stale PATH entries and mixed global package-manager installs visible
+- No new production dependencies — uses the existing `string-width` package and built-in Node modules (`node:child_process`, `node:https`, `node:fs`, `node:os`, `node:path`)
 
 ### Self-Upgrade
 

--- a/src/__tests__/update-check.test.ts
+++ b/src/__tests__/update-check.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import stringWidth from 'string-width';
 import { checkForUpdate } from '../utils/update-check.js';
 import { cacheStore } from '../utils/store.js';
 import * as fetchModule from '../utils/fetch.js';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(() => '/home/测试/.pnpm-global/bin/antd\n'),
+}));
 
 // Replace the Conf-backed store with an in-memory shim to avoid cross-test on-disk races.
 let memStore: Record<string, unknown> = {};
@@ -72,6 +77,19 @@ describe('update-check', () => {
     expect(calls).toContain('Update available');
     expect(calls).toContain('99.0.0');
     fetchSpy.mockRestore();
+  });
+
+  it('shows the active CLI path and matching install command in the update notice', async () => {
+    stripCI();
+    vi.spyOn(fetchModule, 'fetchFirstJson').mockResolvedValue({ version: '99.0.0' });
+
+    await checkForUpdate();
+
+    const notice = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(notice).toContain('Running: /home/测试/.pnpm-global/bin/antd');
+    expect(notice).toContain('pnpm add -g @ant-design/cli@latest');
+    const boxLines = notice.trim().split('\n');
+    expect(new Set(boxLines.map((boxLine) => stringWidth(boxLine))).size).toBe(1);
   });
 
   it('does not print notice when fetched version is older or equal', async () => {

--- a/src/__tests__/utils/detect-pm.test.ts
+++ b/src/__tests__/utils/detect-pm.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { inferPackageManagerFromPath, detectPackageManager, UPGRADE_COMMANDS } from '../../utils/detect-pm.js';
+import {
+  inferPackageManagerFromPath,
+  detectPackageManager,
+  findAntdBinaryPath,
+  UPGRADE_COMMANDS,
+} from '../../utils/detect-pm.js';
 import type { PackageManager } from '../../utils/detect-pm.js';
 import * as childProcess from 'node:child_process';
 
@@ -36,6 +41,23 @@ describe('inferPackageManagerFromPath', () => {
 
   it('detects pnpm from pnpm/global path', () => {
     expect(inferPackageManagerFromPath('/home/user/pnpm/global/bin/antd')).toBe('pnpm');
+  });
+
+  it.each([
+    '/Users/user/Library/pnpm/antd',
+    '/home/user/.local/share/pnpm/antd',
+    'C:\\Users\\user\\AppData\\Local\\pnpm\\antd.cmd',
+  ])('detects pnpm from a standard global bin path: %s', (binPath) => {
+    expect(inferPackageManagerFromPath(binPath)).toBe('pnpm');
+  });
+
+  it.each([
+    '/home/user/.yarn/bin/antd',
+    'C:\\Users\\user\\AppData\\Local\\Yarn\\bin\\antd.cmd',
+    'C:\\Users\\user\\AppData\\Local\\Yarn\\Data\\global\\node_modules\\@ant-design\\cli\\dist\\index.js',
+    'C:\\Users\\user\\AppData\\Local\\Yarn\\config\\global\\node_modules\\@ant-design\\cli\\dist\\index.js',
+  ])('detects yarn from a standard global bin path: %s', (binPath) => {
+    expect(inferPackageManagerFromPath(binPath)).toBe('yarn');
   });
 
   it('detects bun from .bun path', () => {
@@ -136,6 +158,13 @@ describe('detectPackageManager', () => {
   function mockPlatform(platform: string) {
     Object.defineProperty(process, 'platform', { value: platform });
   }
+
+  it('prefers the current CLI invocation path over a different PATH entry', () => {
+    mockExecFileSync.mockReturnValue('/usr/local/bin/antd\n');
+
+    expect(findAntdBinaryPath('/home/user/.local/share/pnpm/antd')).toBe('/home/user/.local/share/pnpm/antd');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
 
   it('returns npm when which returns an npm-style path (Unix)', () => {
     mockPlatform('darwin');

--- a/src/utils/detect-pm.ts
+++ b/src/utils/detect-pm.ts
@@ -10,8 +10,11 @@ interface PMRule {
 const PM_RULES: PMRule[] = [
   { pm: 'utoo', keywords: ['.utoo', 'utoo/global'] },
   { pm: 'cnpm', keywords: ['.cnpm', 'cnpm/global'] },
-  { pm: 'yarn', keywords: ['yarn/global'] },
-  { pm: 'pnpm', keywords: ['.pnpm-global', 'pnpm/global'] },
+  {
+    pm: 'yarn',
+    keywords: ['yarn/global', '/.yarn/bin/', '/yarn/bin/', '/yarn/data/global/', '/yarn/config/global/'],
+  },
+  { pm: 'pnpm', keywords: ['.pnpm-global', 'pnpm/global', '/pnpm/'] },
   { pm: 'bun', keywords: ['.bun', 'bun/install/global'] },
 ];
 
@@ -25,7 +28,7 @@ export const UPGRADE_COMMANDS: Record<PackageManager, { cmd: string; args: strin
 };
 
 export function inferPackageManagerFromPath(binPath: string): PackageManager {
-  const normalized = binPath.replace(/\\/g, '/');
+  const normalized = binPath.replace(/\\/g, '/').toLowerCase();
   for (const rule of PM_RULES) {
     for (const keyword of rule.keywords) {
       if (normalized.includes(keyword)) return rule.pm;
@@ -34,7 +37,20 @@ export function inferPackageManagerFromPath(binPath: string): PackageManager {
   return 'npm';
 }
 
-export function detectPackageManager(): PackageManager | null {
+function isAntdCliPath(entryPath: string): boolean {
+  const normalized = entryPath.replace(/\\/g, '/').toLowerCase();
+  const fileName = normalized.split('/').pop();
+  return fileName === 'antd'
+    || fileName === 'antd.cmd'
+    || fileName === 'antd.exe'
+    || normalized.endsWith('/@ant-design/cli/dist/index.js');
+}
+
+export function findAntdBinaryPath(invocationPath: string | undefined = process.argv[1]): string | null {
+  if (invocationPath && isAntdCliPath(invocationPath)) {
+    return invocationPath;
+  }
+
   const isWin = process.platform === 'win32';
   try {
     const binPath = execFileSync(isWin ? 'where' : 'which', ['antd'], {
@@ -43,9 +59,13 @@ export function detectPackageManager(): PackageManager | null {
     }).trim();
     if (!binPath) return null;
     // Take first line in case of multiple matches
-    const firstPath = binPath.split('\n')[0].trim();
-    return inferPackageManagerFromPath(firstPath);
+    return binPath.split(/\r?\n/)[0].trim() || null;
   } catch {
     return null;
   }
+}
+
+export function detectPackageManager(): PackageManager | null {
+  const binPath = findAntdBinaryPath();
+  return binPath ? inferPackageManagerFromPath(binPath) : null;
 }

--- a/src/utils/update-check.ts
+++ b/src/utils/update-check.ts
@@ -1,6 +1,8 @@
 import { compare, valid } from '../data/version.js';
+import stringWidth from 'string-width';
 import { cacheStore } from './store.js';
 import { fetchFirstJson } from './fetch.js';
+import { findAntdBinaryPath, inferPackageManagerFromPath, UPGRADE_COMMANDS } from './detect-pm.js';
 
 declare const __CLI_VERSION__: string;
 
@@ -19,16 +21,21 @@ export async function fetchLatestVersion(): Promise<string | null> {
 
 function printUpdateNotice(currentVersion: string, latestVersion: string): void {
   const line = `  Update available: ${currentVersion} → ${latestVersion}  `;
+  const binPath = findAntdBinaryPath();
+  const packageManager = binPath ? inferPackageManagerFromPath(binPath) : 'npm';
+  const upgrade = UPGRADE_COMMANDS[packageManager];
+  const running = binPath ? `  Running: ${binPath}  ` : null;
   const cmd = '  Run: antd upgrade  ';
-  const install = '  Or: npm i -g @ant-design/cli  ';
-  const width = Math.max(line.length, cmd.length, install.length);
-  const pad = (s: string) => s + ' '.repeat(width - s.length);
+  const install = `  Or: ${upgrade.cmd} ${upgrade.args.join(' ')}  `;
+  const lines = [line, running, cmd, install].filter((item): item is string => item !== null);
+  const width = Math.max(...lines.map((item) => stringWidth(item)));
+  const pad = (s: string) => s + ' '.repeat(width - stringWidth(s));
   const bar = '─'.repeat(width);
 
   process.stderr.write(`\n╭${bar}╮\n`);
-  process.stderr.write(`│${pad(line)}│\n`);
-  process.stderr.write(`│${pad(cmd)}│\n`);
-  process.stderr.write(`│${pad(install)}│\n`);
+  for (const item of lines) {
+    process.stderr.write(`│${pad(item)}│\n`);
+  }
   process.stderr.write(`╰${bar}╯\n`);
 }
 


### PR DESCRIPTION
## Summary

- show the active `antd` executable path in update notices
- infer the matching package manager from that path
- print a package-manager-specific global install command with `@latest`

This makes PATH shadowing and mixed global installs visible when a newer CLI is already installed elsewhere.

## Testing

- `npm run build`
- `npm run typecheck`
- `npx vitest run --exclude src/__tests__/snapshots/migrate.test.ts` (50 files, 686 tests)

Closes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新提示现在会显示当前 CLI 的运行路径。
  - 根据检测到的包管理器，自动展示匹配的全局安装命令。
- **问题修复**
  - 优化中文及不同长度路径下的提示框排版，确保各行显示宽度一致。
  - 改进对 pnpm、Yarn 及 Windows 路径的识别，提升更新检查的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->