### PR TITLE
feat: remember upgrade package manager

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -821,11 +821,12 @@ Upgrade the CLI itself to the latest version published on npm.
 
 ```bash
 antd upgrade                        # upgrade to latest version
+antd upgrade --package-manager pnpm # select and remember the package manager
 antd upgrade --format json          # structured JSON output
 antd upgrade --lang zh              # Chinese output
 ```
 
-The command automatically detects which package manager was used to install the CLI by resolving the binary path (`which antd` on Unix, `where antd` on Windows) and matching path keywords:
+The command accepts `--package-manager npm|yarn|pnpm|bun|cnpm|utoo`. An explicit selection is saved in the user config and reused by later upgrades. Without a saved selection, the command detects which package manager was used to install the CLI by resolving the binary path (`which antd` on Unix, `where antd` on Windows) and matching path keywords:
 
 | Path Keyword | Package Manager |
 |---|---|
@@ -854,7 +855,7 @@ Each package manager uses its own global upgrade command:
 1. Fetch the latest version from npm (reuses the existing `fetchLatestVersion()` with 3-mirror race: npmjs, npmmirror, unpkg)
 2. Compare with current CLI version (`__CLI_VERSION__`)
 3. If already up to date, output and exit 0
-4. Detect the package manager from the binary path; if detection fails, print error with manual command suggestion and exit 1
+4. Resolve the package manager from an explicit option, then saved user config, then the binary path; if all methods fail, print an error with a manual command suggestion and exit 1
 5. Execute the corresponding upgrade command via `child_process.spawn` (120s timeout, `stdio: 'inherit'` for passthrough, `shell: true` on Windows for `.cmd` compatibility)
 6. Verify the upgraded version by running `antd --cli-version`; if version unchanged, warn and exit 2
 

