### PR TITLE
fix: report deprecated List usage

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -637,7 +637,7 @@ Note: This is complementary to ESLint. `antd lint` focuses on antd-specific know
 
 **Rule categories:**
 
-- **deprecated** — Deprecated props (with replacement info from metadata) and deprecated components (`BackTop` → `FloatButton.BackTop`, `Button.Group` / `Input.Group` → `Space.Compact`). Deprecated prop detection uses AST traversal to precisely match props to their owning JSX element, eliminating false positives from sibling components.
+- **deprecated** — Deprecated props (with replacement info from metadata) and deprecated components. Component-level `Deprecated Notice` blocks in bundled metadata are reported automatically and localized by `--lang` (for example, `List` in antd v6); named aliases, root namespace/default imports, component subpath imports, and member usage resolve to their canonical antd component. Legacy structural rules include `BackTop` → `FloatButton.BackTop` and `Button.Group` / `Input.Group` → `Space.Compact`. Deprecated prop detection uses AST traversal to precisely match props to their owning JSX element, eliminating false positives from sibling components.
 - **a11y** — Accessibility: missing `alt` on Image, missing `aria-label` on clickable icons
 - **usage** — Prop combination mistakes detected from antd runtime warnings:
   - Form.Item `shouldUpdate` + `dependencies` conflict

