### PR TITLE
docs: expand release notes since v6.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,80 @@
 
 ## [6.6.0](https://github.com/ant-design/ant-design-cli/compare/v6.5.4...v6.6.0) (2026-08-10)
 
+### Security
+
+- Resolve the remaining dependency security alerts by upgrading `@modelcontextprotocol/sdk`, `@hono/node-server`, `postcss`, and `body-parser` ([#208](https://github.com/ant-design/ant-design-cli/pull/208))
+
+### Other Changes
+
 - Update antd metadata ([v6@6.6.0](https://github.com/ant-design/ant-design-cli/compare/v6.5.4...v6.6.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+
+---
+
+### 安全
+
+- 升级 `@modelcontextprotocol/sdk`、`@hono/node-server`、`postcss` 和 `body-parser`，修复剩余的依赖安全告警 ([#208](https://github.com/ant-design/ant-design-cli/pull/208))
+
+### 其他变更
+
+- 同步 antd 元数据 ([v6@6.6.0](https://github.com/ant-design/ant-design-cli/compare/v6.5.4...v6.6.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.5.4](https://github.com/ant-design/ant-design-cli/compare/v6.5.3...v6.5.4) (2026-08-07)
 
+### Other Changes
+
 - Update antd metadata ([v6@6.5.4](https://github.com/ant-design/ant-design-cli/compare/v6.5.3...v6.5.4#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+
+---
+
+### 其他变更
+
+- 同步 antd 元数据 ([v6@6.5.4](https://github.com/ant-design/ant-design-cli/compare/v6.5.3...v6.5.4#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.5.3](https://github.com/ant-design/ant-design-cli/compare/v6.5.2...v6.5.3) (2026-07-31)
 
+### Security
+
+- Upgrade `fast-uri` from 3.1.2 to 3.1.4 to include its latest security fixes ([#206](https://github.com/ant-design/ant-design-cli/pull/206))
+
+### Other Changes
+
+- Upgrade `hono` from 4.12.26 to 4.12.32 ([#207](https://github.com/ant-design/ant-design-cli/pull/207))
 - Update antd metadata ([v6@6.5.3](https://github.com/ant-design/ant-design-cli/compare/v6.5.2...v6.5.3#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+
+---
+
+### 安全
+
+- 将 `fast-uri` 从 3.1.2 升级至 3.1.4，纳入最新安全修复 ([#206](https://github.com/ant-design/ant-design-cli/pull/206))
+
+### 其他变更
+
+- 将 `hono` 从 4.12.26 升级至 4.12.32 ([#207](https://github.com/ant-design/ant-design-cli/pull/207))
+- 同步 antd 元数据 ([v6@6.5.3](https://github.com/ant-design/ant-design-cli/compare/v6.5.2...v6.5.3#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.5.2](https://github.com/ant-design/ant-design-cli/compare/v6.5.1...v6.5.2) (2026-07-24)
 
+### Documentation
+
+- Expand the v6.5.0 and v6.5.1 release notes and align the English and Chinese changelogs ([#202](https://github.com/ant-design/ant-design-cli/pull/202))
+
+### Other Changes
+
 - Update antd metadata ([v6@6.5.2](https://github.com/ant-design/ant-design-cli/compare/v6.5.1...v6.5.2#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
+
+---
+
+### 文档
+
+- 补充 v6.5.0 和 v6.5.1 发布说明，并对齐中英文 changelog ([#202](https://github.com/ant-design/ant-design-cli/pull/202))
+
+### 其他变更
+
+- 同步 antd 元数据 ([v6@6.5.2](https://github.com/ant-design/ant-design-cli/compare/v6.5.1...v6.5.2#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.5.1](https://github.com/ant-design/ant-design-cli/compare/v6.5.0...v6.5.1) (2026-07-13)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,20 +2,41 @@
 
 ## [6.6.0](https://github.com/ant-design/ant-design-cli/compare/v6.5.4...v6.6.0) (2026-08-10)
 
+### 安全
+
+- 升级 `@modelcontextprotocol/sdk`、`@hono/node-server`、`postcss` 和 `body-parser`，修复剩余的依赖安全告警 ([#208](https://github.com/ant-design/ant-design-cli/pull/208))
+
+### 其他变更
+
 - 同步 antd 元数据 ([v6@6.6.0](https://github.com/ant-design/ant-design-cli/compare/v6.5.4...v6.6.0#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.5.4](https://github.com/ant-design/ant-design-cli/compare/v6.5.3...v6.5.4) (2026-08-07)
+
+### 其他变更
 
 - 同步 antd 元数据 ([v6@6.5.4](https://github.com/ant-design/ant-design-cli/compare/v6.5.3...v6.5.4#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.5.3](https://github.com/ant-design/ant-design-cli/compare/v6.5.2...v6.5.3) (2026-07-31)
 
+### 安全
+
+- 将 `fast-uri` 从 3.1.2 升级至 3.1.4，纳入最新安全修复 ([#206](https://github.com/ant-design/ant-design-cli/pull/206))
+
+### 其他变更
+
+- 将 `hono` 从 4.12.26 升级至 4.12.32 ([#207](https://github.com/ant-design/ant-design-cli/pull/207))
 - 同步 antd 元数据 ([v6@6.5.3](https://github.com/ant-design/ant-design-cli/compare/v6.5.2...v6.5.3#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 
 
 ## [6.5.2](https://github.com/ant-design/ant-design-cli/compare/v6.5.1...v6.5.2) (2026-07-24)
+
+### 文档
+
+- 补充 v6.5.0 和 v6.5.1 发布说明，并对齐中英文 changelog ([#202](https://github.com/ant-design/ant-design-cli/pull/202))
+
+### 其他变更
 
 - 同步 antd 元数据 ([v6@6.5.2](https://github.com/ant-design/ant-design-cli/compare/v6.5.1...v6.5.2#diff-ebaa5874f72b5c0a62edf9d98d6ae55fffc16dc881ade7a697e589c8614c7436))
 


### PR DESCRIPTION
## Summary

- expand the v6.5.2, v6.5.3, v6.5.4, and v6.6.0 release notes from the pull requests and metadata syncs actually shipped in each tag
- keep `CHANGELOG.md` and `CHANGELOG.zh-CN.md` aligned with English-first bilingual and Chinese-only versions
- prepare the four changelog bodies for verbatim synchronization to their GitHub Releases

## Verification

- verified all four bilingual bodies and their PR mappings with a Node assertion script
- `git diff --check origin/main...HEAD`
- `npm run typecheck`
- `npm run build`
- `npx vitest run --exclude src/__tests__/commands/migrate.test.ts --exclude src/__tests__/snapshots/migrate.test.ts --reporter=dot` — 49 files and 710 tests passed

## Test note

The two excluded migrate test files scan the real `/tmp` directory and fail when unrelated temporary projects are present. The same snapshot mismatches reproduced on the unchanged baseline and are unrelated to this documentation-only diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新中英文变更日志，新增 6.6.0 的安全与其他变更说明。
  * 补充 6.5.2、6.5.3 和 6.5.4 的分类标题及发布记录。
  * 同步中英文内容与版本元数据，完善历史版本信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->