--- a/src/__tests__/commands/upgrade.test.ts
+++ b/src/__tests__/commands/upgrade.test.ts
@@ -19,9 +19,19 @@ vi.mock('../../utils/update-check.js', () => ({
   checkForUpdate: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../../utils/store.js', () => ({
+  configStore: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
 // Mock detect-pm module
 vi.mock('../../utils/detect-pm.js', () => ({
   detectPackageManager: vi.fn(() => null),
+  PACKAGE_MANAGERS: ['npm', 'yarn', 'pnpm', 'bun', 'cnpm', 'utoo'],
+  isPackageManager: (value: unknown) =>
+    typeof value === 'string' && ['npm', 'yarn', 'pnpm', 'bun', 'cnpm', 'utoo'].includes(value),
   UPGRADE_COMMANDS: {
     npm: { cmd: 'npm', args: ['install', '-g', '@ant-design/cli@latest'] },
     yarn: { cmd: 'yarn', args: ['global', 'add', '@ant-design/cli@latest'] },
@@ -48,6 +58,7 @@ import { spawn, execFile } from 'node:child_process';
 import { fetchLatestVersion } from '../../utils/update-check.js';
 import { detectPackageManager } from '../../utils/detect-pm.js';
 import { compare, valid } from '../../data/version.js';
+import { configStore } from '../../utils/store.js';
 
 const mockSpawn = vi.mocked(spawn);
 const mockExecFile = vi.mocked(execFile);
@@ -55,6 +66,8 @@ const mockFetchLatestVersion = vi.mocked(fetchLatestVersion);
 const mockDetectPackageManager = vi.mocked(detectPackageManager);
 const mockCompare = vi.mocked(compare);
 const mockValid = vi.mocked(valid);
+const mockConfigGet = vi.mocked(configStore.get);
+const mockConfigSet = vi.mocked(configStore.set);
 
 function createMockChildProcess(exitCode: number): ChildProcess {
   const cp = new EventEmitter() as ChildProcess;
@@ -78,6 +91,7 @@ describe('upgrade command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDetectPackageManager.mockReturnValue('npm');
+    mockConfigGet.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -125,6 +139,54 @@ describe('upgrade command', () => {
     expect(result.stdout).toContain('npm install -g');
     expect(result.stdout).toContain('Successfully upgraded to v99.0.0');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('persists and uses an explicit package manager override', async () => {
+    mockFetchLatestVersion.mockResolvedValue('99.0.0');
+    mockSpawn.mockReturnValue(createMockChildProcess(0));
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+      (cb as (err: null, stdout: string) => void)(null, '99.0.0');
+      return {} as never;
+    });
+
+    const result = await runCLI('upgrade', '--package-manager', 'pnpm');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('pnpm add -g @ant-design/cli@latest');
+    expect(mockConfigSet).toHaveBeenCalledWith('packageManager', 'pnpm');
+  });
+
+  it('prefers the saved package manager over path detection', async () => {
+    mockConfigGet.mockReturnValue('yarn');
+    mockFetchLatestVersion.mockResolvedValue('99.0.0');
+    mockSpawn.mockReturnValue(createMockChildProcess(0));
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+      (cb as (err: null, stdout: string) => void)(null, '99.0.0');
+      return {} as never;
+    });
+
+    const result = await runCLI('upgrade');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('yarn global add @ant-design/cli@latest');
+    expect(mockDetectPackageManager).not.toHaveBeenCalled();
+  });
+
+  it('ignores an invalid saved package manager and falls back to path detection', async () => {
+    mockConfigGet.mockReturnValue('corepack' as never);
+    mockDetectPackageManager.mockReturnValue('pnpm');
+    mockFetchLatestVersion.mockResolvedValue('99.0.0');
+    mockSpawn.mockReturnValue(createMockChildProcess(0));
+    mockExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+      (cb as (err: null, stdout: string) => void)(null, '99.0.0');
+      return {} as never;
+    });
+
+    const result = await runCLI('upgrade');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('pnpm add -g @ant-design/cli@latest');
+    expect(mockDetectPackageManager).toHaveBeenCalledOnce();
   });
 
   it('upgrades successfully via yarn (JSON format)', async () => {

--- a/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/help.test.ts.snap
@@ -58,8 +58,20 @@ Commands:
   mcp                              Start MCP server for AI assistant integration
   setup [options]                  Set up Ant Design MCP/Skill for AI agents or
                                    GitHub Actions
-  upgrade                          Upgrade the CLI to the latest version
+  upgrade [options]                Upgrade the CLI to the latest version
   bug [options]                    Report a bug to the antd repository
   bug-cli [options]                Report a bug to the ant-design-cli repository
   help [command]                   display help for command"
+`;
+
+exports[`help > upgrade --help 1`] = `
+"Usage: antd upgrade [options]
+
+Upgrade the CLI to the latest version
+
+Options:
+  --package-manager <manager>  Package manager to use and remember for future
+                               upgrades (choices: "npm", "yarn", "pnpm", "bun",
+                               "cnpm", "utoo")
+  -h, --help                   display help for command"
 `;

--- a/src/__tests__/snapshots/help.test.ts
+++ b/src/__tests__/snapshots/help.test.ts
@@ -5,4 +5,8 @@ describe('help', () => {
   it('--help', async () => {
     expect(await run('--help')).toMatchSnapshot();
   });
+
+  it('upgrade --help', async () => {
+    expect(await run('upgrade', '--help')).toMatchSnapshot();
+  });
 });

--- a/src/__tests__/utils/detect-pm.test.ts
+++ b/src/__tests__/utils/detect-pm.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { inferPackageManagerFromPath, detectPackageManager, UPGRADE_COMMANDS } from '../../utils/detect-pm.js';
+import {
+  detectPackageManager,
+  inferPackageManagerFromPath,
+  isPackageManager,
+  PACKAGE_MANAGERS,
+  UPGRADE_COMMANDS,
+} from '../../utils/detect-pm.js';
 import type { PackageManager } from '../../utils/detect-pm.js';
 import * as childProcess from 'node:child_process';
 
@@ -8,6 +14,18 @@ vi.mock('node:child_process', () => ({
 }));
 
 const mockExecFileSync = vi.mocked(childProcess.execFileSync);
+
+describe('isPackageManager', () => {
+  it('accepts every supported package manager', () => {
+    for (const packageManager of PACKAGE_MANAGERS) {
+      expect(isPackageManager(packageManager)).toBe(true);
+    }
+  });
+
+  it.each(['corepack', '', undefined, null, 1])('rejects unsupported value %s', (value) => {
+    expect(isPackageManager(value)).toBe(false);
+  });
+});
 
 describe('inferPackageManagerFromPath', () => {
   it('detects utoo from .utoo path', () => {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,12 +1,19 @@
-import type { Command } from 'commander';
+import { Option, type Command } from 'commander';
 import type { GlobalOptions } from '../types.js';
 import { localize } from '../types.js';
 import { execFile, spawn } from 'node:child_process';
 import { compare, valid } from '../data/version.js';
 import { output } from '../output/formatter.js';
 import { createError, printError, ErrorCodes } from '../output/error.js';
-import { detectPackageManager, UPGRADE_COMMANDS } from '../utils/detect-pm.js';
+import {
+  detectPackageManager,
+  isPackageManager,
+  PACKAGE_MANAGERS,
+  UPGRADE_COMMANDS,
+  type PackageManager,
+} from '../utils/detect-pm.js';
 import { fetchLatestVersion } from '../utils/update-check.js';
+import { configStore } from '../utils/store.js';
 
 declare const __CLI_VERSION__: string;
 
@@ -22,6 +29,10 @@ interface UpgradeSuccessResult {
 }
 
 type UpgradeResult = AlreadyUpToDateResult | UpgradeSuccessResult;
+
+interface UpgradeCommandOptions {
+  packageManager?: PackageManager;
+}
 
 function formatUpgradeMarkdown(data: UpgradeResult, lang: string): string {
   const lines = [`## ${localize('Upgrade', '升级', lang)}`, ''];
@@ -64,9 +75,16 @@ export function registerUpgradeCommand(program: Command): void {
   program
     .command('upgrade')
     .description('Upgrade the CLI to the latest version')
-    .action(async () => {
+    .addOption(
+      new Option('--package-manager <manager>', 'Package manager to use and remember for future upgrades')
+        .choices(PACKAGE_MANAGERS),
+    )
+    .action(async (cmdOpts: UpgradeCommandOptions) => {
       const opts = program.opts<GlobalOptions>();
       const currentVersion = __CLI_VERSION__;
+      if (cmdOpts.packageManager) {
+        configStore.set('packageManager', cmdOpts.packageManager);
+      }
 
       // Step 1: Fetch latest version
       let latestVersion: string | null;
@@ -129,7 +147,9 @@ export function registerUpgradeCommand(program: Command): void {
       }
 
       // Step 3: Detect package manager
-      const pm = detectPackageManager();
+      const savedPackageManager: unknown = configStore.get('packageManager');
+      const pm = cmdOpts.packageManager
+        ?? (isPackageManager(savedPackageManager) ? savedPackageManager : detectPackageManager());
       if (!pm) {
         const err = createError(
           ErrorCodes.PM_NOT_FOUND,

--- a/src/utils/detect-pm.ts
+++ b/src/utils/detect-pm.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 
-export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'cnpm' | 'utoo';
+export const PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm', 'bun', 'cnpm', 'utoo'] as const;
+export type PackageManager = (typeof PACKAGE_MANAGERS)[number];
 
 interface PMRule {
   pm: PackageManager;
@@ -23,6 +24,10 @@ export const UPGRADE_COMMANDS: Record<PackageManager, { cmd: string; args: strin
   cnpm: { cmd: 'cnpm', args: ['install', '-g', '@ant-design/cli@latest'] },
   utoo: { cmd: 'ut', args: ['install', '-g', '@ant-design/cli@latest'] },
 };
+
+export function isPackageManager(value: unknown): value is PackageManager {
+  return typeof value === 'string' && PACKAGE_MANAGERS.includes(value as PackageManager);
+}
 
 export function inferPackageManagerFromPath(binPath: string): PackageManager {
   const normalized = binPath.replace(/\\/g, '/');

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,5 +1,6 @@
 import Conf, { type Options } from 'conf';
 import envPaths from 'env-paths';
+import type { PackageManager } from './detect-pm.js';
 
 const paths = envPaths('antd-cli');
 
@@ -12,7 +13,7 @@ const sharedConfig: Options<any> = {
 // 1. User config store (stored in config dir)
 // ==========================================
 export interface AppConfig {
-  // Add other user preferences here
+  packageManager?: PackageManager;
 }
 
 export const configStore = new Conf<AppConfig>({


### PR DESCRIPTION
## Summary

- add `antd upgrade --package-manager <manager>`
- persist an explicit package-manager choice in the user config
- reuse the saved choice before falling back to executable-path detection
- update help coverage and the command specification

## Testing

- `npm run build`
- `npm run typecheck`
- `npx vitest run --exclude src/__tests__/snapshots/migrate.test.ts` (50 files, 687 tests)

Closes #221