--- a/src/__tests__/commands/lint.test.ts
+++ b/src/__tests__/commands/lint.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { chmodSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import type { LintIssue } from '../../commands/lint.js';
+import { getDeprecatedComponents, type LintIssue } from '../../commands/lint.js';
 import { run, runCLI } from '../helper.js';
 
 describe('lint', () => {
@@ -463,6 +463,206 @@ const App = () => (
     );
     const data = JSON.parse(out);
     expect(data.issues.some((i: LintIssue) => i.rule === 'deprecated' && i.message.includes('BackTop'))).toBe(true);
+  });
+
+  it('should report components marked by a metadata deprecation notice', async () => {
+    const out = await lintFixture(
+      'deprecated-list-v6',
+      `import { List } from 'antd';\nconst App = () => <List />;`,
+      ['--only', 'deprecated', '--format', 'json'],
+      '6.5.3',
+    );
+    const data = JSON.parse(out);
+    const issue = data.issues.find(
+      (item: LintIssue) => item.rule === 'deprecated' && item.message.includes('List'),
+    );
+    expect(issue).toBeDefined();
+    expect(issue.message).toContain('removed in the next major version');
+  });
+
+  it.each([
+    {
+      name: 'named-alias',
+      code: `import { List as AntList } from 'antd';\nconst App = () => <AntList />;`,
+    },
+    {
+      name: 'namespace',
+      code: `import * as Antd from 'antd';\nconst App = () => <Antd.List />;`,
+    },
+    {
+      name: 'default-root',
+      code: `import Antd from 'antd';\nconst App = () => <Antd.List />;`,
+    },
+    {
+      name: 'default-subpath',
+      code: `import AntList from 'antd/es/list';\nconst App = () => <AntList />;`,
+    },
+    {
+      name: 'member',
+      code: `import { List } from 'antd';\nconst App = () => <List.Item />;`,
+    },
+  ])('should resolve deprecated components through $name imports', async ({ name, code }) => {
+    const out = await lintFixture(
+      `deprecated-list-${name}`,
+      code,
+      ['--only', 'deprecated', '--format', 'json'],
+      '6.5.3',
+    );
+    const data = JSON.parse(out);
+    const listIssues = data.issues.filter(
+      (item: LintIssue) => item.rule === 'deprecated' && item.message.includes('List'),
+    );
+    expect(listIssues).toHaveLength(1);
+  });
+
+  it('should resolve a deprecated component from a custom alias subpath', async () => {
+    const out = await lintFixture(
+      'deprecated-list-custom-subpath',
+      `import AntList from '@my/antd/es/list';\nconst App = () => <AntList />;`,
+      ['--antd-alias', '@my/antd', '--only', 'deprecated', '--format', 'json'],
+      '6.5.3',
+    );
+    const data = JSON.parse(out);
+    expect(data.issues).toHaveLength(1);
+    expect(data.issues[0].message).toContain('List');
+  });
+
+  it('should not treat a component style subpath as the component', async () => {
+    const out = await lintFixture(
+      'deprecated-list-style-subpath',
+      `import ListStyles from 'antd/es/list/style';\nconst App = () => <ListStyles />;`,
+      ['--only', 'deprecated', '--format', 'json'],
+      '6.5.3',
+    );
+    const data = JSON.parse(out);
+    expect(data.issues).toHaveLength(0);
+  });
+
+  it('should not report a shadowing local List component as deprecated', async () => {
+    const out = await lintFixture(
+      'deprecated-list-shadowed',
+      `import { List } from 'antd';\nconst App = ({ List }: { List: React.ComponentType }) => <List />;`,
+      ['--only', 'deprecated', '--format', 'json'],
+      '6.5.3',
+    );
+    const data = JSON.parse(out);
+    expect(data.issues).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      name: 'function',
+      code: `import { List } from 'antd';\nconst App = () => { function List() { return null; } return <List />; };`,
+    },
+    {
+      name: 'class',
+      code: `import { List } from 'antd';\nconst App = () => { class List {} return <List />; };`,
+    },
+    {
+      name: 'namespace-function',
+      code: `import * as Antd from 'antd';\nconst App = () => { function Antd() { return null; } return <Antd.List />; };`,
+    },
+    {
+      name: 'hoisted-function-after-jsx',
+      code: `import { List } from 'antd';\nconst App = () => { const node = <List />; function List() { return null; } return node; };`,
+    },
+    {
+      name: 'function-scoped-var',
+      code: `import { List } from 'antd';\nconst App = () => { if (true) { var List = () => null; } return <List />; };`,
+    },
+    {
+      name: 'named-function-expression',
+      code: `import { List } from 'antd';\nconst App = function List() { return <List />; };`,
+    },
+    {
+      name: 'named-class-expression',
+      code: `import { List } from 'antd';\nconst App = class List { render() { return <List />; } };`,
+    },
+  ])('should not report components shadowed by a $name declaration', async ({ name, code }) => {
+    const out = await lintFixture(
+      `deprecated-list-shadowed-${name}`,
+      code,
+      ['--only', 'deprecated', '--format', 'json'],
+      '6.5.3',
+    );
+    const data = JSON.parse(out);
+    expect(data.issues).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      name: 'for-loop',
+      code: `import { List } from 'antd';\nconst App = ({ items }: any) => { for (let List of items) {} return <List />; };`,
+    },
+    {
+      name: 'for-in-loop',
+      code: `import { List } from 'antd';\nconst App = ({ items }: any) => { for (let List in items) {} return <List />; };`,
+    },
+    {
+      name: 'switch',
+      code: `import { List } from 'antd';\nconst App = () => { switch (1) { case 1: let List = 1; break; } return <List />; };`,
+    },
+    {
+      name: 'static-block',
+      code: `import { List } from 'antd';\nclass Holder { static { let List = 1; } }\nconst App = () => <List />;`,
+    },
+    {
+      name: 'import-after-jsx',
+      code: `const App = () => <List />;\nimport { List } from 'antd';`,
+    },
+  ])('should keep antd imports visible outside a $name scope', async ({ name, code }) => {
+    const out = await lintFixture(
+      `deprecated-list-scope-${name}`,
+      code,
+      ['--only', 'deprecated', '--format', 'json'],
+      '6.5.3',
+    );
+    const data = JSON.parse(out);
+    expect(data.issues).toHaveLength(1);
+    expect(data.issues[0].message).toContain('List');
+  });
+
+  it('should localize metadata component deprecation notices', async () => {
+    const out = await lintFixture(
+      'deprecated-list-zh',
+      `import { List } from 'antd';\nconst App = () => <List />;`,
+      ['--only', 'deprecated', '--format', 'json', '--lang', 'zh'],
+      '6.5.3',
+    );
+    const data = JSON.parse(out);
+    expect(data.issues).toHaveLength(1);
+    expect(data.issues[0].message).toContain('List 组件已经进入废弃阶段');
+  });
+
+  it('should keep fallback component deprecation messages in one language', () => {
+    const englishOnly = {
+      components: [{
+        name: 'Legacy',
+        whenToUse: ':::warning{ title = "Deprecated Notice" }\nEnglish detail.\n:::',
+      }],
+    } as any;
+    const chineseOnly = {
+      components: [{
+        name: 'Legacy',
+        whenToUseZh: ':::warning{title=废弃提示}\n中文详情。\n:::',
+      }],
+    } as any;
+
+    expect(getDeprecatedComponents(englishOnly, 'zh').get('Legacy'))
+      .toBe('`Legacy` is deprecated. English detail.');
+    expect(getDeprecatedComponents(chineseOnly, 'en').get('Legacy'))
+      .toBe('`Legacy` 已废弃。中文详情。');
+  });
+
+  it('should not report List as deprecated when its metadata has no deprecation notice', async () => {
+    const out = await lintFixture(
+      'list-v5',
+      `import { List } from 'antd';\nconst App = () => <List />;`,
+      ['--only', 'deprecated', '--format', 'json'],
+      '5.29.3',
+    );
+    const data = JSON.parse(out);
+    expect(data.issues).toHaveLength(0);
   });
 
   it('should warn on Button.Group deprecation', async () => {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -8,7 +8,13 @@ import { parseSync, Visitor } from 'oxc-parser';
 import { loadMetadataForVersion } from '../data/loader.js';
 import { detectVersion } from '../data/version.js';
 import { formatTable, output } from '../output/formatter.js';
-import { collectFiles, getJSXElementName, SCAN_EXTENSIONS, SKIP_DIRS } from '../utils/scan.js';
+import {
+  collectFiles,
+  getJSXElementName,
+  normalizeComponentKey,
+  SCAN_EXTENSIONS,
+  SKIP_DIRS,
+} from '../utils/scan.js';
 
 export interface LintIssue {
   file: string;
@@ -42,6 +48,33 @@ function getDeprecatedProps(store: ReturnType<typeof loadMetadataForVersion>): M
         };
       }));
     }
