### PR TITLE
feat: warn when --version resolves to a different bundled snapshot

### DIFF
--- a/src/__tests__/commands/demo.test.ts
+++ b/src/__tests__/commands/demo.test.ts
@@ -32,6 +32,12 @@ describe('demo', () => {
     expect(data.demo).toBe('basic');
   });
 
+  it('should not warn on a later command without --version in the same process', async () => {
+    await runCLI('demo', 'Button', 'basic', '--version', '5.3.4');
+    const result = await runCLI('demo', 'Button', 'basic', '--format', 'json');
+    expect(result.stderr).not.toContain('using bundled snapshot');
+  });
+
   it('should handle demo not found', async () => {
     const result = await runCLI('demo', 'Button', 'nonexistent');
     expect(result.exitCode).toBe(1);

--- a/src/__tests__/commands/demo.test.ts
+++ b/src/__tests__/commands/demo.test.ts
@@ -22,6 +22,16 @@ describe('demo', () => {
     expect(data.code).toContain('import');
   });
 
+  it('should warn on stderr but still output when --version falls back', async () => {
+    const result = await runCLI('demo', 'Button', 'basic', '--version', '5.3.4', '--format', 'json');
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('5.3.4');
+    expect(result.stderr).toContain('5.3.3');
+    const data = JSON.parse(result.stdout);
+    expect(data.component).toBe('Button');
+    expect(data.demo).toBe('basic');
+  });
+
   it('should handle demo not found', async () => {
     const result = await runCLI('demo', 'Button', 'nonexistent');
     expect(result.exitCode).toBe(1);

--- a/src/__tests__/commands/demo.test.ts
+++ b/src/__tests__/commands/demo.test.ts
@@ -38,6 +38,13 @@ describe('demo', () => {
     expect(result.stderr).not.toContain('using bundled snapshot');
   });
 
+  it('should warn again on each CLI invocation with the same fallback version', async () => {
+    const first = await runCLI('demo', 'Button', 'basic', '--version', '5.3.4', '--format', 'json');
+    const second = await runCLI('demo', 'Button', 'basic', '--version', '5.3.4', '--format', 'json');
+    expect(first.stderr).toContain('using bundled snapshot 5.3.3');
+    expect(second.stderr).toContain('using bundled snapshot 5.3.3');
+  });
+
   it('should handle demo not found', async () => {
     const result = await runCLI('demo', 'Button', 'nonexistent');
     expect(result.exitCode).toBe(1);

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -287,7 +287,7 @@ describe('data/loader', () => {
       spy.mockRestore();
     });
 
-    it('deduplicates repeated fallback warnings in the same process', async () => {
+    it('deduplicates repeated fallback warnings within the same CLI invocation', async () => {
       const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
       enableVersionFallbackWarning(true);
       const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
@@ -297,15 +297,31 @@ describe('data/loader', () => {
       spy.mockRestore();
     });
 
+    it('warns again when fallback warning is re-enabled for a new CLI invocation', async () => {
+      const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      enableVersionFallbackWarning(true);
+      load('5.3.4');
+      enableVersionFallbackWarning(true);
+      load('5.3.4');
+      expect(spy).toHaveBeenCalledTimes(2);
+      spy.mockRestore();
+    });
+
     it('does not color warnings when NO_COLOR is set', async () => {
       const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
       enableVersionFallbackWarning(true);
-      process.env.NO_COLOR = '1';
+      const previousNoColor = process.env.NO_COLOR;
       const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-      load('5.3.4');
-      expect(String(spy.mock.calls[0]?.[0])).not.toContain('\x1b[33m');
-      spy.mockRestore();
-      delete process.env.NO_COLOR;
+      try {
+        process.env.NO_COLOR = '1';
+        load('5.3.4');
+        expect(String(spy.mock.calls[0]?.[0])).not.toContain('\x1b[33m');
+      } finally {
+        spy.mockRestore();
+        if (previousNoColor === undefined) delete process.env.NO_COLOR;
+        else process.env.NO_COLOR = previousNoColor;
+      }
     });
   });
 

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -221,6 +221,53 @@ describe('data/loader', () => {
     expect(store.components.length).toBeGreaterThan(0);
   });
 
+  describe('version fallback warning', () => {
+    async function loadFreshLoader() {
+      vi.resetModules();
+      return import('../data/loader.js');
+    }
+
+    it('warns on stderr when --version resolves to a different bundled snapshot', async () => {
+      const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
+      enableVersionFallbackWarning();
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const store = load('5.3.4');
+      expect(store.version).toBe('5.3.3');
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('Version 5.3.4 is not available; using bundled snapshot 5.3.3 instead.'),
+      );
+      spy.mockRestore();
+    });
+
+    it('colors the warning on stderr TTY', async () => {
+      const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
+      enableVersionFallbackWarning();
+      const originalIsTTY = process.stderr.isTTY;
+      const originalNoColor = process.env.NO_COLOR;
+      const originalTerm = process.env.TERM;
+      delete process.env.NO_COLOR;
+      process.env.TERM = 'xterm-256color';
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true });
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      load('5.3.4');
+      expect(String(spy.mock.calls[0]?.[0])).toContain('\x1b[33m');
+      spy.mockRestore();
+      Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: originalIsTTY });
+      if (originalNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = originalNoColor;
+      if (originalTerm === undefined) delete process.env.TERM;
+      else process.env.TERM = originalTerm;
+    });
+
+    it('does not warn when version fallback happens without --version', async () => {
+      const { loadMetadataForVersion: load } = await loadFreshLoader();
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      load('5.3.4');
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
   it('loadMetadataForVersion falls back when no minor', () => {
     const store = loadMetadataForVersion('5');
     expect(store.components.length).toBeGreaterThan(0);

--- a/src/__tests__/version-loader.test.ts
+++ b/src/__tests__/version-loader.test.ts
@@ -229,7 +229,7 @@ describe('data/loader', () => {
 
     it('warns on stderr when --version resolves to a different bundled snapshot', async () => {
       const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
-      enableVersionFallbackWarning();
+      enableVersionFallbackWarning(true);
       const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
       const store = load('5.3.4');
       expect(store.version).toBe('5.3.3');
@@ -241,7 +241,7 @@ describe('data/loader', () => {
 
     it('colors the warning on stderr TTY', async () => {
       const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
-      enableVersionFallbackWarning();
+      enableVersionFallbackWarning(true);
       const originalIsTTY = process.stderr.isTTY;
       const originalNoColor = process.env.NO_COLOR;
       const originalTerm = process.env.TERM;
@@ -265,6 +265,47 @@ describe('data/loader', () => {
       load('5.3.4');
       expect(spy).not.toHaveBeenCalled();
       spy.mockRestore();
+    });
+
+    it('warns when requested major has no bundled snapshot', async () => {
+      const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
+      enableVersionFallbackWarning(true);
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      load('99.0.0');
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('[antd-cli] Warning: Version 99.0.0 is not available; no bundled snapshot found.'),
+      );
+      spy.mockRestore();
+    });
+
+    it('does not warn when requested version matches the bundled snapshot', async () => {
+      const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
+      enableVersionFallbackWarning(true);
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      load('5.3.3');
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('deduplicates repeated fallback warnings in the same process', async () => {
+      const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
+      enableVersionFallbackWarning(true);
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      load('5.3.4');
+      load('5.3.4');
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+
+    it('does not color warnings when NO_COLOR is set', async () => {
+      const { enableVersionFallbackWarning, loadMetadataForVersion: load } = await loadFreshLoader();
+      enableVersionFallbackWarning(true);
+      process.env.NO_COLOR = '1';
+      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      load('5.3.4');
+      expect(String(spy.mock.calls[0]?.[0])).not.toContain('\x1b[33m');
+      spy.mockRestore();
+      delete process.env.NO_COLOR;
     });
   });
 

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -13,6 +13,7 @@ let versionFallbackWarningEnabled = false;
 /** Toggle stderr warnings when a requested version resolves to a different bundled snapshot. */
 export function enableVersionFallbackWarning(enabled: boolean): void {
   versionFallbackWarningEnabled = enabled;
+  warnedVersionFallbacks.clear();
 }
 
 function versionsEquivalent(a: string, b: string): boolean {

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -10,9 +10,9 @@ import { compare } from './version.js';
 const warnedVersionFallbacks = new Set<string>();
 let versionFallbackWarningEnabled = false;
 
-/** Enable stderr warnings when a requested version resolves to a different bundled snapshot. */
-export function enableVersionFallbackWarning(): void {
-  versionFallbackWarningEnabled = true;
+/** Toggle stderr warnings when a requested version resolves to a different bundled snapshot. */
+export function enableVersionFallbackWarning(enabled: boolean): void {
+  versionFallbackWarningEnabled = enabled;
 }
 
 function versionsEquivalent(a: string, b: string): boolean {
@@ -29,7 +29,10 @@ function colorizeStderrWarning(message: string): string {
 }
 
 function warnVersionFallback(requested: string, store: MetadataStore): void {
-  if (!versionFallbackWarningEnabled || versionsEquivalent(requested, store.version)) return;
+  if (!versionFallbackWarningEnabled) return;
+
+  const noBundledSnapshot = store.components.length === 0;
+  if (!noBundledSnapshot && versionsEquivalent(requested, store.version)) return;
 
   const key = `${requested}|${store.version}|${store.components.length}`;
   if (warnedVersionFallbacks.has(key)) return;

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -5,6 +5,41 @@ import { fileURLToPath } from 'node:url';
 import type { MetadataStore, ComponentData, PropData, CLIError } from '../types.js';
 import { createError, fuzzyMatch, ErrorCodes } from '../output/error.js';
 import { readJson } from '../utils/json.js';
+import { compare } from './version.js';
+
+const warnedVersionFallbacks = new Set<string>();
+let versionFallbackWarningEnabled = false;
+
+/** Enable stderr warnings when a requested version resolves to a different bundled snapshot. */
+export function enableVersionFallbackWarning(): void {
+  versionFallbackWarningEnabled = true;
+}
+
+function versionsEquivalent(a: string, b: string): boolean {
+  return compare(a, b) === 0;
+}
+
+function colorizeStderrWarning(message: string): string {
+  const useColor = (process.env.FORCE_COLOR && process.env.FORCE_COLOR !== '0')
+    || (!process.env.NO_COLOR && process.stderr.isTTY && process.env.TERM !== 'dumb');
+  if (!useColor) return message;
+
+  const text = message.endsWith('\n') ? message.slice(0, -1) : message;
+  return `\x1b[1m\x1b[33m${text}\x1b[0m${message.endsWith('\n') ? '\n' : ''}`;
+}
+
+function warnVersionFallback(requested: string, store: MetadataStore): void {
+  if (!versionFallbackWarningEnabled || versionsEquivalent(requested, store.version)) return;
+
+  const key = `${requested}|${store.version}|${store.components.length}`;
+  if (warnedVersionFallbacks.has(key)) return;
+  warnedVersionFallbacks.add(key);
+
+  const message = store.components.length === 0
+    ? `[antd-cli] Warning: Version ${requested} is not available; no bundled snapshot found.\n`
+    : `[antd-cli] Warning: Version ${requested} is not available; using bundled snapshot ${store.version} instead.\n`;
+  process.stderr.write(colorizeStderrWarning(message));
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -99,7 +134,10 @@ const metadataCache = new Map<string, MetadataStore>();
 
 export function loadMetadataForVersion(version: string): MetadataStore {
   const cached = metadataCache.get(version);
-  if (cached) return cached;
+  if (cached) {
+    warnVersionFallback(version, cached);
+    return cached;
+  }
 
   const result = loadMetadataForVersionUncached(version);
   metadataCache.set(version, result);
@@ -108,6 +146,7 @@ export function loadMetadataForVersion(version: string): MetadataStore {
     if (oldestKey === undefined) break;
     metadataCache.delete(oldestKey);
   }
+  warnVersionFallback(version, result);
   return result;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { registerMcpCommand } from './commands/mcp.js';
 import { registerSetupCommand } from './commands/setup.js';
 import { checkForUpdate } from './utils/update-check.js';
 import { createHelpBanner } from './output/banner.js';
+import { enableVersionFallbackWarning } from './data/loader.js';
 import type { GlobalOptions } from './types.js';
 declare const __CLI_VERSION__: string;
 const CLI_VERSION = __CLI_VERSION__;
@@ -83,6 +84,9 @@ export function createProgram(): Command {
   // Validate global options before any command runs
   program.hook('preAction', () => {
     const opts = program.opts<GlobalOptions>();
+    if (opts.version) {
+      enableVersionFallbackWarning();
+    }
     const validFormats = ['json', 'text', 'markdown'];
     const validLangs = ['en', 'zh'];
     if (opts.format && !validFormats.includes(opts.format)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,9 +84,7 @@ export function createProgram(): Command {
   // Validate global options before any command runs
   program.hook('preAction', () => {
     const opts = program.opts<GlobalOptions>();
-    if (opts.version) {
-      enableVersionFallbackWarning();
-    }
+    enableVersionFallbackWarning(Boolean(opts.version));
     const validFormats = ['json', 'text', 'markdown'];
     const validLangs = ['en', 'zh'];
     if (opts.format && !validFormats.includes(opts.format)) {


### PR DESCRIPTION
## Summary
- When the user passes `--version` and the bundled metadata snapshot differs from the requested version, print a stderr warning while keeping stdout output unchanged.
- Warnings are deduplicated per process, respect `NO_COLOR`/non-TTY output, and use yellow bold styling in interactive terminals.
- Enable the warning path from the global `--version` flag in `index.ts`, so all commands benefit without per-command wiring.

## Test plan
- [x] `npm test`
- [x] `node dist/index.js demo Button basic --version 5.3.4` shows stderr warning and normal demo output
- [x] `node dist/index.js demo Button basic --version 5.3.3` shows no warning


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 使用 `--version` 请求不存在的版本时，命令会自动回退到可用版本并返回 JSON 结果。
  * 回退时在错误输出中提示请求版本与实际使用版本；同一命令仅提示一次，后续命令调用会重新提示。
  * 交互式终端中提供颜色提示，并支持通过 `NO_COLOR` 禁用颜色。
  * 对缺少可用快照的版本提供相应提示；精确匹配版本时不显示回退警告。

* **测试**
  * 新增版本回退、提示显示、重复提示抑制及无颜色输出场景的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->