### PR TITLE
fix: remove invalid Button migration steps

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -672,6 +672,8 @@ antd migrate --format json
 
 **Available migration paths:** v3→v4, v4→v5, v5→v6. Multi-version migrations (e.g., v3→v6) are not supported directly — migrate step by step.
 
+The v5→v6 Button guidance keeps `danger` and `ghost` as supported syntactic-sugar props. It may recommend the newer `color` and `variant` APIs through the general `type` migration, but must not report `danger` or `ghost` as removed breaking changes.
+
 Behavior of `--apply <dir>`:
 - Scans the target directory for antd component imports (reuses the `usage` scanning logic)
 - Filters migration steps to only those relevant to the project's actual component usage

--- a/src/__tests__/commands/migrate.test.ts
+++ b/src/__tests__/commands/migrate.test.ts
@@ -86,6 +86,27 @@ describe('migrate', () => {
     expect(out).toContain('variant');
   });
 
+  it('should not report supported Button props as removed in v6', async () => {
+    const info = JSON.parse(await run('info', 'Button', '--version', '6', '--detail', '--format', 'json'));
+    for (const propName of ['danger', 'ghost']) {
+      const prop = info.props.find((item: any) => item.name === propName);
+      expect(prop, `${propName} should remain in the v6 Button metadata`).toBeDefined();
+      expect(prop.deprecated, `${propName} should not be deprecated`).toBeFalsy();
+    }
+
+    const migration = JSON.parse(
+      await run('migrate', '5', '6', '--component', 'Button', '--format', 'json'),
+    );
+    const invalidSteps = migration.steps.filter(
+      (step: any) => {
+        const guidance = `${step.description ?? ''} ${step.migrationGuide ?? ''}`;
+        return /\b(?:danger|ghost)\b/i.test(guidance)
+          && (step.breaking || /\b(?:removed|unsupported|no longer supported)\b/i.test(guidance));
+      },
+    );
+    expect(invalidSteps).toEqual([]);
+  });
+
   it('should handle invalid migration path', async () => {
     const result = await runCLI('migrate', '3', '6');
     expect(result.exitCode).toBe(1);

--- a/src/__tests__/snapshots/__snapshots__/migrate.test.ts.snap
+++ b/src/__tests__/snapshots/__snapshots__/migrate.test.ts.snap
@@ -1398,28 +1398,6 @@ exports[`migrate > migrate 5 6 --format json 1`] = `
     },
     {
       "component": "Button",
-      "breaking": true,
-      "description": "Prop \`danger\` removed. Use \`color=\\"danger\\"\` instead.",
-      "autoFixable": true,
-      "codemod": "v6-danger-migration",
-      "searchPattern": "<Button[^>]*\\\\bdanger\\\\b",
-      "before": "<Button danger>Delete</Button>\\n<Button type=\\"primary\\" danger>Delete</Button>",
-      "after": "<Button color=\\"danger\\">Delete</Button>\\n<Button color=\\"danger\\" variant=\\"solid\\">Delete</Button>",
-      "migrationGuide": "Search for all Button components with \`danger\` prop. Replace with \`color=\\"danger\\"\`. If the button also had \`type=\\"primary\\"\`, add \`variant=\\"solid\\"\`."
-    },
-    {
-      "component": "Button",
-      "breaking": true,
-      "description": "Prop \`ghost\` removed. Use \`variant=\\"outlined\\"\` instead.",
-      "autoFixable": true,
-      "codemod": "v6-ghost-migration",
-      "searchPattern": "<Button[^>]*\\\\bghost\\\\b",
-      "before": "<Button ghost>Ghost</Button>\\n<Button type=\\"primary\\" ghost>Ghost Primary</Button>",
-      "after": "<Button variant=\\"outlined\\">Ghost</Button>\\n<Button color=\\"primary\\" variant=\\"outlined\\">Ghost Primary</Button>",
-      "migrationGuide": "Search for all Button components with \`ghost\` prop. Replace with \`variant=\\"outlined\\"\`. Preserve the color from the original \`type\` prop."
-    },
-    {
-      "component": "Button",
       "breaking": false,
       "description": "\`iconPosition\` deprecated, use \`iconPlacement\` instead.",
       "autoFixable": true,
@@ -1683,8 +1661,8 @@ exports[`migrate > migrate 5 6 --format json 1`] = `
     }
   ],
   "summary": {
-    "total": 42,
-    "autoFixable": 4,
+    "total": 40,
+    "autoFixable": 2,
     "manual": 38
   }
 }"
@@ -1693,7 +1671,7 @@ exports[`migrate > migrate 5 6 --format json 1`] = `
 exports[`migrate > migrate 5 6 --format markdown 1`] = `
 "# Migration Guide: antd v5 → v6
 
-> 42 total steps: 4 auto-fixable, 38 manual
+> 40 total steps: 2 auto-fixable, 38 manual
 
 ## Global
 