+  }
+  return result;
+}
+
+function extractDeprecatedNotice(source: string | undefined): string | undefined {
+  const notice = source?.match(
+    /:::warning\{\s*title\s*=\s*["']?(?:Deprecated Notice|废弃提示)["']?\s*\}\s*([\s\S]*?)\s*:::/,
+  );
+  return notice?.[1]?.replace(/\s+/g, ' ').trim();
+}
+
+export function getDeprecatedComponents(
+  store: ReturnType<typeof loadMetadataForVersion>,
+  lang: string,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const comp of store.components) {
+    const englishDetail = extractDeprecatedNotice(comp.whenToUse);
+    const chineseDetail = extractDeprecatedNotice(comp.whenToUseZh);
+    const englishMessage = englishDetail && `\`${comp.name}\` is deprecated. ${englishDetail}`;
+    const chineseMessage = chineseDetail && `\`${comp.name}\` 已废弃。${chineseDetail}`;
+    const fallbackMessage = englishMessage ?? chineseMessage;
+    if (!fallbackMessage) continue;
+    result.set(
+      comp.name,
+      localize(englishMessage ?? fallbackMessage, chineseMessage ?? fallbackMessage, lang),
+    );
   }
   return result;
 }
@@ -145,6 +178,115 @@ function collectPatternNames(pattern: any, names: string[] = []): string[] {
   return names;
 }
 
+type BindingScopeKind = 'program' | 'function' | 'block' | 'catch' | 'class' | 'loop' | 'switch' | 'static';
+
+function collectScopeBindings(program: any): Map<any, Set<string>> {
+  const bindings = new Map<any, Set<string>>();
+  const scopeStack: { node: any; kind: BindingScopeKind }[] = [];
+
+  const pushScope = (node: any, kind: BindingScopeKind) => {
+    bindings.set(node, new Set());
+    scopeStack.push({ node, kind });
+  };
+  const declareIn = (scope: { node: any }, pattern: any) => {
+    const names = bindings.get(scope.node)!;
+    for (const name of collectPatternNames(pattern)) names.add(name);
+  };
+  const currentScope = () => scopeStack[scopeStack.length - 1];
+  const nearestFunctionScope = () => [...scopeStack].reverse().find(
+    ({ kind }) => kind === 'function' || kind === 'program' || kind === 'static',
+  )!;
+  const pushFunctionScope = (node: any) => {
+    pushScope(node, 'function');
+    if (node.type === 'FunctionExpression' && node.id) declareIn(currentScope(), node.id);
+    for (const param of node.params ?? []) declareIn(currentScope(), param);
+  };
+
+  pushScope(program, 'program');
+  const visitor = new Visitor({
+    BlockStatement(node: any) {
+      pushScope(node, 'block');
+    },
+    'BlockStatement:exit'() {
+      scopeStack.pop();
+    },
+    FunctionDeclaration(node: any) {
+      declareIn(currentScope(), node.id);
+      pushFunctionScope(node);
+    },
+    'FunctionDeclaration:exit'() {
+      scopeStack.pop();
+    },
+    FunctionExpression: pushFunctionScope,
+    'FunctionExpression:exit'() {
+      scopeStack.pop();
+    },
+    ArrowFunctionExpression: pushFunctionScope,
+    'ArrowFunctionExpression:exit'() {
+      scopeStack.pop();
+    },
+    ClassDeclaration(node: any) {
+      declareIn(currentScope(), node.id);
+      pushScope(node, 'class');
+      declareIn(currentScope(), node.id);
+    },
+    'ClassDeclaration:exit'() {
+      scopeStack.pop();
+    },
+    ClassExpression(node: any) {
+      pushScope(node, 'class');
+      if (node.id) declareIn(currentScope(), node.id);
+    },
+    'ClassExpression:exit'() {
+      scopeStack.pop();
+    },
+    ForStatement(node: any) {
+      pushScope(node, 'loop');
+    },
+    'ForStatement:exit'() {
+      scopeStack.pop();
+    },
+    ForInStatement(node: any) {
+      pushScope(node, 'loop');
+    },
+    'ForInStatement:exit'() {
+      scopeStack.pop();
+    },
+    ForOfStatement(node: any) {
+      pushScope(node, 'loop');
+    },
+    'ForOfStatement:exit'() {
+      scopeStack.pop();
+    },
+    SwitchStatement(node: any) {
+      pushScope(node, 'switch');
+    },
+    'SwitchStatement:exit'() {
+      scopeStack.pop();
+    },
+    StaticBlock(node: any) {
+      pushScope(node, 'static');
+    },
+    'StaticBlock:exit'() {
+      scopeStack.pop();
+    },
+    CatchClause(node: any) {
+      pushScope(node, 'catch');
+      if (node.param) declareIn(currentScope(), node.param);
+    },
+    'CatchClause:exit'() {
+      scopeStack.pop();
+    },
+    VariableDeclaration(node: any) {
+      const target = node.kind === 'var' ? nearestFunctionScope() : currentScope();
+      for (const declaration of node.declarations ?? []) declareIn(target, declaration.id);
+    },
+  });
+  visitor.visit(program);
+  scopeStack.pop();
+  return bindings;
+}
+
 const STATIC_FEEDBACK_METHODS: Record<string, string[]> = {
   message: ['open', 'success', 'error', 'info', 'warning', 'warn', 'loading'],
   notification: ['open', 'success', 'error', 'info', 'warning', 'warn'],
@@ -182,6 +324,26 @@ function matchesAntdAlias(source: string, antdAliases: string[]): boolean {
   return antdAliases.some((antdAlias) => source === antdAlias || source.startsWith(`${antdAlias}/`));
 }
 
+function getComponentFromSubpath(
+  source: string,
+  antdAliases: string[],
+  componentBySubpath: Map<string, string>,
+): string | undefined {
+  const matchedAlias = [...antdAliases]
+    .sort((a, b) => b.length - a.length)
+    .find((antdAlias) => source.startsWith(`${antdAlias}/`))!;
+
+  const parts = source.slice(matchedAlias.length + 1).split('/');
+  const componentParts = parts[0] === 'es' || parts[0] === 'lib' ? parts.slice(1) : parts;
+  if (componentParts.includes('style') || componentParts.includes('locale')) return undefined;
+
+  for (let i = componentParts.length - 1; i >= 0; i--) {
+    const componentName = componentBySubpath.get(normalizeComponentKey(componentParts[i]));
+    if (componentName) return componentName;
+  }
+  return undefined;
+}
+
 function isLocalePath(source: string, antdAliases: string[]): boolean {
   return antdAliases.some(
     (alias) =>
@@ -201,6 +363,77 @@ function isNonModuleSource(source: string): boolean {
   const match = /\.([^./]+)$/.exec(source);
   if (!match) return false;
   return !MODULE_EXTENSIONS.has(match[1].toLowerCase());
+}
+
+interface CollectedAntdImports {
+  importedComponents: Set<string>;
+  antdImportLocals: Map<string, string>;
+  antdRootImportLocals: Set<string>;
+  performanceImports: {
+    node: any;
+    source: string;
+    localName: string;
+    kind: 'namespace' | 'default';
+  }[];
+}
+
+function collectAntdImports(
+  program: any,
+  antdAliases: string[],
+  componentBySubpath: Map<string, string>,
+): CollectedAntdImports {
+  const importedComponents = new Set<string>();
+  const antdImportLocals = new Map<string, string>();
+  const antdRootImportLocals = new Set<string>();
+  const performanceImports: CollectedAntdImports['performanceImports'] = [];
+
+  const visitor = new Visitor({
+    ImportDeclaration(node: any) {
+      const source = node.source.value;
+      if (!matchesAntdAlias(source, antdAliases) || node.importKind === 'type') return;
+
+      const isRootImport = antdAliases.includes(source);
+      for (const spec of node.specifiers) {
+        if (spec.type === 'ImportSpecifier' && spec.importKind !== 'type') {
+          const name = spec.imported?.name || spec.local?.name;
+          const localName = spec.local?.name || name;
+          if (name) importedComponents.add(name);
+          if (name && localName) antdImportLocals.set(localName, name);
+        }
+
+        if (spec.type === 'ImportNamespaceSpecifier' && isRootImport) {
+          antdRootImportLocals.add(spec.local?.name ?? '');
+        }
+
+        if (spec.type === 'ImportDefaultSpecifier') {
+          const localName = spec.local?.name;
+          if (localName && isRootImport) {
+            antdRootImportLocals.add(localName);
+          } else if (localName) {
+            const componentName = getComponentFromSubpath(source, antdAliases, componentBySubpath);
+            if (componentName) {
+              importedComponents.add(componentName);
+              antdImportLocals.set(localName, componentName);
+            }
+          }
+        }
+
+        const isNamespace = spec.type === 'ImportNamespaceSpecifier';
+        const isDefault = spec.type === 'ImportDefaultSpecifier';
+        if ((isNamespace || isDefault) && !isLocalePath(source, antdAliases) && !isNonModuleSource(source)) {
+          performanceImports.push({
+            node,
+            source,
+            localName: spec.local?.name ?? '',
+            kind: isNamespace ? 'namespace' : 'default',
+          });
+        }
+      }
+    },
+  });
+  visitor.visit(program);
+
+  return { importedComponents, antdImportLocals, antdRootImportLocals, performanceImports };
 }
 
 function mayContainAntdAlias(content: string, antdAliases: string[]): boolean {
@@ -294,6 +527,8 @@ function collectGitFiles(targetPath: string, mode: 'diff' | 'staged', diff?: boo
 function lintFile(
   filePath: string,
   deprecatedMap: Map<string, DeprecatedInfo[]>,
+  deprecatedComponents: Map<string, string>,
+  componentBySubpath: Map<string, string>,
   antdAliases: string[],
   antdMajor: number,
   only?: string,
@@ -330,8 +565,12 @@ function lintFile(
   }
 
   const issues: LintIssue[] = [];
-  const importedComponents = new Set<string>();
-  const antdImportLocals = new Map<string, string>();
+  const {
+    importedComponents,
+    antdImportLocals,
+    antdRootImportLocals,
+    performanceImports,
+  } = collectAntdImports(result.program, antdAliases, componentBySubpath);
   const offsetToLine = createLineMapper(content);
   const enableV5UsageRules = antdMajor >= 5;
 
@@ -350,53 +589,83 @@ function lintFile(
   const isInsideComponent = (name: string): boolean => jsxAncestorStack.includes(name);
 
   // Track namespace/default import usage for performance rule suggestions
-  const pendingPerformanceIssues: { line: number; source: string; localName: string; kind: 'namespace' | 'default' }[] = [];
-  const namespaceMemberUsage = new Map<string, Set<string>>();
-  const scopeStack: Set<string>[] = [new Set()];
-
-  const declarePattern = (pattern: any) => {
-    const currentScope = scopeStack[scopeStack.length - 1];
-    for (const name of collectPatternNames(pattern)) {
-      currentScope.add(name);
-    }
-  };
+  const pendingPerformanceIssues = (!only || only === 'performance')
+    ? performanceImports.map(({ node, ...item }) => ({ line: lineOf(node), ...item }))
+    : [];
+  const namespaceMemberUsage = new Map(
+    pendingPerformanceIssues.map((item) => [item.localName, new Set<string>()]),
+  );
+  const scopeBindings = collectScopeBindings(result.program);
+  const scopeStack: Set<string>[] = [scopeBindings.get(result.program) ?? new Set()];
+  const pushScope = (node: any) => scopeStack.push(scopeBindings.get(node) ?? new Set());
 
   const isShadowed = (name: string): boolean => scopeStack.some((scope) => scope.has(name));
 
-  const pushFunctionScope = (node: any) => {
-    scopeStack.push(new Set());
-    for (const param of node.params ?? []) declarePattern(param);
+  const resolveCanonicalComponent = (
+    compName: string,
+  ): { root: string; full: string } | null => {
+    const [localRoot, ...members] = compName.split('.');
+    if (!localRoot || isShadowed(localRoot)) return null;
+
+    const importedRoot = antdImportLocals.get(localRoot);
+    if (importedRoot) {
+      return { root: importedRoot, full: [importedRoot, ...members].join('.') };
+    }
+    if (antdRootImportLocals.has(localRoot) && members.length > 0) {
+      return { root: members[0], full: members.join('.') };
+    }
+    return null;
   };
 
   // Single pass: collect imports and check all rules
   const visitor = new Visitor({
-    BlockStatement() {
-      scopeStack.push(new Set());
-    },
+    BlockStatement: pushScope,
     'BlockStatement:exit'() {
       scopeStack.pop();
     },
-    FunctionDeclaration: pushFunctionScope,
+    FunctionDeclaration: pushScope,
     'FunctionDeclaration:exit'() {
       scopeStack.pop();
     },
-    FunctionExpression: pushFunctionScope,
+    FunctionExpression: pushScope,
     'FunctionExpression:exit'() {
       scopeStack.pop();
     },
-    ArrowFunctionExpression: pushFunctionScope,
+    ArrowFunctionExpression: pushScope,
     'ArrowFunctionExpression:exit'() {
       scopeStack.pop();
     },
-    CatchClause(node: any) {
-      scopeStack.push(new Set());
-      if (node.param) declarePattern(node.param);
-    },
-    'CatchClause:exit'() {
+    ClassDeclaration: pushScope,
+    'ClassDeclaration:exit'() {
       scopeStack.pop();
     },
-    VariableDeclarator(node: any) {
-      declarePattern(node.id);
+    ClassExpression: pushScope,
+    'ClassExpression:exit'() {
+      scopeStack.pop();
+    },
+    ForStatement: pushScope,
+    'ForStatement:exit'() {
+      scopeStack.pop();
+    },
+    ForInStatement: pushScope,
+    'ForInStatement:exit'() {
+      scopeStack.pop();
+    },
+    ForOfStatement: pushScope,
+    'ForOfStatement:exit'() {
+      scopeStack.pop();
+    },
+    SwitchStatement: pushScope,
+    'SwitchStatement:exit'() {
+      scopeStack.pop();
+    },
+    StaticBlock: pushScope,
+    'StaticBlock:exit'() {
+      scopeStack.pop();
+    },
+    CatchClause: pushScope,
+    'CatchClause:exit'() {
+      scopeStack.pop();
     },
     JSXElement(node: any) {
       const elName = getJSXElementName(node.openingElement?.name);
@@ -404,36 +673,6 @@ function lintFile(
     },
     'JSXElement:exit'() {
       jsxAncestorStack.pop();
-    },
-
-    ImportDeclaration(node: any) {
-      const source = node.source.value;
-      if (!matchesAntdAlias(source, antdAliases)) return;
-
-      if (node.importKind === 'type') return;
-
-      for (const spec of node.specifiers) {
-        if (spec.type === 'ImportSpecifier') {
-          if (spec.importKind === 'type') continue;
-          const name = spec.imported?.name || spec.local?.name;
-          const localName = spec.local?.name || name;
-          if (name) importedComponents.add(name);
-          if (name && localName) antdImportLocals.set(localName, name);
-        }
-
-        if (!only || only === 'performance') {
-          const isNamespace = spec.type === 'ImportNamespaceSpecifier';
-          const isDefault = spec.type === 'ImportDefaultSpecifier';
-          if ((isNamespace || isDefault) && !isLocalePath(source, antdAliases) && !isNonModuleSource(source)) {
-            const localName = spec.local?.name ?? '';
-            pendingPerformanceIssues.push({
-              line: lineOf(node), source, localName,
-              kind: isNamespace ? 'namespace' : 'default',
-            });
-            namespaceMemberUsage.set(localName, new Set());
-          }
-        }
-      }
     },
 
     CallExpression(node: any) {
@@ -469,26 +708,30 @@ function lintFile(
 
       // --- Deprecated checks ---
       if (!only || only === 'deprecated') {
-        if (compName === 'BackTop' && importedComponents.has('BackTop')) {
+        const canonicalComponent = resolveCanonicalComponent(compName);
+        if (canonicalComponent?.full === 'BackTop') {
           report('deprecated', 'warning', line, '`BackTop` is deprecated, use `FloatButton.BackTop` instead');
         }
-        if (compName === 'Button.Group' && importedComponents.has('Button')) {
+        if (canonicalComponent?.full === 'Button.Group') {
           report('deprecated', 'warning', line, '`Button.Group` is deprecated, use `Space.Compact` instead');
         }
-        if (compName === 'Input.Group' && importedComponents.has('Input')) {
+        if (canonicalComponent?.full === 'Input.Group') {
           report('deprecated', 'warning', line, '`Input.Group` is deprecated, use `Space.Compact` instead');
         }
 
-        const baseName = compName.includes('.') ? compName.split('.')[0] : compName;
-        if (importedComponents.has(baseName) || importedComponents.has(compName)) {
-          const deprecations = deprecatedMap.get(compName);
+        if (canonicalComponent) {
+          const componentNotice = deprecatedComponents.get(canonicalComponent.root);
+          if (componentNotice) {
+            report('deprecated', 'warning', line, componentNotice);
+          }
+          const deprecations = deprecatedMap.get(canonicalComponent.full);
           if (deprecations) {
             for (const attr of attrs) {
               if (attr.type !== 'JSXAttribute') continue;
               const propName = attr.name?.name;
               const dep = deprecations.find((d) => d.prop === propName);
               if (dep) {
-                report('deprecated', 'warning', lineOf(attr) || line, `${compName} ${dep.message}`);
+                report('deprecated', 'warning', lineOf(attr) || line, `${canonicalComponent.full} ${dep.message}`);
               }
             }
           }
@@ -657,6 +900,10 @@ export function registerLintCommand(program: Command): void {
       const versionInfo = detectVersion(opts.version);
       const store = loadMetadataForVersion(versionInfo.version);
       const deprecatedMap = getDeprecatedProps(store);
+      const deprecatedComponents = getDeprecatedComponents(store, opts.lang);
+      const componentBySubpath = new Map(
+        store.components.map((component) => [normalizeComponentKey(component.name), component.name]),
+      );
       const antdAliases = normalizeAntdAliases(cmdOpts.antdAlias);
 
       let files: string[];
@@ -673,7 +920,7 @@ export function registerLintCommand(program: Command): void {
       const skippedFiles: SkippedFile[] = [];
 
       for (const file of files) {
-        const result = lintFile(file, deprecatedMap, antdAliases, parseInt(versionInfo.majorVersion.slice(1), 10), cmdOpts.only);
+        const result = lintFile(file, deprecatedMap, deprecatedComponents, componentBySubpath, antdAliases, parseInt(versionInfo.majorVersion.slice(1), 10), cmdOpts.only);
         allIssues.push(...result.issues);
         if (result.skipped) skippedFiles.push(result.skipped);
       }


### PR DESCRIPTION
## Summary

- derive component-level deprecations from bundled `Deprecated Notice` metadata
- report `List` usage as deprecated for antd v6
- keep antd v5 behavior unchanged
- document the metadata-driven lint rule

## Testing

- `npm run build`
- `npm run typecheck`
- `npx vitest run --exclude src/__tests__/snapshots/migrate.test.ts` (50 files, 687 tests)

Closes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持识别组件级 `Deprecated Notice` 元数据，并根据 `--lang` 提供本地化废弃提示。
  * 支持解析组件别名、默认导入、命名空间导入、子路径导入及成员用法。
* **问题修复**
  * 改进废弃组件检测，减少因局部变量遮蔽、作用域差异或样式等非组件资源导致的误报。
  * 支持语言回退，并兼容缺少废弃元数据的旧版本组件。
* **文档**
  * 更新 `deprecated` 规则说明，明确包含组件级废弃提示及本地化支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->