@@ -1775,46 +1753,6 @@ Button type prop is decomposed:
 \`\`\`
 
 **Search pattern:** \`<Button[^>]*\\btype\\s*=\\s*['"](?:primary|dashed|link|text)['"]\`
-
-### Prop \`danger\` removed. Use \`color="danger"\` instead.
-
-**BREAKING** | 🔧 auto-fixable
-
-Search for all Button components with \`danger\` prop. Replace with \`color="danger"\`. If the button also had \`type="primary"\`, add \`variant="solid"\`.
-
-**Before:**
-\`\`\`tsx
-<Button danger>Delete</Button>
-<Button type="primary" danger>Delete</Button>
-\`\`\`
-
-**After:**
-\`\`\`tsx
-<Button color="danger">Delete</Button>
-<Button color="danger" variant="solid">Delete</Button>
-\`\`\`
-
-**Search pattern:** \`<Button[^>]*\\bdanger\\b\`
-
-### Prop \`ghost\` removed. Use \`variant="outlined"\` instead.
-
-**BREAKING** | 🔧 auto-fixable
-
-Search for all Button components with \`ghost\` prop. Replace with \`variant="outlined"\`. Preserve the color from the original \`type\` prop.
-
-**Before:**
-\`\`\`tsx
-<Button ghost>Ghost</Button>
-<Button type="primary" ghost>Ghost Primary</Button>
-\`\`\`
-
-**After:**
-\`\`\`tsx
-<Button variant="outlined">Ghost</Button>
-<Button color="primary" variant="outlined">Ghost Primary</Button>
-\`\`\`
-
-**Search pattern:** \`<Button[^>]*\\bghost\\b\`
 
 ### \`iconPosition\` deprecated, use \`iconPlacement\` instead.
 
@@ -2186,8 +2124,6 @@ exports[`migrate > migrate 5 6 --format text 1`] = `
 
   Button:
     🔧 [BREAKING] Prop \`type\` split into \`color\` and \`variant\` for styling. \`type="primary"\` → \`color="primary" variant="solid"\`.
-    🔧 [BREAKING] Prop \`danger\` removed. Use \`color="danger"\` instead.
-    🔧 [BREAKING] Prop \`ghost\` removed. Use \`variant="outlined"\` instead.
     🔧 \`iconPosition\` deprecated, use \`iconPlacement\` instead.
 
   Button.Group:
@@ -2289,5 +2225,5 @@ exports[`migrate > migrate 5 6 --format text 1`] = `
   TreeSelect:
     📝 Multiple deprecated props: \`dropdownClassName\` → \`classNames.popup.root\`, \`dropdownRender\` → \`popupRender\`, \`bordered\` → \`variant\`, \`onDropdownVisibleChange\` → \`onOpenChange\`.
 
-Total: 42 steps (4 auto-fixable, 38 manual)"
+Total: 40 steps (2 auto-fixable, 38 manual)"
 `;

--- a/src/commands/migrate-v5-to-v6.ts
+++ b/src/commands/migrate-v5-to-v6.ts
@@ -64,32 +64,6 @@ export const V5_TO_V6_STEPS: MigrationStep[] = [
   },
   {
     component: 'Button',
-    breaking: true,
-    description: 'Prop `danger` removed. Use `color="danger"` instead.',
-    autoFixable: true,
-    codemod: 'v6-danger-migration',
-    searchPattern: `<Button[^>]*\\bdanger\\b`,
-    before: `<Button danger>Delete</Button>
-<Button type="primary" danger>Delete</Button>`,
-    after: `<Button color="danger">Delete</Button>
-<Button color="danger" variant="solid">Delete</Button>`,
-    migrationGuide: `Search for all Button components with \`danger\` prop. Replace with \`color="danger"\`. If the button also had \`type="primary"\`, add \`variant="solid"\`.`,
-  },
-  {
-    component: 'Button',
-    breaking: true,
-    description: 'Prop `ghost` removed. Use `variant="outlined"` instead.',
-    autoFixable: true,
-    codemod: 'v6-ghost-migration',
-    searchPattern: `<Button[^>]*\\bghost\\b`,
-    before: `<Button ghost>Ghost</Button>
-<Button type="primary" ghost>Ghost Primary</Button>`,
-    after: `<Button variant="outlined">Ghost</Button>
-<Button color="primary" variant="outlined">Ghost Primary</Button>`,
-    migrationGuide: `Search for all Button components with \`ghost\` prop. Replace with \`variant="outlined"\`. Preserve the color from the original \`type\` prop.`,
-  },
-  {
-    component: 'Button',
     breaking: false,
     description: '`iconPosition` deprecated, use `iconPlacement` instead.',
     autoFixable: true,


### PR DESCRIPTION
## Summary

- stop reporting Button `danger` and `ghost` as removed in antd v6
- remove the invalid breaking and auto-fix migration steps
- update text, JSON, and Markdown migration snapshots
- add regression coverage for both supported props

## Testing

- `npm run build`
- `npm run typecheck`
- `npx vitest run --exclude src/__tests__/snapshots/migrate.test.ts` (50 files, 686 tests)
- `npx vitest run src/__tests__/snapshots/migrate.test.ts -t 'migrate 5 6'` (3 tests)

Closes #218